### PR TITLE
Fix os.mkdirs typo in checkpoint dumping script

### DIFF
--- a/scripts/dump_checkpoint_vars.py
+++ b/scripts/dump_checkpoint_vars.py
@@ -48,8 +48,7 @@ def main():
   reader = tf.train.NewCheckpointReader(chk_fpath)
   var_to_shape_map = reader.get_variable_to_shape_map()
   output_dir = os.path.expanduser(FLAGS.output_dir)
-  if not os.path.exists(output_dir):
-    os.mkdirs(output_dir)
+  tf.gfile.MakeDirs(output_dir)
   manifest = {}
   remove_vars_compiled_re = re.compile(FLAGS.remove_variables_regex)
 


### PR DESCRIPTION
tf.gfile.MakeDirs will succeed whether or not the directory already exists, so no need to do the os.path.exists check before calling it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/24)
<!-- Reviewable:end -->
