### PR TITLE
Create git tag when running make-version script

### DIFF
--- a/scripts/make-version
+++ b/scripts/make-version
@@ -15,8 +15,10 @@
 // =============================================================================
 
 var fs = require('fs');
+var exec = require( 'child_process' ).exec;
 
 var version = JSON.parse(fs.readFileSync('package.json', 'utf8')).version;
+var tag = `v${version}`;
 
 const versionCode =
 `/** @license See the LICENSE file. */
@@ -25,6 +27,12 @@ const versionCode =
 const version = '${version}';
 export {version};
 `
+
+exec( `git tag ${tag}`, err =>
+  err
+    ? console.log(`WARNING: Could not git tag with ${tag}: ${err.message}`)
+    : console.log(`Tagged with ${tag}`)
+);
 
 fs.writeFile('src/version.ts', versionCode, err => {
   if (err != null) {


### PR DESCRIPTION
This clears the way for automated changelog diffs. See #262.

An enhancement for this workflow could be to let `make-version` accept an argument that matches the [npm version api](https://docs.npmjs.com/cli/version) -- namely `patch`, `minor`, or `major`.

We could then call `npm version ${arg}`, which would increment the package.json version, and create both a matching git tag and version commit.

Omitting the arg could just revert to the functionality covered by this PR. Let me know what you think.

For example:

```
$ npm run make-version -- patch
$ npm run make-version -- minor
$ npm run make-version -- major
$ npm run make-version
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/298)
<!-- Reviewable:end -->
