### PR TITLE
Make Website: Install dependencies before serving website

### DIFF
--- a/scripts/make-website.sh
+++ b/scripts/make-website.sh
@@ -48,4 +48,11 @@ rm "$TMP_DIR"/homepage.ts
 
 echo "Website staged at $TMP_DIR"
 pushd $TMP_DIR > /dev/null
+
+if ! [ -x "$(command -v bundle)" ]; then
+  echo 'Installing Bundler'
+  gem install bundler
+fi
+
+bundle install --clean
 bundle exec jekyll serve


### PR DESCRIPTION
Currently after bundling website, the script tries serving it without checking if dependencies are installed and if `bundle` command exist. This PR fixes the same.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/268)
<!-- Reviewable:end -->
