### PR TITLE
Add poolType to shader program cache key in pool_gpu.

### DIFF
--- a/src/math/webgl/pool_gpu.ts
+++ b/src/math/webgl/pool_gpu.ts
@@ -37,7 +37,7 @@ export class Pool2DProgram implements GPGPUProgram {
     }
     const xRowsLimit = xShape[0] - 0.5;
     const xColsLimit = xShape[1] - 0.5;
-    this.params = [stride, pad, fSize, computePositions];
+    this.params = [stride, pad, fSize, poolType, computePositions];
     this.outputShape =
         conv_util.computeOutputShape3D(xShape, fSize, xShape[2], stride, pad);
 


### PR DESCRIPTION
This was causing the minPool shader to get cached with the maxPool source, causing the normalization bounds in the imagenet demo to be identical. This causes a totally black canvas.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/73)
<!-- Reviewable:end -->
