### PR TITLE
Don't use `params` for shader key construction. Use `userCode` instead.

### DIFF
--- a/src/math/webgl/addscaledmat_gpu.ts
+++ b/src/math/webgl/addscaledmat_gpu.ts
@@ -20,7 +20,6 @@ import {GPGPUProgram} from './gpgpu_math';
 
 export class AddScaledMatProgram implements GPGPUProgram {
   variableNames = ['A', 'B', 'c1', 'c2'];
-  params: Array<{}> = [];
   outputShape: number[];
   userCode: string;
   supportsBroadcasting = true;

--- a/src/math/webgl/argminmax_gpu.ts
+++ b/src/math/webgl/argminmax_gpu.ts
@@ -45,12 +45,10 @@ export function getArgMinMaxSnippet(
 export class ArgMinMaxProgram implements GPGPUProgram {
   variableNames = ['A'];
   outputShape: number[];
-  params: Array<{}>;
   userCode: string;
   numBatchDims: number;
 
   constructor(shape: number[], axes: number[], opType: 'min'|'max') {
-    this.params = [opType];
     const [outShape, reduceShape] =
         axis_util.computeOutAndReduceShapes(shape, axes);
     this.outputShape = outShape;

--- a/src/math/webgl/batchnorm_gpu.ts
+++ b/src/math/webgl/batchnorm_gpu.ts
@@ -20,7 +20,6 @@ import {GPGPUProgram} from './gpgpu_math';
 
 export class BatchNormProgram implements GPGPUProgram {
   variableNames: string[];
-  params: Array<{}> = [];
   outputShape: number[] = [];
   userCode: string;
   supportsBroadcasting = true;
@@ -47,7 +46,6 @@ export class BatchNormProgram implements GPGPUProgram {
       scaleSnippet = 'getScaleAtOutCoords()';
     }
 
-    this.params = [varianceEpsilon];
     this.outputShape = xShape;
     this.userCode = `
       void main() {

--- a/src/math/webgl/binaryop_gpu.ts
+++ b/src/math/webgl/binaryop_gpu.ts
@@ -30,13 +30,11 @@ export const EQUAL = `
 
 export class BinaryOpProgram implements GPGPUProgram {
   variableNames = ['A', 'B'];
-  params: Array<{}>;
   outputShape: number[];
   userCode: string;
   supportsBroadcasting = true;
 
   constructor(op: string, aShape: number[], bShape: number[]) {
-    this.params = [op];
     this.outputShape =
         broadcast_util.assertAndGetBroadcastShape(aShape, bShape);
     this.userCode = `

--- a/src/math/webgl/clip_gpu.ts
+++ b/src/math/webgl/clip_gpu.ts
@@ -19,7 +19,6 @@ import {GPGPUProgram} from './gpgpu_math';
 
 export class ClipProgram implements GPGPUProgram {
   variableNames = ['A'];
-  params: Array<{}>;
   userCode: string;
   outputShape: number[];
 
@@ -27,7 +26,6 @@ export class ClipProgram implements GPGPUProgram {
     this.outputShape = aShape;
     const minFixed = min.toFixed(20);
     const maxFixed = max.toFixed(20);
-    this.params = [minFixed, maxFixed];
     this.userCode = `
       void main() {
         float value = getAAtOutCoords();

--- a/src/math/webgl/concat_gpu.ts
+++ b/src/math/webgl/concat_gpu.ts
@@ -26,7 +26,6 @@ export class ConcatProgram implements GPGPUProgram {
   constructor(aShape: number[], bShape: number[], axis: number) {
     const yAxes = ['yR', 'yC', 'yD', 'yW'];
     const concatAxis = yAxes[axis];
-    this.params = [axis];
     this.outputShape = concat_util.computeOutShape(aShape, bShape, axis);
 
     const dType = getDataType(aShape.length);

--- a/src/math/webgl/concat_gpu.ts
+++ b/src/math/webgl/concat_gpu.ts
@@ -20,7 +20,6 @@ import {GPGPUProgram} from './gpgpu_math';
 
 export class ConcatProgram implements GPGPUProgram {
   variableNames = ['A', 'B'];
-  params: Array<{}> = [];
   outputShape: number[] = [];
   userCode: string;
 

--- a/src/math/webgl/conv_backprop_gpu.ts
+++ b/src/math/webgl/conv_backprop_gpu.ts
@@ -21,7 +21,6 @@ import {GPGPUProgram} from './gpgpu_math';
 
 export class Conv2DDerWeightsProgram implements GPGPUProgram {
   variableNames = ['x', 'dy'];
-  params: Array<{}>;
   outputShape: number[];
   userCode: string;
 
@@ -34,8 +33,6 @@ export class Conv2DDerWeightsProgram implements GPGPUProgram {
         inDepth, outDepth, convInfo.filterHeight, convInfo.filterWidth);
     const padTop = convInfo.padInfo.top;
     const padLeft = convInfo.padInfo.left;
-
-    this.params = [strideHeight, strideWidth, padLeft, padTop];
 
     this.userCode = `
       void main() {
@@ -75,7 +72,6 @@ export class Conv2DDerWeightsProgram implements GPGPUProgram {
 
 export class Conv2DDerInputProgram implements GPGPUProgram {
   variableNames = ['dy', 'W'];
-  params: Array<{}>;
   outputShape: number[];
   userCode: string;
 
@@ -90,7 +86,6 @@ export class Conv2DDerInputProgram implements GPGPUProgram {
 
     const padTop = filterHeight - 1 - convInfo.padInfo.top;
     const padLeft = filterWidth - 1 - convInfo.padInfo.left;
-    this.params = [strideHeight, strideWidth, padLeft, padTop];
 
     this.userCode = `
       const ivec2 pads = ivec2(${padTop}, ${padLeft});
@@ -141,7 +136,6 @@ export class Conv2DDerInputProgram implements GPGPUProgram {
 
 export class Conv2DDerBiasProgram implements GPGPUProgram {
   variableNames = ['dy'];
-  params: Array<{}> = [];
   outputShape: number[];
   userCode: string;
 

--- a/src/math/webgl/conv_gpu.ts
+++ b/src/math/webgl/conv_gpu.ts
@@ -20,7 +20,6 @@ import {GPGPUProgram} from './gpgpu_math';
 
 export class Conv2DProgram implements GPGPUProgram {
   variableNames = ['x', 'W'];
-  params: Array<{}>;
   outputShape: number[];
   userCode: string;
 
@@ -38,8 +37,6 @@ export class Conv2DProgram implements GPGPUProgram {
     const strideWidth = convInfo.strideWidth;
     const filterHeight = convInfo.filterHeight;
     const filterWidth = convInfo.filterWidth;
-
-    this.params = [strideHeight, strideWidth, hasBias, padLeft, padTop];
 
     const inputDepthNearestVec4 = Math.floor(inputDepth / 4) * 4;
     const inputDepthVec4Remainder = inputDepth % 4;

--- a/src/math/webgl/copy_gpu.ts
+++ b/src/math/webgl/copy_gpu.ts
@@ -20,13 +20,11 @@ import {GPGPUProgram} from './gpgpu_math';
 
 export class Copy2DProgram implements GPGPUProgram {
   variableNames = ['source'];
-  params: Array<{}>;
   outputShape: number[];
   userCode: string;
 
   constructor(srcNumCols: number, destNumCols: number) {
     this.outputShape = null;
-    this.params = [srcNumCols, destNumCols];
     this.userCode = `
       uniform ivec2 sourceStart;
       uniform ivec2 destStart;

--- a/src/math/webgl/gpgpu_math.ts
+++ b/src/math/webgl/gpgpu_math.ts
@@ -28,7 +28,6 @@ const ATTRIBUTE_NAMES = ['uv', 'clipSpacePos'];
 export interface GPGPUProgram {
   variableNames: string[];
   outputShape: number[];
-  params: Array<{}>;
   userCode: string;
   supportsBroadcasting?: boolean;
   numBatchDims?: number;
@@ -164,12 +163,11 @@ export function runProgram<T extends NDArray, K extends NDArray>(
 
 export function makeShaderKey(
     program: GPGPUProgram, inputs: NDArray[], output: NDArray): string {
-  const params = program.params;
-  const keyStart =
+  const keyInputs =
       inputs.concat(output).map(x => `${x.shape}_${x.getTextureShapeRC()}`);
-  const keyEnd = params.map(String);
-  let key = [program.constructor.name];
-  key.push((program.supportsBroadcasting === true).toString());
-  key = key.concat(keyStart, keyEnd);
-  return key.join('_');
+  const keyUserCode = program.userCode;
+  const keyBroadcast = (program.supportsBroadcasting === true).toString();
+  let key = program.constructor.name;
+  key += '_' + keyBroadcast + '_' + keyInputs + '_' + keyUserCode;
+  return key;
 }

--- a/src/math/webgl/gpgpu_math.ts
+++ b/src/math/webgl/gpgpu_math.ts
@@ -165,7 +165,7 @@ export function makeShaderKey(
     program: GPGPUProgram, inputs: NDArray[], output: NDArray): string {
   let keyInputs = '';
   inputs.concat(output).forEach(x => {
-    keyInputs += x.shape + '_' + x.getTextureShapeRC();
+    keyInputs += `${x.shape}_${x.getTextureShapeRC()}`;
   });
   const keyUserCode = program.userCode;
   const keyBroadcast = (program.supportsBroadcasting === true).toString();

--- a/src/math/webgl/gpgpu_math.ts
+++ b/src/math/webgl/gpgpu_math.ts
@@ -170,6 +170,7 @@ export function makeShaderKey(
   const keyUserCode = program.userCode;
   const keyBroadcast = (program.supportsBroadcasting === true).toString();
   let key = program.constructor.name;
+  // Fast string concat. See https://jsperf.com/string-concatenation/14.
   key += '_' + keyBroadcast + '_' + keyInputs + '_' + keyUserCode;
   return key;
 }

--- a/src/math/webgl/gpgpu_math.ts
+++ b/src/math/webgl/gpgpu_math.ts
@@ -163,8 +163,10 @@ export function runProgram<T extends NDArray, K extends NDArray>(
 
 export function makeShaderKey(
     program: GPGPUProgram, inputs: NDArray[], output: NDArray): string {
-  const keyInputs =
-      inputs.concat(output).map(x => `${x.shape}_${x.getTextureShapeRC()}`);
+  let keyInputs = '';
+  inputs.concat(output).forEach(x => {
+    keyInputs += x.shape + '_' + x.getTextureShapeRC();
+  });
   const keyUserCode = program.userCode;
   const keyBroadcast = (program.supportsBroadcasting === true).toString();
   let key = program.constructor.name;

--- a/src/math/webgl/logsumexp_gpu.ts
+++ b/src/math/webgl/logsumexp_gpu.ts
@@ -21,7 +21,6 @@ import {GPGPUProgram} from './gpgpu_math';
 
 export class LogSumExpProgram implements GPGPUProgram {
   variableNames = ['A'];
-  params: Array<{}> = [];
   outputShape: number[];
   userCode: string;
   numBatchDims: number;

--- a/src/math/webgl/max_pool_backprop_gpu.ts
+++ b/src/math/webgl/max_pool_backprop_gpu.ts
@@ -21,7 +21,6 @@ import {GPGPUProgram} from './gpgpu_math';
 
 export class MaxPool2DBackpropProgram implements GPGPUProgram {
   variableNames = ['dy', 'maxPos'];
-  params: Array<{}>;
   outputShape: number[];
   userCode: string;
 
@@ -36,8 +35,6 @@ export class MaxPool2DBackpropProgram implements GPGPUProgram {
 
     const padTop = filterHeight - 1 - convInfo.padInfo.top;
     const padLeft = filterWidth - 1 - convInfo.padInfo.left;
-    this.params =
-        [filterHeight, filterWidth, strideHeight, strideWidth, padTop, padLeft];
 
     const lastIndex = filterHeight * filterWidth - 1;
     this.userCode = `

--- a/src/math/webgl/minmax_gpu.ts
+++ b/src/math/webgl/minmax_gpu.ts
@@ -21,7 +21,6 @@ import {GPGPUProgram} from './gpgpu_math';
 
 export class MinMaxProgram implements GPGPUProgram {
   variableNames = ['A'];
-  params: Array<{}>;
   outputShape: number[];
   userCode: string;
   numBatchDims: number;
@@ -33,7 +32,6 @@ export class MinMaxProgram implements GPGPUProgram {
     this.numBatchDims = outShape.length;
 
     const size = util.sizeFromShape(reduceShape);
-    this.params = [op];
     const sizeNearestVec4 = Math.floor(size / 4) * 4;
     const sizeVec4Remainder = size % 4;
 

--- a/src/math/webgl/mulmat_gpu.ts
+++ b/src/math/webgl/mulmat_gpu.ts
@@ -20,7 +20,6 @@ import {GPGPUProgram} from './gpgpu_math';
 
 export class MatMulProgram implements GPGPUProgram {
   variableNames = ['matrixA', 'matrixB'];
-  params: Array<{}>;
   outputShape: number[];
   userCode: string;
 
@@ -28,8 +27,6 @@ export class MatMulProgram implements GPGPUProgram {
       aShape: [number, number], bShape: [number, number],
       aOrient = MatrixOrientation.REGULAR,
       bOrient = MatrixOrientation.REGULAR) {
-    this.params = [aOrient, bOrient];
-
     const outerShapeA =
         (aOrient === MatrixOrientation.REGULAR) ? aShape[0] : aShape[1];
     const outerShapeB =

--- a/src/math/webgl/multinomial_gpu.ts
+++ b/src/math/webgl/multinomial_gpu.ts
@@ -20,7 +20,6 @@ import {GPGPUProgram} from './gpgpu_math';
 
 export class MultinomialProgram implements GPGPUProgram {
   variableNames = ['probs'];
-  params: Array<{}>;
   outputShape: number[];
   userCode: string;
   numBatchDims: number;
@@ -31,7 +30,6 @@ export class MultinomialProgram implements GPGPUProgram {
   constructor(batchSize: number, numOutcomes: number, numSamples: number) {
     this.outputShape = [batchSize, numSamples];
     this.numBatchDims = 1;
-    this.params = [];
 
     this.userCode = `
       uniform float seed;

--- a/src/math/webgl/onehot_gpu.ts
+++ b/src/math/webgl/onehot_gpu.ts
@@ -20,7 +20,6 @@ import {GPGPUProgram} from './gpgpu_math';
 
 export class OneHotProgram implements GPGPUProgram {
   variableNames = ['indices'];
-  params: Array<{}>;
   outputShape: number[];
   userCode: string;
 
@@ -30,7 +29,6 @@ export class OneHotProgram implements GPGPUProgram {
   constructor(
       numIndices: number, depth: number, onValue: number, offValue: number) {
     this.outputShape = [numIndices, depth];
-    this.params = [onValue, offValue];
 
     this.userCode = `
       void main() {

--- a/src/math/webgl/pool_gpu.ts
+++ b/src/math/webgl/pool_gpu.ts
@@ -20,7 +20,6 @@ import {GPGPUProgram} from './gpgpu_math';
 
 export class Pool2DProgram implements GPGPUProgram {
   variableNames = ['x'];
-  params: Array<{}>;
   outputShape: number[];
   userCode: string;
 
@@ -40,9 +39,6 @@ export class Pool2DProgram implements GPGPUProgram {
     const xNumCols = convInfo.inShape[1];
     const padTop = convInfo.padInfo.top;
     const padLeft = convInfo.padInfo.left;
-    this.params = [
-      strideHeight, strideWidth, padLeft, padTop, poolType, computePositions
-    ];
     this.outputShape = convInfo.outShape;
 
     const isAvgPool = poolType === 'avg';

--- a/src/math/webgl/reducesum_gpu.ts
+++ b/src/math/webgl/reducesum_gpu.ts
@@ -21,7 +21,6 @@ import {GPGPUProgram} from './gpgpu_math';
 
 export class ReduceSumProgram implements GPGPUProgram {
   variableNames = ['A'];
-  params: Array<{}> = [];
   outputShape: number[];
   userCode: string;
   numBatchDims: number;

--- a/src/math/webgl/resize_bilinear_gpu.ts
+++ b/src/math/webgl/resize_bilinear_gpu.ts
@@ -19,7 +19,6 @@ import {GPGPUProgram} from './gpgpu_math';
 
 export class ResizeBilinear3DProgram implements GPGPUProgram {
   variableNames = ['A'];
-  params: Array<{}> = [];
   outputShape: number[] = [];
   userCode: string;
 
@@ -29,7 +28,6 @@ export class ResizeBilinear3DProgram implements GPGPUProgram {
     const depth = inputShape[2];
     this.outputShape =
         [outputDimensionsRowCol[0], outputDimensionsRowCol[1], depth];
-    this.params = [alignCorners];
 
     const effectiveInputShape = alignCorners ?
         [inputShape[0] - 1, inputShape[1] - 1, depth] :
@@ -40,10 +38,8 @@ export class ResizeBilinear3DProgram implements GPGPUProgram {
         this.outputShape;
     this.userCode = `
       const vec2 effectiveInputOverOutputRatioRC = vec2(
-          ${effectiveInputShape[0] /
-        effectiveOutputShape[0]},
-          ${effectiveInputShape[1] /
-        effectiveOutputShape[1]});
+          ${effectiveInputShape[0] / effectiveOutputShape[0]},
+          ${effectiveInputShape[1] / effectiveOutputShape[1]});
       const vec2 inputShapeRC = vec2(${inputShape[0]}.0, ${inputShape[1]}.0);
 
       void main() {

--- a/src/math/webgl/slice_gpu.ts
+++ b/src/math/webgl/slice_gpu.ts
@@ -20,7 +20,6 @@ import {GPGPUProgram} from './gpgpu_math';
 
 export class SliceProgram implements GPGPUProgram {
   variableNames = ['source'];
-  params: Array<{}>;
   outputShape: number[];
   userCode: string;
   rank: number;
@@ -31,7 +30,6 @@ export class SliceProgram implements GPGPUProgram {
   constructor(destSize: number[]) {
     this.outputShape = destSize;
     this.rank = destSize.length;
-    this.params = [];
 
     const dtype = getDataType(this.rank);
     const sourceCoords = getCoords(this.rank);

--- a/src/math/webgl/transpose_gpu.ts
+++ b/src/math/webgl/transpose_gpu.ts
@@ -19,7 +19,6 @@ import {GPGPUProgram} from './gpgpu_math';
 
 export class TransposeProgram implements GPGPUProgram {
   variableNames = ['A'];
-  params: Array<{}>;
   outputShape: number[];
   userCode: string;
   rank: number;
@@ -31,7 +30,6 @@ export class TransposeProgram implements GPGPUProgram {
     }
     this.outputShape = outputShape;
     this.rank = outputShape.length;
-    this.params = [newDim.toString()];
     const dtype = getDataType(this.rank);
     const switched = getSwitchedCoords(newDim);
 

--- a/src/math/webgl/unaryop_gpu.ts
+++ b/src/math/webgl/unaryop_gpu.ts
@@ -19,13 +19,11 @@ import {GPGPUProgram} from './gpgpu_math';
 
 export class UnaryOpProgram implements GPGPUProgram {
   variableNames = ['A'];
-  params: Array<{}>;
   userCode: string;
   outputShape: number[];
 
   constructor(aShape: number[], opSnippet: string) {
     this.outputShape = aShape;
-    this.params = [opSnippet];
     this.userCode = `
       float unaryOperation(float x) {
         ${opSnippet}


### PR DESCRIPTION
Fixes #75

Also improve string concatenation based on results in https://jsperf.com/string-concatenation/14

**Perf timeline for shader key at master when running model builder on MNIST (focus on % of time):**

![shaderkey-master](https://user-images.githubusercontent.com/2294279/32336470-ce5db578-bfc5-11e7-952a-91d930d471cc.png)

**Perf timeline for shader key at PR:**

![shaderkey-pr](https://user-images.githubusercontent.com/2294279/32336480-d0c17bf6-bfc5-11e7-97f8-d11a8fe73b45.png)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/290)
<!-- Reviewable:end -->
