### PR TITLE
Export initializeGPU and release new version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deeplearn",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Hardware-accelerated JavaScript library for machine intelligence",
   "private": false,
   "main": "dist/src/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,8 @@ export {ConstantInitializer, Initializer, NDArrayInitializer, OnesInitializer, R
 export {MatrixOrientation, NDArrayMath} from './math/math';
 export {NDArrayMathCPU} from './math/math_cpu';
 export {NDArrayMathGPU} from './math/math_gpu';
+// TODO(nsthorat): Remove this once we decouple NDArray from storage mechanism.
+export {initializeGPU} from './math/ndarray';
 // tslint:disable-next-line:max-line-length
 export {Array1D, Array2D, Array3D, Array4D, NDArray, Scalar} from './math/ndarray';
 export {GPGPUContext} from './math/webgl/gpgpu_context';

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,5 +1,5 @@
 /** @license See the LICENSE file. */
 
 // This code is auto-generated, do not modify this file!
-const version = '0.3.6';
+const version = '0.3.7';
 export {version};


### PR DESCRIPTION
Unfortunately we have to export initializeGPU because when we have multiple versions of deeplearn.js on the page (because of two standalones) they conflict because of the global. This exports initializeGPU so we can sync the two versions.

We will remove this once decoupling happens.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/306)
<!-- Reviewable:end -->
