### PR TITLE
Add benchmark for packed texture on GPU

### DIFF
--- a/demos/benchmarks/math-benchmark-run-groups.ts
+++ b/demos/benchmarks/math-benchmark-run-groups.ts
@@ -26,7 +26,7 @@ import * as mulmat_gpu_benchmark from './mulmat_gpu_benchmark';
 export const BENCHMARK_RUN_GROUPS: BenchmarkRunGroup[] = [
   {
     name:
-        'Matrix Multiplication (CPU vs GPU): ' +
+        'Matrix Multiplication (CPU vs GPU vs GPU (packed texture)): ' +
             'matmul([size, size], [size, size])',
     min: 0,
     max: 1024,
@@ -34,7 +34,9 @@ export const BENCHMARK_RUN_GROUPS: BenchmarkRunGroup[] = [
     stepToSizeTransformation: (step: number) => Math.max(1, step),
     benchmarkRuns: [
       new BenchmarkRun('mulmat_gpu', mulmat_gpu_benchmark.BENCHMARK_TEST),
-      new BenchmarkRun('mulmat_cpu', mulmat_cpu_benchmark.BENCHMARK_TEST)
+      new BenchmarkRun('mulmat_gpu_pack',
+        mulmat_gpu_benchmark.BENCHMARK_TEST_PACKED),
+      new BenchmarkRun('mulmat_cpu', mulmat_cpu_benchmark.BENCHMARK_TEST),
     ],
   },
   {


### PR DESCRIPTION
Add missing benchmark of packed texture on GPU. It can show the speed that is significantly faster than unpacked texture.

<img width="754" alt="screen shot 2017-09-10 at 23 09 02" src="https://user-images.githubusercontent.com/1713047/30249756-8d305f90-967d-11e7-86f7-4e420b353d1a.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/115)
<!-- Reviewable:end -->
