### PR TITLE
Clear duplicated benchmark data

### DIFF
--- a/demos/benchmarks/benchmark.ts
+++ b/demos/benchmarks/benchmark.ts
@@ -41,6 +41,10 @@ export class BenchmarkRun {
     this.benchmarkTest = benchmarkTest;
     this.chartData = [];
   }
+
+  clearChartData() {
+    this.chartData = [];
+  }
 }
 
 export abstract class BenchmarkTest {

--- a/demos/benchmarks/math-benchmark.ts
+++ b/demos/benchmarks/math-benchmark.ts
@@ -87,10 +87,14 @@ export class MathBenchmark extends MathBenchmarkPolymer {
 
     const canvas = this.querySelectorAll('.run-plot')[benchmarkRunGroupIndex] as
         HTMLCanvasElement;
+    // Avoid to growing size of rendered chart.
+    canvas.width = 400;
+    canvas.height = 300;
     const context = canvas.getContext('2d') as CanvasRenderingContext2D;
 
     const datasets: ChartDataSets[] = [];
     for (let i = 0; i < benchmarkRunGroup.benchmarkRuns.length; i++) {
+      benchmarkRunGroup.benchmarkRuns[i].clearChartData();
       const hue = Math.floor(360 * i / benchmarkRunGroup.benchmarkRuns.length);
       datasets.push({
         data: benchmarkRunGroup.benchmarkRuns[i].chartData,


### PR DESCRIPTION
Running benchmars multiple time generates duplicated chart data. Besides the benchmark chart becomes double size in every run.

<img width="1072" alt="screen shot 2017-09-25 at 23 14 04" src="https://user-images.githubusercontent.com/1713047/30813081-69ac469e-a247-11e7-844a-bd2dea9bbab2.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/152)
<!-- Reviewable:end -->
