### PR TITLE
Add unit tests for NDArray.rand().

### DIFF
--- a/src/math/ndarray_test.ts
+++ b/src/math/ndarray_test.ts
@@ -18,6 +18,7 @@
 import * as test_util from '../test_util';
 
 import * as ndarray from './ndarray';
+import * as util from '../util';
 // tslint:disable-next-line:max-line-length
 import {Array1D, Array2D, Array3D, Array4D, DType, NDArray, Scalar} from './ndarray';
 import {GPGPUContext} from './webgl/gpgpu_context';
@@ -1318,6 +1319,37 @@ test_util.describeCustom('NDArray CPU <--> GPU with dtype', () => {
     expect(a.inGPU()).toBe(false);
   });
 }, FEATURES, customBeforeEach, customAfterEach);
+
+// NDArray.rand
+test_util.describeCustom('NDArray.rand', () => {
+  it('should return a random 1D float32 array', () => {
+    const shape: [number] = [10];
+    const result = NDArray.rand(shape, () => util.randUniform(0, 2));
+    expect(result.dtype).toBe('float32');
+    test_util.expectArrayInUniform(result.getValues(), 0, 2);
+  });
+
+  it('should return a random 2D float32 array', () => {
+    const shape: [number] = [3, 4];
+    const result = NDArray.rand(shape, () => util.randUniform(0, 2.5));
+    expect(result.dtype).toBe('float32');
+    test_util.expectArrayInUniform(result.getValues(), 0, 2.5);
+  });
+
+  it('should return a random 3D float32 array', () => {
+    const shape: [number] = [3, 4, 5];
+    const result = NDArray.rand(shape, () => util.randUniform(0, 2.5));
+    expect(result.dtype).toBe('float32');
+    test_util.expectArrayInUniform(result.getValues(), 0, 2.5);
+  });
+
+  it('should return a random 4D float32 array', () => {
+    const shape: [number] = [3, 4, 5, 6];
+    const result = NDArray.rand(shape, () => util.randUniform(0, 2.5));
+    expect(result.dtype).toBe('float32');
+    test_util.expectArrayInUniform(result.getValues(), 0, 2.5);
+  });
+});
 
 // NDArray.fromPixels
 {

--- a/src/math/ndarray_test.ts
+++ b/src/math/ndarray_test.ts
@@ -1326,28 +1326,28 @@ test_util.describeCustom('NDArray.rand', () => {
     const shape: [number] = [10];
     const result = NDArray.rand(shape, () => util.randUniform(0, 2));
     expect(result.dtype).toBe('float32');
-    test_util.expectArrayInUniform(result.getValues(), 0, 2);
+    test_util.expectValuesInRange(result.getValues(), 0, 2);
   });
 
   it('should return a random 2D float32 array', () => {
     const shape: [number] = [3, 4];
     const result = NDArray.rand(shape, () => util.randUniform(0, 2.5));
     expect(result.dtype).toBe('float32');
-    test_util.expectArrayInUniform(result.getValues(), 0, 2.5);
+    test_util.expectValuesInRange(result.getValues(), 0, 2.5);
   });
 
   it('should return a random 3D float32 array', () => {
     const shape: [number] = [3, 4, 5];
     const result = NDArray.rand(shape, () => util.randUniform(0, 2.5));
     expect(result.dtype).toBe('float32');
-    test_util.expectArrayInUniform(result.getValues(), 0, 2.5);
+    test_util.expectValuesInRange(result.getValues(), 0, 2.5);
   });
 
   it('should return a random 4D float32 array', () => {
     const shape: [number] = [3, 4, 5, 6];
     const result = NDArray.rand(shape, () => util.randUniform(0, 2.5));
     expect(result.dtype).toBe('float32');
-    test_util.expectArrayInUniform(result.getValues(), 0, 2.5);
+    test_util.expectValuesInRange(result.getValues(), 0, 2.5);
   });
 });
 

--- a/src/test_util.ts
+++ b/src/test_util.ts
@@ -70,6 +70,18 @@ function areClose(a: number, e: number, epsilon: number): boolean {
   return true;
 }
 
+export function expectArrayInUniform(
+    actual: TypedArray|number[],
+    low: number,
+    high: number) {
+  for (let i = 0; i < actual.length; i++) {
+    if (actual[i] < low || actual[i] > high) {
+      throw new Error(
+        `Value out of range:${actual[i]} low: ${low}, high: ${high}`);
+    }
+  }
+}
+
 export function randomArrayInRange(
     n: number, minValue: number, maxValue: number): Float32Array {
   const v = new Float32Array(n);

--- a/src/test_util.ts
+++ b/src/test_util.ts
@@ -70,7 +70,7 @@ function areClose(a: number, e: number, epsilon: number): boolean {
   return true;
 }
 
-export function expectArrayInUniform(
+export function expectValuesInRange(
     actual: TypedArray|number[],
     low: number,
     high: number) {


### PR DESCRIPTION
Here is the first chunk of my broken up type work - tests for NDArray.rand() with float32. I'll circle back and add tests for the other types in a future PR that includes the type-conversion fix as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/340)
<!-- Reviewable:end -->
