### PR TITLE
fix meanSquaredCost usages in demos

### DIFF
--- a/demos/complementary-color-prediction/complementary-color-prediction.ts
+++ b/demos/complementary-color-prediction/complementary-color-prediction.ts
@@ -79,7 +79,7 @@ class ComplementaryColorModel {
 
     // We will optimize using mean squared loss.
     this.costTensor =
-        graph.meanSquaredCost(this.predictionTensor, this.targetTensor);
+        graph.meanSquaredCost(this.targetTensor, this.predictionTensor);
 
     // Create the session only after constructing the graph.
     this.session = new Session(graph, this.math);

--- a/demos/complementary-color-prediction/complementary_color_prediction.md
+++ b/demos/complementary-color-prediction/complementary_color_prediction.md
@@ -197,7 +197,7 @@ We also add a cost tensor that specifies the loss function (mean squared).
 
 ```ts
 this.costTensor =
-    graph.meanSquaredCost(this.predictionTensor, this.targetTensor);
+    graph.meanSquaredCost(this.targetTensor, this.predictionTensor);
 ```
 
 Finally, we create a session for running training and inference.

--- a/demos/intro/intro.ts
+++ b/demos/intro/intro.ts
@@ -63,7 +63,7 @@ import {NDArrayMathGPU, Scalar, Array1D, Array2D, Graph, Session, SGDOptimizer, 
 
   // Top level graph methods take Tensors and return Tensors.
   const outputTensor = g.matmul(multiplier, inputTensor);
-  const costTensor = g.meanSquaredCost(outputTensor, labelTensor);
+  const costTensor = g.meanSquaredCost(labelTensor, outputTensor);
 
   // Tensors, like NDArrays, have a shape attribute.
   console.log(outputTensor.shape);


### PR DESCRIPTION
The function signature in **src/graph.ts** is
`meanSquaredCost(label: Tensor, prediction: Tensor)`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/71)
<!-- Reviewable:end -->
