### PR TITLE
Clone dy when setting a gradient in as the same as gradient out.

### DIFF
--- a/src/ops/add.ts
+++ b/src/ops/add.ts
@@ -19,7 +19,7 @@ import {Tensor} from '../graph';
 import * as graph_util from '../graph_util';
 import {NDArrayMath} from '../math/math';
 import {NDArray, Scalar} from '../math/ndarray';
-import {TensorArrayMap, SummedTensorArrayMap} from '../tensor_array_map';
+import {SummedTensorArrayMap, TensorArrayMap} from '../tensor_array_map';
 import * as util from '../util';
 
 import {Operation} from './op';
@@ -75,7 +75,7 @@ export class Add extends Operation {
           gradientArrays.add(
               this.x1Tensor, math.divide(sum, this.dySizeScalar));
         } else {
-          gradientArrays.add(this.x1Tensor, dy);
+          gradientArrays.add(this.x1Tensor, math.clone(dy));
         }
       }
 
@@ -88,7 +88,7 @@ export class Add extends Operation {
           gradientArrays.add(
               this.x2Tensor, math.divide(sum, this.dySizeScalar));
         } else {
-          gradientArrays.add(this.x2Tensor, dy);
+          gradientArrays.add(this.x2Tensor, math.clone(dy));
         }
       }
     });

--- a/src/ops/subtract.ts
+++ b/src/ops/subtract.ts
@@ -19,7 +19,7 @@ import {Tensor} from '../graph';
 import * as graph_util from '../graph_util';
 import {NDArrayMath} from '../math/math';
 import {NDArray, Scalar} from '../math/ndarray';
-import {TensorArrayMap, SummedTensorArrayMap} from '../tensor_array_map';
+import {SummedTensorArrayMap, TensorArrayMap} from '../tensor_array_map';
 import * as util from '../util';
 
 import {Operation} from './op';
@@ -71,10 +71,9 @@ export class Subtract extends Operation {
           if (this.dySizeScalar == null) {
             this.dySizeScalar = Scalar.new(dy.size);
           }
-          gradientArrays.add(
-              this.t1, math.divide(sum, this.dySizeScalar));
+          gradientArrays.add(this.t1, math.divide(sum, this.dySizeScalar));
         } else {
-          gradientArrays.add(this.t1, dy);
+          gradientArrays.add(this.t1, math.clone(dy));
         }
       }
 
@@ -85,8 +84,7 @@ export class Subtract extends Operation {
           if (this.dySizeScalar == null) {
             this.dySizeScalar = Scalar.new(dy.size);
           }
-          gradientArrays.add(
-              this.t2, math.divide(negSum, this.dySizeScalar));
+          gradientArrays.add(this.t2, math.divide(negSum, this.dySizeScalar));
         } else {
           gradientArrays.add(this.t2, math.neg(dy));
         }


### PR DESCRIPTION
If we don't clone, the SummedGradientMap will dispose the old value, whose value may be read by another op.

FWIW this was so tricky to debug, even as a core author. An eager style execution will make this so much simpler.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/134)
<!-- Reviewable:end -->
