### PR TITLE
Point to the release page on GitHub for other versions of deeplearnjs…

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,15 @@ everything from education, to model understanding, to art projects.
 Typescript is the preferred language of choice for **deeplearn.js**, however
 you can use it with plain JavaScript.
 
-For this use case, you can load the library directly from Google CDN:
+For this use case, you can load the latest version of the library directly from
+Google CDN:
 
 ```html
 <script src="https://storage.googleapis.com/learnjs-data/deeplearn.js"></script>
 ```
+
+To use a different version, see the
+[release](https://github.com/PAIR-code/deeplearnjs/releases) page on GitHub.
 
 #### From TypeScript
 

--- a/scripts/build-npm.sh
+++ b/scripts/build-npm.sh
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # =============================================================================
+npm run prep
+rm -rf dist/
 node_modules/.bin/tsc
 cd dist/
 npm pack ../

--- a/scripts/build-standalone.sh
+++ b/scripts/build-standalone.sh
@@ -13,6 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # =============================================================================
-mkdir -p dist/
+npm run prep
 node_modules/.bin/browserify --standalone deeplearn src/index.ts -p [tsify] > dist/deeplearn.js
 echo 'Stored standalone library at dist/deeplearn.js'


### PR DESCRIPTION
Point to the release page on GitHub for other versions of deeplearnjs and improve release scripts