### PR TITLE
Fix leakyRelu and elu tests

### DIFF
--- a/src/math/unaryop_test.ts
+++ b/src/math/unaryop_test.ts
@@ -778,7 +778,7 @@ import {Array1D, Array2D, Scalar} from './ndarray';
       const a = Array1D.new([0, 1, -2]);
       const result = math.leakyRelu(a);
 
-      expect(result.shape).toBe(a.shape);
+      expect(result.shape).toEqual(a.shape);
       test_util.expectArraysClose(result.dataSync(),
           new Float32Array([0, 1, -0.4]));
     });
@@ -787,7 +787,7 @@ import {Array1D, Array2D, Scalar} from './ndarray';
       const a = Array1D.new([0, 1, NaN]);
       const result = math.leakyRelu(a);
 
-      expect(result.shape).toBe(a.shape);
+      expect(result.shape).toEqual(a.shape);
       test_util.expectArraysClose(result.dataSync(),
           new Float32Array([0, 1, NaN]));
     });
@@ -809,7 +809,7 @@ import {Array1D, Array2D, Scalar} from './ndarray';
       const a = Array1D.new([1, -1, 0]);
       const result = math.elu(a);
 
-      expect(result.shape).toBe(a.shape);
+      expect(result.shape).toEqual(a.shape);
       test_util.expectArraysClose(result.dataSync(),
           new Float32Array([1, -0.6321, 0]));
     });
@@ -817,7 +817,7 @@ import {Array1D, Array2D, Scalar} from './ndarray';
     it('elu propagates NaN', math => {
       const a = Array1D.new([1, NaN]);
       const result = math.elu(a);
-      expect(result.shape).toBe(a.shape);
+      expect(result.shape).toEqual(a.shape);
       test_util.expectArraysClose(result.dataSync(),
           new Float32Array([1, NaN]));
     });


### PR DESCRIPTION
We can use toEqual() instead of toBe() because it checks only equivalence of its value. 

```
Chrome 61.0.3163 (Mac OS X 10.12.6) math_cpu.leakyRelu basic FAILED
	Expected [ 3 ] to be [ 3 ].
	    at src/math/unaryop_test.ts:280:6 <-
src/math/unaryop_test.js:1480:46
	    at src/test_util.ts:199:31 <- src/test_util.js:322:32
	    at Object.<anonymous> (src/test_util.ts:173:19 <-
src/test_util.js:276:34)
```

It fixed on the local machine. But we need to also set username and password of BrowserStack as said in #260.

see #261 [CI](https://travis-ci.org/PAIR-code/deeplearnjs/builds/291699345?utm_source=github_status&utm_medium=notification)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/263)
<!-- Reviewable:end -->
