### PR TITLE
Remove MDL from nn-art, and bring back polymer. Enable firefox.

### DIFF
--- a/demos/homepage/assets/support.js
+++ b/demos/homepage/assets/support.js
@@ -13,10 +13,6 @@ function isMobile() {
   return /(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino/i.test(a)||/1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i.test(a.substr(0,4));
 }
 
-function isFirefox() {
-  return navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
-}
-
 function isWebGLEnabled() {
   var canvas = document.createElement('canvas');
 
@@ -33,11 +29,11 @@ function isWebGLEnabled() {
 }
 
 function isNotSupported() {
-  return isMobile() || isSafari() || isFirefox() || !isWebGLEnabled();
+  return isMobile() || isSafari() || !isWebGLEnabled();
 }
 
 function inializePolymerPage() {
-  document.addEventListener("DOMContentLoaded", function(event) {
+  document.addEventListener("WebComponentsReady", function(event) {
     if (isNotSupported()) {
       var dialogContainer = document.createElement('div');
       dialogContainer.innerHTML = `

--- a/demos/imagenet/imagenet-demo.ts
+++ b/demos/imagenet/imagenet-demo.ts
@@ -87,6 +87,7 @@ export class ImagenetDemo extends ImagenetDemoPolymer {
       this.staticImgElement.src = 'images/' + event.detail.selected + '.jpg';
     });
 
+    // tslint:disable-next-line:no-any
     const navigatorAny = navigator as any;
     navigator.getUserMedia = navigator.getUserMedia ||
         navigatorAny.webkitGetUserMedia || navigatorAny.mozGetUserMedia || 

--- a/demos/imagenet/imagenet-demo.ts
+++ b/demos/imagenet/imagenet-demo.ts
@@ -87,6 +87,10 @@ export class ImagenetDemo extends ImagenetDemoPolymer {
       this.staticImgElement.src = 'images/' + event.detail.selected + '.jpg';
     });
 
+    const navigatorAny = navigator as any;
+    navigator.getUserMedia = navigator.getUserMedia ||
+        navigatorAny.webkitGetUserMedia || navigatorAny.mozGetUserMedia || 
+        navigatorAny.msGetUserMedia;
     if (navigator.getUserMedia) {
       navigator.getUserMedia(
           {video: true},

--- a/demos/nn-art/nn-art.html
+++ b/demos/nn-art/nn-art.html
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================-->
 <link rel="import" href="../../bower_components/polymer/polymer.html">
+<link rel="import" href="../../bower_components/paper-button/paper-button.html">
+<link rel="import" href="../../bower_components/paper-slider/paper-slider.html">
 <link rel="import" href="../../bower_components/paper-dropdown-menu/paper-dropdown-menu.html">
 <link rel="import" href="../../bower_components/paper-listbox/paper-listbox.html">
 <link rel="import" href="../../bower_components/paper-item/paper-item.html">
@@ -27,68 +29,48 @@ limitations under the License.
       margin-left: 20px;
       margin-top: 20px;
     }
-
-    li.mdl-menu__item {
-      height: 40px;
-      line-height: 40px;
-    }
-    .getmdl-select .mdl-icon-toggle__label {
-        float: right;
-        margin-top: -30px;
-        color: rgba(0,0,0,0.4);
+    #random {
+      color: rgb(66,66,66);
+      background-color: rgb(255,171,64);
     }
   </style>
 <template>
   <div class="container">
     <canvas id="inference"></canvas>
     <br>
-    <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label getmdl-select getmdl-select__fix-height">
-      <input class="mdl-textfield__input" type="text" id="colormode" value="rgb" readonly tabIndex="-1">
-      <label for="colormode">
-        <i class="mdl-icon-toggle__label material-icons">keyboard_arrow_down</i>
-      </label>
-      <label for="colormode" class="mdl-textfield__label">Color mode</label>
-      <ul for="colormode" class="mdl-menu mdl-menu--bottom-left mdl-js-menu" id="color-selector">
-        <li class="mdl-menu__item" data-val="rgb">rgb</li>
-        <li class="mdl-menu__item" data-val="rgba">rgba</li>
-        <li class="mdl-menu__item" data-val="hsv">hsv</li>
-        <li class="mdl-menu__item" data-val="hsva">hsva</li>
-        <li class="mdl-menu__item" data-val="yuv">yuv</li>
-        <li class="mdl-menu__item" data-val="yuva">yuva</li>
-        <li class="mdl-menu__item" data-val="bw">bw</li>
-      </ul>
+    <div>
+      <paper-dropdown-menu no-animations label="Color mode">
+        <paper-listbox attr-for-selected="value" id="color-mode-dropdown" class="dropdown-content" selected="{{selectedColorModeName}}" slot="dropdown-content">
+          <template is="dom-repeat" items="[[colorModeNames]]">
+            <paper-item value="[[item]]" label="[[item]]">
+              [[item]]
+            </paper-item>
+          </template>
+        </paper-listbox>
+      </paper-dropdown-menu>
     </div>
-    <br>
-    <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label getmdl-select getmdl-select__fix-height">
-      <input class="mdl-textfield__input" type="text" id="activation-fn" value="tanh" readonly tabIndex="-1">
-      <label for="activation-fn">
-        <i class="mdl-icon-toggle__label material-icons">keyboard_arrow_down</i>
-      </label>
-      <label for="activation-fn" class="mdl-textfield__label">Activation function</label>
-      <ul for="activation-fn" class="mdl-menu mdl-menu--bottom-left mdl-js-menu" id="activation-selector">
-        <li class="mdl-menu__item" data-val="tanh">tanh</li>
-        <li class="mdl-menu__item" data-val="sin">sin</li>
-        <li class="mdl-menu__item" data-val="relu">relu</li>
-        <li class="mdl-menu__item" data-val="step">step</li>
-      </ul>
+    <div>
+      <paper-dropdown-menu no-animations label="Activation function">
+        <paper-listbox attr-for-selected="value" id="activation-function-dropdown" class="dropdown-content" selected="{{selectedActivationFunctionName}}" slot="dropdown-content">
+          <template is="dom-repeat" items="[[activationFunctionNames]]">
+            <paper-item value="[[item]]" label="[[item]]">
+              [[item]]
+            </paper-item>
+          </template>
+        </paper-listbox>
+      </paper-dropdown-menu>
     </div>
     <br>
     <div>Number of layers: <div id="layers-count" style="display: inline-block"></div></div>
-
-    <p style="width:200px">
-      <input class="mdl-slider mdl-js-slider" type="range" min="0" max="7" value="3" tabindex="1" id="layers-slider">
-    </p>
+    <paper-slider pin min="0" max="10" value="3" id="layers-slider"></paper-slider>
 
     <div>z1 time coefficient</div>
-    <p style="width:200px">
-      <input class="mdl-slider mdl-js-slider" type="range" min="1" max="1000" value="100" tabindex="2" id="z1-slider">
-    </p>
-    <div>z2 time coefficient</div>
-    <p style="width:200px">
-      <input class="mdl-slider mdl-js-slider" type="range" min="1" max="1000" value="100" tabindex="3" id="z2-slider">
-    </p>
+    <paper-slider min="1" max="100" value="1" id="z1-slider"></paper-slider>
 
-    <button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent" type="button" id="random">randomize</button>
+    <div>z2 time coefficient</div>
+    <paper-slider min="1" max="100" value="1" id="z2-slider"></paper-slider>
+
+    <paper-button type="button" id="random">randomize</paper-button>
     <br><br>
     <a href="http://blog.otoro.net/2016/03/25/generating-abstract-patterns-with-tensorflow/" target="_blank">What is a CPPN?</a>
   </div>

--- a/demos/nn-art/nn-art.ts
+++ b/demos/nn-art/nn-art.ts
@@ -24,9 +24,19 @@ const WEIGHTS_STDEV = .6;
 
 // tslint:disable-next-line:variable-name
 const NNArtPolymer: new () => PolymerHTMLElement =
-    PolymerElement({is: 'nn-art', properties: {}});
+    PolymerElement({is: 'nn-art', properties: {
+      colorModeNames: Array,
+      selectedColorModeName: String,
+      activationFunctionNames: Array,
+      selectedActivationFunctionName: String
+    }});
 
 class NNArt extends NNArtPolymer {
+  private colorModeNames: ColorMode[];
+  private selectedColorModeName: ColorMode;
+  private activationFunctionNames: ActivationFunction[];
+  private selectedActivationFunctionName: ActivationFunction;
+
   private cppn: CPPN;
 
   private inferenceCanvas: HTMLCanvasElement;
@@ -45,41 +55,33 @@ class NNArt extends NNArtPolymer {
     this.inferenceCanvas.style.height =
         this.inferenceCanvas.height * CANVAS_UPSCALE_FACTOR + 'px';
 
-    const currentColorElement =
-        this.querySelector('#colormode') as HTMLInputElement;
-    this.querySelector('#color-selector')
-        .addEventListener(
-            // tslint:disable-next-line:no-any
-            'click', (event: any) => {
-              const colorMode =
-                  (event.target as HTMLElement).getAttribute('data-val') as
-                  ColorMode;
-              currentColorElement.value = colorMode;
-              this.cppn.setColorMode(colorMode);
-            });
-    this.cppn.setColorMode('rgb');
-
-    const currentActivationFnElement =
-        this.querySelector('#activation-fn') as HTMLInputElement;
-    this.querySelector('#activation-selector')
-        .addEventListener(
-            // tslint:disable-next-line:no-any
-            'click', (event: any) => {
-              const activationFn =
-                  (event.target as HTMLElement).getAttribute('data-val') as
-                  ActivationFunction;
-              currentActivationFnElement.value = activationFn;
-              this.cppn.setActivationFunction(activationFn);
-            });
-    this.cppn.setActivationFunction('tanh');
+    this.colorModeNames = ['rgb', 'rgba', 'hsv', 'hsva', 'yuv', 'yuva', 'bw'];
+    this.selectedColorModeName = 'rgb';
+    this.cppn.setColorMode(this.selectedColorModeName);    
+    this.querySelector('#color-mode-dropdown')!.addEventListener(
+        // tslint:disable-next-line:no-any
+        'iron-activate', (event: any) => {
+          this.selectedColorModeName = event.detail.selected;
+          this.cppn.setColorMode(this.selectedColorModeName);
+        });
+  
+    this.activationFunctionNames = ['tanh', 'sin', 'relu', 'step'];
+    this.selectedActivationFunctionName = 'tanh';
+    this.cppn.setActivationFunction(this.selectedActivationFunctionName);
+    this.querySelector('#activation-function-dropdown')!.addEventListener(
+        // tslint:disable-next-line:no-any
+        'iron-activate', (event: any) => {
+          this.selectedActivationFunctionName = event.detail.selected;
+          this.cppn.setActivationFunction(this.selectedActivationFunctionName);
+        });
 
     const layersSlider =
         this.querySelector('#layers-slider') as HTMLInputElement;
     const layersCountElement =
         this.querySelector('#layers-count') as HTMLDivElement;
-    layersSlider.addEventListener('input', (event) => {
+    layersSlider.addEventListener('immediate-value-changed', (event) => {
       // tslint:disable-next-line:no-any
-      this.numLayers = parseInt((event as any).target.value, 10);
+      this.numLayers = parseInt((event as any).target.immediateValue, 10);
       layersCountElement.innerText = '' + this.numLayers;
       this.cppn.setNumLayers(this.numLayers);
     });
@@ -88,22 +90,22 @@ class NNArt extends NNArtPolymer {
     this.cppn.setNumLayers(this.numLayers);
 
     const z1Slider = this.querySelector('#z1-slider') as HTMLInputElement;
-    z1Slider.addEventListener('input', (event) => {
+    z1Slider.addEventListener('immediate-value-changed', (event) => {
       // tslint:disable-next-line:no-any
-      this.z1Scale = parseInt((event as any).target.value, 10);
-      this.cppn.setZ1Scale(this.z1Scale);
+      this.z1Scale = parseInt((event as any).target.immediateValue, 10);
+      this.cppn.setZ1Scale(convertZScale(this.z1Scale));
     });
     this.z1Scale = parseInt(z1Slider.value, 10);
-    this.cppn.setZ1Scale(this.z1Scale);
+    this.cppn.setZ1Scale(convertZScale(this.z1Scale));
 
     const z2Slider = this.querySelector('#z2-slider') as HTMLInputElement;
-    z2Slider.addEventListener('input', (event) => {
+    z2Slider.addEventListener('immediate-value-changed', (event) => {
       // tslint:disable-next-line:no-any
-      this.z2Scale = parseInt((event as any).target.value, 10);
-      this.cppn.setZ2Scale(this.z1Scale);
+      this.z2Scale = parseInt((event as any).target.immediateValue, 10);
+      this.cppn.setZ2Scale(convertZScale(this.z2Scale));
     });
     this.z2Scale = parseInt(z2Slider.value, 10);
-    this.cppn.setZ2Scale(this.z2Scale);
+    this.cppn.setZ2Scale(convertZScale(this.z2Scale));
 
     const randomizeButton = this.querySelector('#random') as HTMLButtonElement;
     randomizeButton.addEventListener('click', () => {
@@ -113,6 +115,10 @@ class NNArt extends NNArtPolymer {
     this.cppn.generateWeights(MAT_WIDTH, WEIGHTS_STDEV);
     this.cppn.start();
   }
+}
+
+function convertZScale(z: number): number {
+  return (103 - z);
 }
 
 document.registerElement(NNArt.prototype.is, NNArt);


### PR DESCRIPTION
This change enables firefox on our demos! NN-art has been converted back to polymer.

For future demos, we will not use exclusively use MDL, but bringing polymer back was the easiest thing to get firefox working.

This fixes #51.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/76)
<!-- Reviewable:end -->
