### PR TITLE
Add minpool benchmark

### DIFF
--- a/demos/benchmarks/math-benchmark-run-groups.ts
+++ b/demos/benchmarks/math-benchmark-run-groups.ts
@@ -71,49 +71,21 @@ export function getRunGroups(): BenchmarkRunGroup[] {
     params: convTransposedParams
   });
 
-  const maxPoolParams:
+  const poolParams:
       PoolBenchmarkParams = {depth: 8, fieldSize: 4, stride: 4, type: 'max'};
   groups.push({
-    name: 'Max pool',
+    name: 'Pool Op Benchmark: input [size, size]',
     min: 0,
     max: 1024,
     stepSize: 64,
     stepToSizeTransformation: (step: number) => Math.max(4, step),
+    options: ['max', 'min', 'avg'],
+    selectedOption: 'max',
     benchmarkRuns: [
-      new BenchmarkRun('max_pool_gpu', new PoolGPUBenchmark(maxPoolParams)),
-      new BenchmarkRun('max_pool_cpu', new PoolCPUBenchmark(maxPoolParams))
+      new BenchmarkRun('pool_gpu', new PoolGPUBenchmark(poolParams)),
+      new BenchmarkRun('pool_cpu', new PoolCPUBenchmark(poolParams))
     ],
-    params: maxPoolParams
-  });
-
-  const minPoolParams:
-      PoolBenchmarkParams = {depth: 8, fieldSize: 4, stride: 4, type: 'min'};
-  groups.push({
-    name: 'Min pool',
-    min: 0,
-    max: 1024,
-    stepSize: 64,
-    stepToSizeTransformation: (step: number) => Math.max(4, step),
-    benchmarkRuns: [
-      new BenchmarkRun('min_pool_gpu', new PoolGPUBenchmark(minPoolParams)),
-      new BenchmarkRun('min_pool_cpu', new PoolCPUBenchmark(minPoolParams))
-    ],
-    params: minPoolParams
-  });
-
-  const avgPoolParams:
-      PoolBenchmarkParams = {depth: 8, fieldSize: 4, stride: 4, type: 'avg'};
-  groups.push({
-    name: 'Avg pool',
-    min: 0,
-    max: 1024,
-    stepSize: 64,
-    stepToSizeTransformation: (step: number) => Math.max(4, step),
-    benchmarkRuns: [
-      new BenchmarkRun('avg_pool_gpu', new PoolGPUBenchmark(avgPoolParams)),
-      new BenchmarkRun('avg_pool_cpu', new PoolCPUBenchmark(avgPoolParams))
-    ],
-    params: avgPoolParams
+    params: poolParams
   });
 
   groups.push({

--- a/demos/benchmarks/math-benchmark-run-groups.ts
+++ b/demos/benchmarks/math-benchmark-run-groups.ts
@@ -86,6 +86,21 @@ export function getRunGroups(): BenchmarkRunGroup[] {
     params: maxPoolParams
   });
 
+  const minPoolParams:
+      PoolBenchmarkParams = {depth: 8, fieldSize: 4, stride: 4, type: 'min'};
+  groups.push({
+    name: 'Min pool',
+    min: 0,
+    max: 1024,
+    stepSize: 64,
+    stepToSizeTransformation: (step: number) => Math.max(4, step),
+    benchmarkRuns: [
+      new BenchmarkRun('min_pool_gpu', new PoolGPUBenchmark(minPoolParams)),
+      new BenchmarkRun('min_pool_cpu', new PoolCPUBenchmark(minPoolParams))
+    ],
+    params: minPoolParams
+  });
+
   const avgPoolParams:
       PoolBenchmarkParams = {depth: 8, fieldSize: 4, stride: 4, type: 'avg'};
   groups.push({

--- a/demos/benchmarks/pool_benchmarks.ts
+++ b/demos/benchmarks/pool_benchmarks.ts
@@ -30,12 +30,40 @@ export interface PoolBenchmarkParams {
   depth: number;
   fieldSize: number;
   stride: number;
-  type: 'max'|'avg';
+  type: 'max'|'min'|'avg';
 }
 
 export abstract class PoolBenchmark extends BenchmarkTest {
   constructor(protected params: PoolBenchmarkParams) {
     super(params);
+  }
+
+  protected getPoolingOp(option: string, math: NDArrayMathCPU):
+      (x: Array3D, filterSize: [number, number]|number,
+       strides: [number, number]|number,
+       pad: 'valid'|'same'|number) => Array3D {
+    switch (option) {
+      case 'max':
+        return (x: Array3D, filterSize: [number, number] | number,
+                strides: [number, number] | number,
+                pad: 'valid' | 'same' | number) => {
+          return math.maxPool(x, filterSize, strides, pad);
+        };
+      case 'min':
+        return (x: Array3D, filterSize: [number, number] | number,
+                strides: [number, number] | number,
+                pad: 'valid' | 'same' | number) => {
+          return math.minPool(x, filterSize, strides, pad);
+        };
+      case 'avg':
+        return (x: Array3D, filterSize: [number, number] | number,
+                strides: [number, number] | number,
+                pad: 'valid' | 'same' | number) => {
+          return math.avgPool(x, filterSize, strides, pad);
+        };
+      default:
+        throw new Error(`Not found such ops: ${option}`);
+    }
   }
 }
 
@@ -47,12 +75,13 @@ export class PoolCPUBenchmark extends PoolBenchmark {
     const fieldSize = this.params.fieldSize;
     const stride = this.params.stride;
     const zeroPad = conv_util.computeDefaultPad(xShape, fieldSize, stride);
+    const op = this.getPoolingOp(this.params.type, math);
 
     const x = Array3D.randUniform(xShape, -1, 1);
 
     const start = performance.now();
     for (let i = 0; i < CPU_OP_RUNS; i++) {
-      math.maxPool(x as Array3D, fieldSize, stride, zeroPad);
+      op(x as Array3D, fieldSize, stride, zeroPad);
     }
     const avgTime = (performance.now() - start) / CPU_OP_RUNS;
 

--- a/demos/benchmarks/pool_benchmarks.ts
+++ b/demos/benchmarks/pool_benchmarks.ts
@@ -68,14 +68,14 @@ export abstract class PoolBenchmark extends BenchmarkTest {
 }
 
 export class PoolCPUBenchmark extends PoolBenchmark {
-  run(size: number): Promise<number> {
+  run(size: number, option: string): Promise<number> {
     const math = new NDArrayMathCPU();
     const outputDepth = this.params.depth;
     const xShape: [number, number, number] = [size, size, outputDepth];
     const fieldSize = this.params.fieldSize;
     const stride = this.params.stride;
     const zeroPad = conv_util.computeDefaultPad(xShape, fieldSize, stride);
-    const op = this.getPoolingOp(this.params.type, math);
+    const op = this.getPoolingOp(option, math);
 
     const x = Array3D.randUniform(xShape, -1, 1);
 


### PR DESCRIPTION
I added minPool to the benchmark demo.
I also noticed that the avgPool CPU benchmark was actually calling `maxPool` instead of `avgPool` so I added a method that will call the correct pool method based on the type param.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/249)
<!-- Reviewable:end -->
