### PR TITLE
Minor nitpick in model-builder.ts learingRate typo

### DIFF
--- a/demos/model-builder/model-builder.ts
+++ b/demos/model-builder/model-builder.ts
@@ -131,7 +131,7 @@ export class ModelBuilder extends ModelBuilderPolymer {
   private dataSet: InMemoryDataset;
   private xhrDatasetConfigs: {[datasetName: string]: XhrDatasetConfig};
   private datasetStats: DataStats[];
-  private learingRate: number;
+  private learningRate: number;
   private momentum: number;
   private needMomentum: boolean;
   private gamma: number;
@@ -198,7 +198,7 @@ export class ModelBuilder extends ModelBuilderPolymer {
           totalTimeSec.toFixed(1),
     };
     this.graphRunner = new GraphRunner(this.math, this.session, eventObserver);
-    this.optimizer = new MomentumOptimizer(this.learingRate, this.momentum);
+    this.optimizer = new MomentumOptimizer(this.learningRate, this.momentum);
 
     // Set up datasets.
     this.populateDatasets();


### PR DESCRIPTION
change `learingRate` to `learningRate`. This never caused problems before since the optimizer is always recreated with `learningRate` when Train is clicked. In fact, I may be wrong but I don't believe there is a need for the initial optimizer at all.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/201)
<!-- Reviewable:end -->
