### PR TITLE
Don't check for `WEBGL_color_buffer_float` since `OES_texture_float` implicitly enables it

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -108,17 +108,12 @@ function isFloatTextureReadPixelsEnabled(webGLVersion: number): boolean {
 
   const gl = getWebGLRenderingContext(webGLVersion);
 
-  let floatExtension;
-  let colorBufferFloatExtension;
   if (webGLVersion === 1) {
-    floatExtension = gl.getExtension('OES_texture_float');
-    colorBufferFloatExtension = gl.getExtension('WEBGL_color_buffer_float');
-    if (floatExtension == null || colorBufferFloatExtension == null) {
+    if (gl.getExtension('OES_texture_float') == null) {
       return false;
     }
   } else {
-    colorBufferFloatExtension = gl.getExtension('EXT_color_buffer_float');
-    if (colorBufferFloatExtension == null) {
+    if (gl.getExtension('EXT_color_buffer_float') == null) {
       return false;
     }
   }


### PR DESCRIPTION
Fixes a bug in the Environment where we would always fall back to byte packing whenever Web 2.0 was not enabled, even though Web 1.0 supports floats.

Checking if `OES_texture_float` is available is enough, since that implicitly enables `WEBGL_color_buffer_float`, according to the WebGL specs. See https://developer.mozilla.org/en-US/docs/Web/API/WEBGL_color_buffer_float

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/301)
<!-- Reviewable:end -->
