### PR TITLE
Fix timeout of model runner test

### DIFF
--- a/src/graph_runner_test.ts
+++ b/src/graph_runner_test.ts
@@ -47,6 +47,7 @@ describe('Model runner', () => {
 
   let avgCostCallback: (avgCost: Scalar) => void;
   let metricCallback: (metric: Scalar) => void;
+  let originalTimeout: number;
 
   const fakeUserEvents: GraphRunnerEventObserver = {
     batchesTrainedCallback: (totalBatchesTrained: number) => null,
@@ -59,6 +60,9 @@ describe('Model runner', () => {
   };
 
   beforeEach(() => {
+    // Workaround to avoid jasmine callback timeout.
+    originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000;
     math = new NDArrayMathCPU();
     g = new Graph();
     optimizer = new SGDOptimizer(FAKE_LEARNING_RATE);
@@ -92,6 +96,10 @@ describe('Model runner', () => {
     spyOn(fakeUserEvents, 'inferenceExamplesCallback').and.callThrough();
     spyOn(fakeUserEvents, 'trainExamplesPerSecCallback').and.callThrough();
     spyOn(fakeUserEvents, 'totalTimeCallback').and.callThrough();
+  });
+
+  afterEach(() => {
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
   });
 
   it('basic train usage, train 3 batches', (doneFn) => {


### PR DESCRIPTION
Model runner test failed due to timeout intermittently.
We can increase default timeout from 5s to 20s to make it stable.

```
Chrome 60.0.3112 (Mac OS X 10.12.6) Model runner basic train usage, train 3 batches FAILED
	Error: Timeout - Async callback was not invoked within timeout specified by jasmine.DEFAULT_TIMEOUT_INTERVAL.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/86)
<!-- Reviewable:end -->
