### PR TITLE
Update build-demo to take a path where bundle.js is written. This fixes the make-website script.

### DIFF
--- a/scripts/build-demo
+++ b/scripts/build-demo
@@ -18,7 +18,16 @@ const path = require('path');
 const spawn = require('cross-spawn');
 
 const startTsFilePath = process.argv[2];
-const outputPath = path.join(path.dirname(startTsFilePath), 'bundle.js')
+const outDir = process.argv[3];
+
+let outputPath;
+
+if (outDir != null) {
+  outputPath = path.join(outDir, 'bundle.js');
+} else {
+  outputPath = path.join(path.dirname(startTsFilePath), 'bundle.js')
+}
+
 
 const cmd = path.join('node_modules', '.bin', 'browserify');
 const child = spawn(cmd, [startTsFilePath, '-p', '[tsify]', '-o' , outputPath],

--- a/scripts/build-demo
+++ b/scripts/build-demo
@@ -21,7 +21,6 @@ const startTsFilePath = process.argv[2];
 const outDir = process.argv[3];
 
 let outputPath;
-
 if (outDir != null) {
   outputPath = path.join(outDir, 'bundle.js');
 } else {

--- a/scripts/deploy-demo
+++ b/scripts/deploy-demo
@@ -22,7 +22,7 @@ const startHTMLFilePath = process.argv[3];
 const outDir = process.argv[4];
 
 const cmd = path.join('scripts', 'build-demo');
-const child = spawn(cmd, [startTsFilePath], {detached: false});
+const child = spawn(cmd, [startTsFilePath, outDir], {detached: false});
 child.stdout.pipe(process.stdout);
 child.stderr.pipe(process.stderr);
 child.on('close', () => {


### PR DESCRIPTION
Before, bundle.js was written in master to demos/$DEMO/bundle.js after the copy to $TMP. This means bundle.js never gets updated.

Now, build-demo takes an optional second param, where to store the bundle, so we can write the bundle to the TMP dir.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/70)
<!-- Reviewable:end -->
