### PR TITLE
Enable single run to make sure exit

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -26,6 +26,7 @@ module.exports = function(config) {
       tsconfig: "tsconfig.json"
     },
     reporters: ['progress', 'karma-typescript'],
-    browsers: ['Chrome', 'Firefox']
+    browsers: ['Chrome', 'Firefox'],
+    singleRun: true
   });
 };


### PR DESCRIPTION
`singleRun` of karma is false as default. It causes stuck without exit when running `npm run test` in CLI. We can make sure to exit by enabling `singleRun`.

see: https://karma-runner.github.io/1.0/config/configuration-file.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/85)
<!-- Reviewable:end -->
