### PR TITLE
Reduction Ops Benchmark: logsumexp -> logSumExp

### DIFF
--- a/demos/benchmarks/reduction_ops_benchmark.ts
+++ b/demos/benchmarks/reduction_ops_benchmark.ts
@@ -29,7 +29,7 @@ export abstract class ReductionOpsBenchmark extends BenchmarkTest {
         return (input: NDArray) => math.min(input);
       case 'sum':
         return (input: NDArray) => math.sum(input);
-      case 'logsumexp':
+      case 'logSumExp':
         return (input: NDArray) => math.logSumExp(input);
       default:
         throw new Error(`Not found such ops: ${option}`);


### PR DESCRIPTION
This pull request fixes a minor typo in Reduction Ops Benchmark which was breaking the demo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/254)
<!-- Reviewable:end -->
