### PR TITLE
Cache uniform locations in the GPGPUBinary so we don't query them every time we set an inputTextureMatrix

### DIFF
--- a/demos/benchmarks/benchmark-demo.html
+++ b/demos/benchmarks/benchmark-demo.html
@@ -14,16 +14,17 @@ limitations under the License.
 ==============================================================================-->
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="UTF-8">
   <script src="../../bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>
   <link rel="import" href="math-benchmark.html">
   <link rel="import" href="../demo-header.html">
   <link rel="import" href="../demo-footer.html">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/dialog-polyfill/0.4.8/dialog-polyfill.min.css"/>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/dialog-polyfill/0.4.8/dialog-polyfill.min.css" />
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/dialog-polyfill/0.4.8/dialog-polyfill.min.js"></script>
   <script src="../homepage/assets/support.js"></script>
-  <title>LearnJS Benchmarks</title>
+  <title>deeplearn.js benchmark</title>
   <style>
     html {
       width: 100%;
@@ -36,15 +37,18 @@ limitations under the License.
       width: 100%;
       height: 100%;
     }
+
     head {
       height: 0;
       width: 0;
     }
   </style>
 </head>
+
 <body>
   <demo-header name="benchmarks"></demo-header>
   <math-benchmark></math-benchmark>
   <demo-footer></demo-footer>
 </body>
+
 </html>

--- a/demos/imagenet/imagenet-demo.html
+++ b/demos/imagenet/imagenet-demo.html
@@ -14,16 +14,17 @@ limitations under the License.
 ==============================================================================-->
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="UTF-8">
   <script src="../../bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>
   <link rel="import" href="imagenet.html">
   <link rel="import" href="../demo-header.html">
   <link rel="import" href="../demo-footer.html">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/dialog-polyfill/0.4.8/dialog-polyfill.min.css"/>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/dialog-polyfill/0.4.8/dialog-polyfill.min.css" />
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/dialog-polyfill/0.4.8/dialog-polyfill.min.js"></script>
   <script src="../homepage/assets/support.js"></script>
-  <title>LearnJS Imagenet Demo</title>
+  <title>deeplearn.js imagenet webcam demo</title>
   <style>
     html {
       width: 100%;
@@ -36,15 +37,18 @@ limitations under the License.
       width: 100%;
       height: 100%;
     }
+
     head {
       height: 0;
       width: 0;
     }
   </style>
 </head>
+
 <body>
   <demo-header name="webcam classifier"></demo-header>
   <imagenet-demo></imagenet-demo>
   <demo-footer></demo-footer>
 </body>
+
 </html>

--- a/demos/model-builder/model-builder-demo.html
+++ b/demos/model-builder/model-builder-demo.html
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================-->
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="UTF-8">
   <script src="../../bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>
@@ -22,10 +23,10 @@ limitations under the License.
   <link rel="import" href="model-builder.html">
   <link rel="import" href="../../bower_components/iron-icons/image-icons.html">
   <link rel="import" href="../../bower_components/iron-icons/iron-icons.html">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/dialog-polyfill/0.4.8/dialog-polyfill.min.css"/>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/dialog-polyfill/0.4.8/dialog-polyfill.min.css" />
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/dialog-polyfill/0.4.8/dialog-polyfill.min.js"></script>
   <script src="../homepage/assets/support.js"></script>
-  <title>LearnJS Demo Page</title>
+  <title>deeplearn.js model builder demo</title>
   <style>
     html {
       width: 100%;
@@ -38,15 +39,18 @@ limitations under the License.
       width: 100%;
       height: 100%;
     }
+
     head {
       height: 0;
       width: 0;
     }
   </style>
 </head>
+
 <body>
   <demo-header name="model builder"></demo-header>
   <model-builder></model-builder>
   <demo-footer></demo-footer>
 </body>
+
 </html>

--- a/demos/models/imagenet_util.ts
+++ b/demos/models/imagenet_util.ts
@@ -64,7 +64,9 @@ export function preprocessInput(
     shapeRowCol: [number, number]) {
   gpgpu.setOutputMatrixTexture(resultTex, shapeRowCol[0], shapeRowCol[1]);
   gpgpu.setProgram(preprocessInputShader);
-  gpgpu.setInputMatrixTexture(sourceTex, 'source', 0);
+  const samplerLocation = webgl_util.getProgramUniformLocationOrThrow(
+      gpgpu.gl, preprocessInputShader, 'source');
+  gpgpu.setInputMatrixTexture(sourceTex, samplerLocation, 0);
   gpgpu.executeProgram();
 }
 
@@ -142,20 +144,32 @@ export function renderGrayscaleChannelsCollage(
     imageSize: number, channels: number, textureSize: number, numRows: number) {
   webgl_util.bindCanvasToFramebuffer(gpgpu.gl);
   gpgpu.setProgram(unpackChannelsShader);
-  gpgpu.setInputMatrixTexture(sourceTex, 'source', 0);
-  gpgpu.setInputMatrixTexture(minValuesTex, 'minValues', 1);
-  gpgpu.setInputMatrixTexture(maxValuesTex, 'maxValues', 2);
 
-  const imageSizeLoc = gpgpu.getUniformLocation('imageSize');
+  const sourceSamplerLocation = webgl_util.getProgramUniformLocationOrThrow(
+      gpgpu.gl, unpackChannelsShader, 'source');
+  const minValuesSamplerLocation = webgl_util.getProgramUniformLocationOrThrow(
+      gpgpu.gl, unpackChannelsShader, 'minValues');
+  const maxValuesSamplerLocation = webgl_util.getProgramUniformLocationOrThrow(
+      gpgpu.gl, unpackChannelsShader, 'maxValues');
+
+  gpgpu.setInputMatrixTexture(sourceTex, sourceSamplerLocation, 0);
+  gpgpu.setInputMatrixTexture(minValuesTex, minValuesSamplerLocation, 1);
+  gpgpu.setInputMatrixTexture(maxValuesTex, maxValuesSamplerLocation, 2);
+
+  const imageSizeLoc =
+      gpgpu.getUniformLocation(unpackChannelsShader, 'imageSize');
   gpgpu.gl.uniform1f(imageSizeLoc, imageSize);
 
-  const channelsLoc = gpgpu.getUniformLocation('channels');
+  const channelsLoc =
+      gpgpu.getUniformLocation(unpackChannelsShader, 'channels');
   gpgpu.gl.uniform1f(channelsLoc, channels);
 
-  const imagesPerRowLoc = gpgpu.getUniformLocation('imagesPerRow');
+  const imagesPerRowLoc =
+      gpgpu.getUniformLocation(unpackChannelsShader, 'imagesPerRow');
   gpgpu.gl.uniform1f(imagesPerRowLoc, Math.floor(textureSize / imageSize));
 
-  const inputShapeCRLoc = gpgpu.getUniformLocation('inputShapeCR');
+  const inputShapeCRLoc =
+      gpgpu.getUniformLocation(unpackChannelsShader, 'inputShapeCR');
   gpgpu.gl.uniform2f(inputShapeCRLoc, inputShapeRC[1], inputShapeRC[0]);
 
   gpgpu.executeProgram();

--- a/demos/nn-art/nn-art-demo.html
+++ b/demos/nn-art/nn-art-demo.html
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================-->
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="UTF-8">
   <!-- This script is stripped during vulcanization, available only during development. It provides
@@ -26,11 +27,11 @@ limitations under the License.
   <link rel="import" href="../../bower_components/iron-icons/image-icons.html">
   <link rel="import" href="../../bower_components/iron-icons/iron-icons.html">
 
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/dialog-polyfill/0.4.8/dialog-polyfill.min.css"/>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/dialog-polyfill/0.4.8/dialog-polyfill.min.css" />
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/dialog-polyfill/0.4.8/dialog-polyfill.min.js"></script>
   <script src="../homepage/assets/support.js"></script>
 
-  <title>Abstract CPPN Art</title>
+  <title>deeplearn.js abstract CPPN art demo</title>
   <style>
     html {
       width: 100%;
@@ -43,15 +44,18 @@ limitations under the License.
       width: 100%;
       height: 100%;
     }
+
     head {
       height: 0;
       width: 0;
     }
   </style>
 </head>
+
 <body>
   <demo-header name="cppn"></demo-header>
   <nn-art></nn-art>
   <demo-footer></demo-footer>
 </body>
+
 </html>

--- a/demos/nn-art/nn_art_util.ts
+++ b/demos/nn-art/nn_art_util.ts
@@ -66,8 +66,12 @@ export function addLatentVariables(
     z2: number) {
   gpgpu.setOutputMatrixTexture(resultTex, shapeRowCol[0], shapeRowCol[1]);
   gpgpu.setProgram(addZShader);
-  gpgpu.setInputMatrixTexture(sourceTex, 'source', 0);
-  const zLoc = gpgpu.getUniformLocation('z');
+
+  const sourceSamplerLocation = webgl_util.getProgramUniformLocationOrThrow(
+      gpgpu.gl, addZShader, 'source');
+  gpgpu.setInputMatrixTexture(sourceTex, sourceSamplerLocation, 0);
+
+  const zLoc = gpgpu.getUniformLocation(addZShader, 'z');
   gpgpu.gl.uniform2f(zLoc, z1, z2);
   gpgpu.executeProgram();
 }
@@ -149,11 +153,14 @@ export function render(
     outputNumDimensions: number, colorMode: number) {
   webgl_util.bindCanvasToFramebuffer(gpgpu.gl);
   gpgpu.setProgram(renderShader);
-  gpgpu.setInputMatrixTexture(sourceTex, 'source', 0);
-  const colorModeLoc = gpgpu.getUniformLocation('colorMode');
+
+  const sourceSamplerLocation = webgl_util.getProgramUniformLocationOrThrow(
+      gpgpu.gl, renderShader, 'source');
+  gpgpu.setInputMatrixTexture(sourceTex, sourceSamplerLocation, 0);
+  const colorModeLoc = gpgpu.getUniformLocation(renderShader, 'colorMode');
   gpgpu.gl.uniform1i(colorModeLoc, colorMode);
   const outputNumDimensionsLoc =
-      gpgpu.getUniformLocation('outputNumDimensions');
+      gpgpu.getUniformLocation(renderShader, 'outputNumDimensions');
   gpgpu.gl.uniform1f(outputNumDimensionsLoc, outputNumDimensions);
   gpgpu.executeProgram();
 }

--- a/src/math/math_gpu.ts
+++ b/src/math/math_gpu.ts
@@ -126,7 +126,8 @@ export class NDArrayMathGPU extends NDArrayMath {
 
   private compileAndRun<T extends NDArray, K extends NDArray>(
       program: GPGPUProgram, inputs: T[], output?: K,
-      customSetup?: (gpgpu: GPGPUContext) => void): K {
+      customSetup?: (gpgpu: GPGPUContext, webGLProgram: WebGLProgram) => void):
+      K {
     if (output == null) {
       output = this.makeOutputArray<K>(program.outputShape);
     }

--- a/src/math/webgl/conv_gpu.ts
+++ b/src/math/webgl/conv_gpu.ts
@@ -19,12 +19,16 @@ import {ConvInfo} from '../conv_util';
 import {GPGPUProgram} from './gpgpu_math';
 
 export class Conv2DProgram implements GPGPUProgram {
-  variableNames = ['x', 'W', 'bias'];
+  variableNames = ['x', 'W'];
   params: Array<{}>;
   outputShape: number[];
   userCode: string;
 
   constructor(convInfo: ConvInfo, hasBias: boolean) {
+    if (hasBias) {
+      this.variableNames.push('bias');
+    }
+
     this.outputShape = convInfo.outShape;
     const biasSnippet = hasBias ? 'dotProd += getBias(d2);' : '';
     const [xNumRows, xNumCols, inputDepth] = convInfo.inShape;

--- a/src/math/webgl/copy_gpu.ts
+++ b/src/math/webgl/copy_gpu.ts
@@ -44,12 +44,14 @@ export class Copy2DProgram implements GPGPUProgram {
   getCustomSetupFunc(
       sourceStart: [number, number], destStart: [number, number],
       destSize: [number, number]) {
-    return (gpgpu: GPGPUContext) => {
+    return (gpgpu: GPGPUContext, webGLProgram: WebGLProgram) => {
       gpgpu.setOutputMatrixWriteRegion(
           destStart[0], destSize[0], destStart[1], destSize[1]);
-      const sourceStartCRLoc = gpgpu.getUniformLocation('sourceStart');
+      const sourceStartCRLoc =
+          gpgpu.getUniformLocation(webGLProgram, 'sourceStart');
       gpgpu.gl.uniform2i(sourceStartCRLoc, sourceStart[0], sourceStart[1]);
-      const destStartCRLoc = gpgpu.getUniformLocation('destStart');
+      const destStartCRLoc =
+          gpgpu.getUniformLocation(webGLProgram, 'destStart');
       gpgpu.gl.uniform2i(destStartCRLoc, destStart[0], destStart[1]);
     };
   }

--- a/src/math/webgl/gpgpu_context.ts
+++ b/src/math/webgl/gpgpu_context.ts
@@ -52,8 +52,9 @@ export class GPGPUContext {
           webgl_util.getExtensionOrThrow(this.gl, 'EXT_color_buffer_float');
     }
 
-    this.loseContextExtension = webgl_util.getExtensionOrThrow(
-        this.gl, 'WEBGL_lose_context') as WebGLLoseContextExtension;
+    this.loseContextExtension =
+        webgl_util.getExtensionOrThrow(this.gl, 'WEBGL_lose_context') as
+        WebGLLoseContextExtension;
     this.vertexBuffer = gpgpu_util.createVertexBuffer(this.gl);
     this.indexBuffer = gpgpu_util.createIndexBuffer(this.gl);
     this.framebuffer = webgl_util.createFramebuffer(this.gl);
@@ -188,20 +189,21 @@ export class GPGPUContext {
     webgl_util.callAndCheck(this.gl, () => this.gl.useProgram(program));
   }
 
-  public getUniformLocation(uniformName: string): WebGLUniformLocation {
+  public getUniformLocation(program: WebGLProgram, uniformName: string):
+      WebGLUniformLocation {
     this.throwIfDisposed();
-    this.throwIfNoProgram();
     return webgl_util.getProgramUniformLocationOrThrow(
-        this.gl, this.program, uniformName);
+        this.gl, program, uniformName);
   }
 
   public setInputMatrixTexture(
-      inputMatrixTexture: WebGLTexture, uniformName: string,
+      inputMatrixTexture: WebGLTexture, uniformLocation: WebGLUniformLocation,
       textureUnit: number) {
     this.throwIfDisposed();
     this.throwIfNoProgram();
     webgl_util.bindTextureToProgramUniformSampler(
-        this.gl, this.program, inputMatrixTexture, uniformName, textureUnit);
+        this.gl, this.program, inputMatrixTexture, uniformLocation,
+        textureUnit);
   }
 
   public setOutputMatrixTexture(

--- a/src/math/webgl/mulmat_packed_gpu.ts
+++ b/src/math/webgl/mulmat_packed_gpu.ts
@@ -18,6 +18,7 @@
 import {MatrixOrientation} from '../math';
 
 import {GPGPUContext} from './gpgpu_context';
+import * as webgl_util from './webgl_util';
 
 export function getFragmentShaderSource(
     sharedDimension: number, aOrientation: MatrixOrientation,
@@ -81,8 +82,12 @@ export function multiplyMatrixPacked(
   gpgpu.setOutputPackedMatrixTexture(
       result, resultShapeRowCol[0], resultShapeRowCol[1]);
   gpgpu.setProgram(multiplyProgram);
-  gpgpu.setInputMatrixTexture(a, 'matrixA', 0);
-  gpgpu.setInputMatrixTexture(b, 'matrixB', 1);
+  const matrixASamplerLocation = webgl_util.getProgramUniformLocationOrThrow(
+      gpgpu.gl, multiplyProgram, 'matrixA');
+  const matrixBSamplerLocation = webgl_util.getProgramUniformLocationOrThrow(
+      gpgpu.gl, multiplyProgram, 'matrixB');
+  gpgpu.setInputMatrixTexture(a, matrixASamplerLocation, 0);
+  gpgpu.setInputMatrixTexture(b, matrixBSamplerLocation, 1);
   gpgpu.executeProgram();
 }
 

--- a/src/math/webgl/render_ndarray_gpu_util.ts
+++ b/src/math/webgl/render_ndarray_gpu_util.ts
@@ -56,6 +56,9 @@ export function renderToCanvas(
 export function renderToFramebuffer(
     gpgpu: GPGPUContext, renderShader: WebGLProgram, sourceTex: WebGLTexture) {
   gpgpu.setProgram(renderShader);
-  gpgpu.setInputMatrixTexture(sourceTex, 'source', 0);
+
+  const sourceSamplerLocation = webgl_util.getProgramUniformLocationOrThrow(
+      gpgpu.gl, renderShader, 'source');
+  gpgpu.setInputMatrixTexture(sourceTex, sourceSamplerLocation, 0);
   gpgpu.executeProgram();
 }

--- a/src/math/webgl/webgl_util.ts
+++ b/src/math/webgl/webgl_util.ts
@@ -69,9 +69,10 @@ export function isWebGL2Enabled() {
     if (gl != null) {
       WEBGL2_ENABLED = true;
 
-      const loseContextExtension = getExtensionOrThrow(
-          gl as WebGLRenderingContext,
-          'WEBGL_lose_context') as WebGLLoseContextExtension;
+      const loseContextExtension =
+          getExtensionOrThrow(
+              gl as WebGLRenderingContext, 'WEBGL_lose_context') as
+          WebGLLoseContextExtension;
       loseContextExtension.loseContext();
     } else {
       WEBGL2_ENABLED = false;
@@ -87,10 +88,9 @@ export function createWebGLRenderingContextFromCanvas(
   if (isWebGL2Enabled()) {
     gl = canvas.getContext('webgl2', attributes) as WebGLRenderingContext;
   } else {
-    gl =
-        (canvas.getContext('webgl', attributes) ||
-         canvas.getContext(
-             'experimental-webgl', attributes)) as WebGLRenderingContext;
+    gl = (canvas.getContext('webgl', attributes) ||
+          canvas.getContext('experimental-webgl', attributes)) as
+        WebGLRenderingContext;
   }
 
   if (gl == null) {
@@ -306,11 +306,9 @@ export function getProgramUniformLocationOrThrow(
 
 export function bindTextureToProgramUniformSampler(
     gl: WebGLRenderingContext, program: WebGLProgram, texture: WebGLTexture,
-    uniformSamplerName: string, textureUnit: number) {
+    uniformSamplerLocation: WebGLUniformLocation, textureUnit: number) {
   callAndCheck(gl, () => bindTextureUnit(gl, texture, textureUnit));
-  const samplerLocation =
-      getProgramUniformLocationOrThrow(gl, program, uniformSamplerName);
-  callAndCheck(gl, () => gl.uniform1i(samplerLocation, textureUnit));
+  callAndCheck(gl, () => gl.uniform1i(uniformSamplerLocation, textureUnit));
 }
 
 export function bindCanvasToFramebuffer(gl: WebGLRenderingContext) {


### PR DESCRIPTION
This speeds things up in the model builder slightly, increase of 300 examples trained over 20 seconds on a macbook pro.

Setting arbitrary uniform values (floats, ints, etc) will come in a follow up PR. Right now the external demos just query uniform locations, but this will be centralized in the GPGPUBinary as well in the next PR which will move demos to logical sampling.

See this page for why caching uniform location is a good idea (TLDR it's slow):
https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/WebGL_best_practices

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/127)
<!-- Reviewable:end -->
