### PR TITLE
Make slice2d internal use makeOutputArray.

### DIFF
--- a/scripts/watch-demo
+++ b/scripts/watch-demo
@@ -30,7 +30,7 @@ let httpServerStarted = false;
 
 console.log('Waiting for initial compile...');
 watchify.stderr.on('data', (data) => {
-  if (data.toString().includes(`written to ${path.dirname(startTsFilePath)}`)) {
+  if (data.toString().includes(`bytes written to`)) {
     if (!httpServerStarted) {
       const httpCmd = path.join('node_modules', '.bin', 'http-server');
       const httpServer = spawn(httpCmd, ['-c-1'], { detached: false});

--- a/src/math/math_gpu.ts
+++ b/src/math/math_gpu.ts
@@ -75,7 +75,7 @@ export class NDArrayMathGPU extends NDArrayMath {
     // Pretend the source was in logical shape that matches the texture shape.
     const source = ndarray.as2D(texShape[0], texShape[1]);
     // Do the same for output.
-    const output = this.makeOutputArray(texShape) as Array2D;
+    const output = this.makeOutputArray<Array2D>(texShape);
     this.copy2D(source, [0, 0], texShape, output, [0, 0], texShape);
     // Get back to the original logical shape.
     return output.reshape(ndarray.shape);
@@ -84,10 +84,7 @@ export class NDArrayMathGPU extends NDArrayMath {
   protected slice2DInternal(
       input: Array2D, beginRowCol: [number, number],
       sizeRowCol: [number, number]): Array2D {
-    const result = NDArray.make<Array2D>(sizeRowCol, {
-      texture: this.textureManager.acquireTexture(sizeRowCol),
-      textureShapeRC: sizeRowCol
-    });
+    const result = this.makeOutputArray<Array2D>(sizeRowCol);
     this.copy2DInternal(
         input, beginRowCol, sizeRowCol, result, [0, 0], sizeRowCol);
     return result;


### PR DESCRIPTION
By not using makeOutputArray, we can't choose a texture size that is smaller than the max texture size.

This PR also updates watch demo to allow for demo URL starting with './' which currently doesn't work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/124)
<!-- Reviewable:end -->
