### PR TITLE
Add batchnorm3d benchmark

### DIFF
--- a/demos/benchmarks/batchnormalization3d_benchmark.ts
+++ b/demos/benchmarks/batchnormalization3d_benchmark.ts
@@ -1,0 +1,91 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+// tslint:disable-next-line:max-line-length
+import {Array1D, Array3D, ENV, NDArray, NDArrayMathCPU, NDArrayMathGPU } from '../deeplearn';
+
+import {BenchmarkTest} from './benchmark';
+
+export class BatchNormalization3DCPUBenchmark extends BenchmarkTest {
+  async run(size: number): Promise<number> {
+    if (size > 256) {
+      return new Promise<number>((resolve, reject) => {
+        resolve(-1);
+      });
+    }
+    const math = new NDArrayMathCPU();
+    const x = Array3D.randUniform([size, size, size], -1, 1);
+    const mean = Array1D.new([0]);
+    const variance = Array1D.new([1]);
+    const varianceEpsilon = .001;
+    const start = performance.now();
+
+    math.batchNormalization3D(
+        x, mean, variance, varianceEpsilon, undefined, undefined);
+
+    const end = performance.now();
+
+    return new Promise<number>((resolve, reject) => {
+      resolve(end - start);
+    });
+  }
+}
+
+export class BatchNormalization3DGPUBenchmark extends BenchmarkTest {
+  async run(size: number) {
+    const math = new NDArrayMathGPU();
+    const x = Array3D.randUniform([size, size, size], -1, 1);
+    const mean = Array1D.new([0]);
+    const variance = Array1D.new([1]);
+    const varianceEpsilon = .001;
+
+    let output: NDArray;
+    const benchmark = () => {
+      math.scope(() => {
+        output = math.batchNormalization3D(
+            x, mean, variance, varianceEpsilon, undefined, undefined);
+      });
+    };
+
+    const cleanup = () => {
+      x.dispose();
+      mean.dispose();
+      variance.dispose();
+      math.dispose();
+    };
+
+    // Warmup.
+    await math.getGPGPUContext().runQuery(benchmark);
+
+    let totalTime: number;
+    if (ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_RELIABLE')) {
+      totalTime = await math.getGPGPUContext().runQuery(benchmark);
+    } else {
+      const start = performance.now();
+
+      benchmark();
+      output.dataSync();
+
+      totalTime = performance.now() - start;
+
+      cleanup();
+    }
+
+    cleanup();
+
+    return totalTime;
+  }
+}

--- a/demos/benchmarks/math-benchmark-run-groups.ts
+++ b/demos/benchmarks/math-benchmark-run-groups.ts
@@ -16,6 +16,8 @@
  */
 
 import {BenchmarkRun, BenchmarkRunGroup} from './benchmark';
+// tslint:disable-next-line:max-line-length
+import {BatchNormalization3DCPUBenchmark, BatchNormalization3DGPUBenchmark} from './batchnormalization3d_benchmark';
 import {ConvBenchmarkParams, ConvGPUBenchmark} from './conv_benchmarks';
 // tslint:disable-next-line:max-line-length
 import {ConvTransposedBenchmarkParams, ConvTransposedGPUBenchmark} from './conv_transposed_benchmarks';
@@ -29,6 +31,21 @@ import {UnaryOpsCPUBenchmark, UnaryOpsGPUBenchmark} from './unary_ops_benchmark'
 
 export function getRunGroups(): BenchmarkRunGroup[] {
   const groups: BenchmarkRunGroup[] = [];
+
+  groups.push({
+    name: 'Batch Normalization 3D: input [size, size, size]',
+    min: 0,
+    max: 512,
+    stepSize: 64,
+    stepToSizeTransformation: (step: number) => Math.max(1, step),
+    benchmarkRuns: [
+      new BenchmarkRun('batchnorm3d_gpu',
+                       new BatchNormalization3DGPUBenchmark()),
+      new BenchmarkRun('batchnorm3d_cpu', 
+                       new BatchNormalization3DCPUBenchmark())
+    ],
+    params: {}
+  });
 
   groups.push({
     name: 'Matrix Multiplication: ' +


### PR DESCRIPTION
Adding benchmark for `math.batchNormalization3D`. Part of #233.

### todo
- [x] cpu
- [x] gpu

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/276)
<!-- Reviewable:end -->
