### PR TITLE
vectorize min/max/logsumexp/nan/reduce_sum

### DIFF
--- a/src/math/webgl/logsumexp_gpu.ts
+++ b/src/math/webgl/logsumexp_gpu.ts
@@ -27,9 +27,9 @@ export class LogSumExpProgram implements GPGPUProgram {
     const sizeNearestVec4 = Math.floor(size / 4) * 4;
     const sizeVec4Remainder = size % 4;
 
-    const remainder1 = sizeNearestVec4;
-    const remainder2 = sizeNearestVec4 + 1;
-    const remainder3 = sizeNearestVec4 + 2;
+    const r1 = sizeNearestVec4;
+    const r2 = sizeNearestVec4 + 1;
+    const r3 = sizeNearestVec4 + 2;
 
     this.userCode = `
       const vec2 ones2 = vec2(1, 1);
@@ -44,13 +44,12 @@ export class LogSumExpProgram implements GPGPUProgram {
           maxVec = max(maxVec, aVec);
         }
         if (${sizeVec4Remainder === 1}) {
-          maxVec = max(maxVec, vec4(maxVec.xyz, getAFlat(${remainder1})));
+          maxVec = max(maxVec, vec4(maxVec.xyz, getAFlat(${r1})));
         } else if (${sizeVec4Remainder === 2}) {
-          vec2 aVec = vec2(getAFlat(${remainder1}), getAFlat(${remainder2}));
+          vec2 aVec = vec2(getAFlat(${r1}), getAFlat(${r2}));
           maxVec = max(maxVec, vec4(maxVec.xy, aVec));
         } else if (${sizeVec4Remainder === 3}) {
-          vec3 aVec = vec3(getAFlat(${remainder1}), getAFlat(${remainder2}),
-                           getAFlat(${remainder3}));
+          vec3 aVec = vec3(getAFlat(${r1}), getAFlat(${r2}), getAFlat(${r3}));
           maxVec = max(maxVec, vec4(maxVec.x, aVec));
         }
         float finalMax = max(maxVec.x, max(maxVec.y, max(maxVec.z, maxVec.w)));
@@ -62,13 +61,12 @@ export class LogSumExpProgram implements GPGPUProgram {
           expSum += dot(ones4, exp(aVec - finalMax));
         }
         if (${sizeVec4Remainder === 1}) {
-          expSum += exp(getAFlat(${remainder1}) - finalMax);
+          expSum += exp(getAFlat(${r1}) - finalMax);
         } else if (${sizeVec4Remainder === 2}) {
-          vec2 aVec = vec2(getAFlat(${remainder1}), getAFlat(${remainder2}));
+          vec2 aVec = vec2(getAFlat(${r1}), getAFlat(${r2}));
           expSum += dot(ones2, exp(aVec - finalMax));
         } else if (${sizeVec4Remainder === 3}) {
-          vec3 aVec = vec3(getAFlat(${remainder1}), getAFlat(${remainder2}),
-              getAFlat(${remainder3}));
+          vec3 aVec = vec3(getAFlat(${r1}), getAFlat(${r2}), getAFlat(${r3}));
           expSum += dot(ones3, exp(aVec - finalMax));
         }
 

--- a/src/math/webgl/logsumexp_gpu_test.ts
+++ b/src/math/webgl/logsumexp_gpu_test.ts
@@ -16,11 +16,12 @@
  */
 
 import * as test_util from '../../test_util';
-import {LogSumExpProgram} from './logsumexp_gpu';
-import * as gpgpu_math from './gpgpu_math';
-import {TextureManager} from './texture_manager';
+import {Array2D, initializeGPU, Scalar} from '../ndarray';
+
 import {GPGPUContext} from './gpgpu_context';
-import {initializeGPU, Array2D, Scalar} from '../ndarray';
+import * as gpgpu_math from './gpgpu_math';
+import {LogSumExpProgram} from './logsumexp_gpu';
+import {TextureManager} from './texture_manager';
 
 function cpuLogSumExp(m: Float32Array): number {
   if (m.length === 0) {
@@ -39,7 +40,7 @@ function cpuLogSumExp(m: Float32Array): number {
 }
 
 describe('logsumexp_gpu', () => {
-  it('returns 0 (ln(1) = 0) when the 1x1 input matrix is [0]', () => {
+  it('logsumexp(1) = 0', () => {
     const a = new Float32Array([0]);
     const result = uploadLogSumExpDownload(a, 1, 1);
     expect(result).toEqual(0);
@@ -51,7 +52,59 @@ describe('logsumexp_gpu', () => {
     expect(result).toBeCloseTo(Math.log(a.length));
   });
 
-  it('computes the same result as cpuLogSumExp', () => {
+  it('same as cpuLogSumExp, 1 element', () => {
+    const a = test_util.randomArrayInRange(1, -2, 2);
+    const result = uploadLogSumExpDownload(a, 1, 1);
+    const expected = cpuLogSumExp(a);
+    expect(result).toBeCloseTo(expected);
+  });
+
+  it('same as cpuLogSumExp, 2 elements', () => {
+    const a = test_util.randomArrayInRange(2, -2, 2);
+    const result = uploadLogSumExpDownload(a, 2, 1);
+    const expected = cpuLogSumExp(a);
+    expect(result).toBeCloseTo(expected);
+  });
+
+  it('same as cpuLogSumExp, 3 elements', () => {
+    const a = test_util.randomArrayInRange(3, -2, 2);
+    const result = uploadLogSumExpDownload(a, 3, 1);
+    const expected = cpuLogSumExp(a);
+    expect(result).toBeCloseTo(expected);
+  });
+
+  it('same as cpuLogSumExp, 4 elements', () => {
+    const a = test_util.randomArrayInRange(4, -2, 2);
+    const result = uploadLogSumExpDownload(a, 4, 1);
+    const expected = cpuLogSumExp(a);
+    expect(result).toBeCloseTo(expected);
+  });
+
+  it('same as cpuLogSumExp, 9 elements, last is max', () => {
+    const a = test_util.randomArrayInRange(9, -2, 2);
+    a[a.length - 1] = 3;
+    const result = uploadLogSumExpDownload(a, 9, 1);
+    const expected = cpuLogSumExp(a);
+    expect(result).toBeCloseTo(expected);
+  });
+
+  it('same as cpuLogSumExp, 10 elements, last is max', () => {
+    const a = test_util.randomArrayInRange(10, -2, 2);
+    a[a.length - 1] = 3;
+    const result = uploadLogSumExpDownload(a, 10, 1);
+    const expected = cpuLogSumExp(a);
+    expect(result).toBeCloseTo(expected);
+  });
+
+  it('same as cpuLogSumExp, 11 elements, last is max', () => {
+    const a = test_util.randomArrayInRange(11, -2, 2);
+    a[a.length - 1] = 3;
+    const result = uploadLogSumExpDownload(a, 11, 1);
+    const expected = cpuLogSumExp(a);
+    expect(result).toBeCloseTo(expected);
+  });
+
+  it('same as cpuLogSumExp many elements', () => {
     const a = test_util.randomArrayInRange(12 * 29, -2, 2);
     const result = uploadLogSumExpDownload(a, 12, 29);
     const expected = cpuLogSumExp(a);
@@ -59,8 +112,8 @@ describe('logsumexp_gpu', () => {
   });
 });
 
-export function uploadLogSumExpDownload(a: Float32Array, rows: number,
-    columns: number): number {
+export function uploadLogSumExpDownload(
+    a: Float32Array, rows: number, columns: number): number {
   const gpgpu = new GPGPUContext();
   const textureManager = new TextureManager(gpgpu);
   initializeGPU(gpgpu, textureManager);

--- a/src/math/webgl/minmax_gpu.ts
+++ b/src/math/webgl/minmax_gpu.ts
@@ -23,20 +23,49 @@ export class MinMaxProgram implements GPGPUProgram {
   outputShape: number[] = [];
   userCode: string;
 
-  constructor(aSize: number, opType: 'min'|'max') {
-    this.params = [opType];
+  constructor(size: number, op: 'min'|'max') {
+    this.params = [op];
+    const sizeNearestVec4 = Math.floor(size / 4) * 4;
+    const sizeVec4Remainder = size % 4;
+
+    const remainder1 = sizeNearestVec4;
+    const remainder2 = sizeNearestVec4 + 1;
+    const remainder3 = sizeNearestVec4 + 2;
+
     this.userCode = `
       void main() {
-        float value = getAFlat(0);
-        for (int i = 0; i < ${aSize}; i++) {
-          float candidate = getAFlat(i);
-          if (isNaN(candidate)) {
-            setOutput(candidate);
+        vec4 bestVec = vec4(getAFlat(0));
+        for (int i = 0; i < ${sizeNearestVec4}; i += 4) {
+          vec4 aVec = vec4(getAFlat(i), getAFlat(i+1),
+                           getAFlat(i+2), getAFlat(i+3));
+          if (hasNaN(aVec)) {
+            setOutput(getNaN(aVec));
             return;
           }
-          value = ${opType}(value, candidate);
+          bestVec = ${op}(bestVec, aVec);
         }
-        setOutput(value);
+        vec4 aVec;
+        if (${sizeVec4Remainder === 1}) {
+          aVec = vec4(bestVec.xyz, getAFlat(${remainder1}));
+        } else if (${sizeVec4Remainder === 2}) {
+          aVec = vec4(bestVec.xy,
+              vec2(getAFlat(${remainder1}), getAFlat(${remainder2})));
+        } else if (${sizeVec4Remainder === 3}) {
+          aVec = vec4(bestVec.x,
+              vec3(getAFlat(${remainder1}), getAFlat(${remainder2}),
+                   getAFlat(${remainder3})));
+        }
+        if (${sizeVec4Remainder > 0}) {
+          if (hasNaN(aVec)) {
+            setOutput(getNaN(aVec));
+            return;
+          }
+          bestVec = ${op}(bestVec, aVec);
+        }
+
+        float final = ${op}(bestVec.x, ${op}(bestVec.y,
+                      ${op}(bestVec.z, bestVec.w)));
+        setOutput(final);
       }
     `;
   }

--- a/src/math/webgl/minmax_gpu.ts
+++ b/src/math/webgl/minmax_gpu.ts
@@ -28,9 +28,9 @@ export class MinMaxProgram implements GPGPUProgram {
     const sizeNearestVec4 = Math.floor(size / 4) * 4;
     const sizeVec4Remainder = size % 4;
 
-    const remainder1 = sizeNearestVec4;
-    const remainder2 = sizeNearestVec4 + 1;
-    const remainder3 = sizeNearestVec4 + 2;
+    const r1 = sizeNearestVec4;
+    const r2 = sizeNearestVec4 + 1;
+    const r3 = sizeNearestVec4 + 2;
 
     this.userCode = `
       void main() {
@@ -46,14 +46,12 @@ export class MinMaxProgram implements GPGPUProgram {
         }
         vec4 aVec;
         if (${sizeVec4Remainder === 1}) {
-          aVec = vec4(bestVec.xyz, getAFlat(${remainder1}));
+          aVec = vec4(bestVec.xyz, getAFlat(${r1}));
         } else if (${sizeVec4Remainder === 2}) {
-          aVec = vec4(bestVec.xy,
-              vec2(getAFlat(${remainder1}), getAFlat(${remainder2})));
+          aVec = vec4(bestVec.xy, vec2(getAFlat(${r1}), getAFlat(${r2})));
         } else if (${sizeVec4Remainder === 3}) {
           aVec = vec4(bestVec.x,
-              vec3(getAFlat(${remainder1}), getAFlat(${remainder2}),
-                   getAFlat(${remainder3})));
+                      vec3(getAFlat(${r1}), getAFlat(${r2}), getAFlat(${r3})));
         }
         if (${sizeVec4Remainder > 0}) {
           if (hasNaN(aVec)) {

--- a/src/math/webgl/reducesum_gpu_test.ts
+++ b/src/math/webgl/reducesum_gpu_test.ts
@@ -16,11 +16,12 @@
  */
 
 import * as test_util from '../../test_util';
-import {ReduceSumProgram} from './reducesum_gpu';
-import {GPGPUContext} from './gpgpu_context';
 import {Array2D, initializeGPU, Scalar} from '../ndarray';
-import {TextureManager} from './texture_manager';
+
+import {GPGPUContext} from './gpgpu_context';
 import * as gpgpu_math from './gpgpu_math';
+import {ReduceSumProgram} from './reducesum_gpu';
+import {TextureManager} from './texture_manager';
 
 describe('reducesum_gpu', () => {
   it('returns 0 when A is [0]', () => {
@@ -68,10 +69,46 @@ describe('reducesum_gpu', () => {
     const result = uploadReduceSumDownload(a, 3, 2);
     expect(result).toEqual(7);
   });
+
+  it('sum across 2 elements', () => {
+    const a = new Float32Array([3, 5]);
+    const result = uploadReduceSumDownload(a, 2, 1);
+    expect(result).toEqual(8);
+  });
+
+  it('sum across 3 elements', () => {
+    const a = new Float32Array([3, 5, 1]);
+    const result = uploadReduceSumDownload(a, 3, 1);
+    expect(result).toEqual(9);
+  });
+
+  it('sum across 4 elements', () => {
+    const a = new Float32Array([3, 5, 1, 2]);
+    const result = uploadReduceSumDownload(a, 4, 1);
+    expect(result).toEqual(11);
+  });
+
+  it('sum across 5 elements', () => {
+    const a = new Float32Array([3, 5, 1, 2, 1]);
+    const result = uploadReduceSumDownload(a, 5, 1);
+    expect(result).toEqual(12);
+  });
+
+  it('sum across 6 elements', () => {
+    const a = new Float32Array([3, 5, 1, 2, 1, -3]);
+    const result = uploadReduceSumDownload(a, 6, 1);
+    expect(result).toEqual(9);
+  });
+
+  it('sum across 7 elements', () => {
+    const a = new Float32Array([3, 5, 1, 2, 1, -3, 5]);
+    const result = uploadReduceSumDownload(a, 7, 1);
+    expect(result).toEqual(14);
+  });
 });
 
-export function uploadReduceSumDownload(a: Float32Array, rows: number,
-    cols: number): number {
+export function uploadReduceSumDownload(
+    a: Float32Array, rows: number, cols: number): number {
   const arr = Array2D.new([rows, cols], a);
   const out = Scalar.new(0);
 

--- a/src/math/webgl/shader_compiler.ts
+++ b/src/math/webgl/shader_compiler.ts
@@ -170,17 +170,7 @@ const SHADER_PREFIX = `
   }
 
   float getNaN(vec4 values) {
-    bvec4 equals = equal(values, values);
-    if (!equals.w) {
-      return values.w;
-    } else if (!equals.x) {
-      return values.x;
-    } else if (!equals.y) {
-      return values.y;
-    } else if (!equals.z) {
-      return values.z;
-    }
-    return 0.0;
+    return dot(vec4(1), values);
   }
 
   ${SAMPLE_1D_SNIPPET}


### PR DESCRIPTION
2x improvement for min/min and 4x for LogSumExp

Old Max on Linux:
![max](https://user-images.githubusercontent.com/2294279/30763247-548be436-9fb3-11e7-93eb-a209e56a7e5d.png)

Vectozied Max on Linux:
![max-vec4](https://user-images.githubusercontent.com/2294279/30763250-560d9f2a-9fb3-11e7-9a0b-b2eee215cfbb.png)

Old LogSumExp on Linux:
![logsumexp](https://user-images.githubusercontent.com/2294279/30763433-214cb824-9fb4-11e7-9d43-ec348e64ba11.png)

Vectorized LogSumExp on Linux:
![logsumexp-vec4](https://user-images.githubusercontent.com/2294279/30763439-2b204b72-9fb4-11e7-80e4-c8fa5d174984.png)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/145)
<!-- Reviewable:end -->
