### PR TITLE
Add unit tests for NDArray.randNormal().

### DIFF
--- a/src/math/ndarray_test.ts
+++ b/src/math/ndarray_test.ts
@@ -18,7 +18,6 @@
 import * as test_util from '../test_util';
 
 import * as ndarray from './ndarray';
-import * as util from '../util';
 // tslint:disable-next-line:max-line-length
 import {Array1D, Array2D, Array3D, Array4D, DType, NDArray, Scalar} from './ndarray';
 import {GPGPUContext} from './webgl/gpgpu_context';
@@ -1322,55 +1321,46 @@ test_util.describeCustom('NDArray CPU <--> GPU with dtype', () => {
 
 // NDArray.randNormal
 test_util.describeCustom('NDArray.randNormal', () => {
-  // W/S test works well with smaller sets.
-  const NUM_SAMPLES_NORMALITY = 10;
-  const NUM_SAMPLES_MEAN_STDV = 10000;
-  // Expect higher precentage of variance from standard deviation and mean.
-  const EPSILON = 0.5;
-  // Lower/Upper boundries for critical values in W/S test with 10 items
-  // (0.01 level of signifigance).
-  // http://webspace.ship.edu/pgmarr/Geo441/Lectures/Lec%205%20-%20Normality%20Testing.pdf
-  const LOWER_BOUNDRY = 2.51;
-  const UPPER_BOUNDRY = 3.875;
+  const NUM_SAMPLES = 10000;
 
   it('should return a float32 1D or random normal values', () => {
-    let result = NDArray.randNormal([NUM_SAMPLES_NORMALITY], 0, 1.5);
+    let result = NDArray.randNormal([NUM_SAMPLES], 0, 1.5);
     expect(result.dtype).toBe('float32');
-    expect(result.shape).toEqual([NUM_SAMPLES_NORMALITY]);
-    expectArrayInNormality(result.getValues(), LOWER_BOUNDRY, UPPER_BOUNDRY);
-
-    result = NDArray.randNormal([NUM_SAMPLES_MEAN_STDV], 1, 1.5);
-    expect(result.dtype).toBe('float32');
-    expect(result.shape).toEqual([NUM_SAMPLES_MEAN_STDV]);
-    test_util.expectArrayInMeanStdRange(result.getValues(), 1, 1.5, EPSILON);
+    expect(result.shape).toEqual([NUM_SAMPLES]);
+    test_util.jarqueBeraNormalityTest(result.getValues());
   });
 
-  function expectArrayInNormality(
-      actual: util.TypedArray|number[],
-      lowerBoundry: number,
-      upperBoundry: number) {
-    // Perform simple W/S test for normality.
-    let low = 0;
-    let high = 0;
-    let sum = 0;
-    for (let i = 0; i < actual.length; i++) {
-      let v = actual[i];
-      if (v < low) {
-        low = v;
-      } else if (v > high) {
-        high = v;
-      }
-      sum += v;
-    }
-    const mean = sum / actual.length;
-    const stdDeviation = test_util.standardDeviation(actual, mean);
-    const criticalRange = (high - low) / stdDeviation;
+  // function expectArrayInNormality(
+  //     actual: util.TypedArray|number[],
+  //     lowerBoundry: number,
+  //     upperBoundry: number) {
+  //   // Perform simple W/S test for normality.
+  //   let low = 0;
+  //   let high = 0;
+  //   let sum = 0;
+  //   for (let i = 0; i < actual.length; i++) {
+  //     let v = actual[i];
+  //     if (v < low) {
+  //       low = v;
+  //     } else if (v > high) {
+  //       high = v;
+  //     }
+  //     sum += v;
+  //   }
+  //   const mean = sum / actual.length;
+  //   const stdDeviation = test_util.standardDeviation(actual, mean);
+  //   const criticalRange = (high - low) / stdDeviation;
 
-    if (criticalRange < lowerBoundry || criticalRange > upperBoundry) {
-      throw new Error('Value out of critical boundry: ' + criticalRange +
-        ' (lower: ' + lowerBoundry + ', upper: ' + upperBoundry + ')');
-    }
-  }
+  //   // Use Jarque-Bera test?
+  //   console.log('kurtosis', test_util.kurtosis(actual));
+  //   console.log('skewness', test_util.skewness(actual));
+  //   console.log('jbTest: ', test_util.jarqueBeraNormalityTest(actual));
+
+  //   // if (criticalRange < lowerBoundry || criticalRange > upperBoundry) {
+  //   //   throw new Error('Value out of critical boundry: ' + criticalRange +
+  //   //     ' (lower: ' + lowerBoundry + ', upper: ' + upperBoundry + ')');
+  //   // }
+  // }
 });
 
 // NDArray.fromPixels

--- a/src/math/ndarray_test.ts
+++ b/src/math/ndarray_test.ts
@@ -20,7 +20,15 @@ import * as util from '../util';
 
 import * as ndarray from './ndarray';
 // tslint:disable-next-line:max-line-length
-import {Array1D, Array2D, Array3D, Array4D, DType, NDArray, Scalar} from './ndarray';
+import {
+  Array1D,
+  Array2D,
+  Array3D,
+  Array4D,
+  DType,
+  NDArray,
+  Scalar
+} from './ndarray';
 import {GPGPUContext} from './webgl/gpgpu_context';
 import * as gpgpu_util from './webgl/gpgpu_util';
 import {TextureManager} from './webgl/texture_manager';
@@ -193,7 +201,7 @@ test_util.describeCustom('NDArray', () => {
     });
   });
 
-  it('NDArray.data GPU --> CPU', async () => {
+  it('NDArray.data GPU --> CPU', async() => {
     const texture = textureManager.acquireTexture([3, 2]);
     gpgpu.uploadMatrixToTexture(
         texture, 3, 2, new Float32Array([1, 2, 3, 4, 5, 6]));
@@ -206,7 +214,7 @@ test_util.describeCustom('NDArray', () => {
     expect(a.inGPU()).toBe(false);
   });
 
-  it('NDArray.val() GPU --> CPU', async () => {
+  it('NDArray.val() GPU --> CPU', async() => {
     const texture = textureManager.acquireTexture([3, 2]);
     gpgpu.uploadMatrixToTexture(
         texture, 3, 2, new Float32Array([1, 2, 3, 4, 5, 6]));
@@ -257,9 +265,7 @@ test_util.describeCustom('NDArray', () => {
     const texture = textureManager.acquireTexture([1, 3]);
     gpgpu.uploadMatrixToTexture(texture, 1, 3, new Float32Array([10, 7, 3]));
 
-    const f = () => {
-      return Array1D.make([3], {texture});
-    };
+    const f = () => { return Array1D.make([3], {texture}); };
 
     expect(f).toThrowError();
     textureManager.releaseTexture(texture, [1, 3]);
@@ -1353,13 +1359,41 @@ test_util.describeCustom('NDArray.rand', () => {
 
 // NDArray.randNormal
 test_util.describeCustom('NDArray.randNormal', () => {
-  const NUM_SAMPLES = 5000;
   const EPSILON = 0.05;
 
-  it('should return a float32 1D or random normal values', () => {
-    const result = NDArray.randNormal([NUM_SAMPLES], 0, 0.5);
+  it('should return a float32 1D of random normal values', () => {
+    const SAMPLES = 1000;
+    const result = NDArray.randNormal([SAMPLES], 0, 0.5);
     expect(result.dtype).toBe('float32');
-    expect(result.shape).toEqual([NUM_SAMPLES]);
+    expect(result.shape).toEqual([SAMPLES]);
+    test_util.jarqueBeraNormalityTest(result.getValues());
+    test_util.expectArrayInMeanStdRange(result.getValues(), 0, 0.5, EPSILON);
+  });
+
+  it('should return a float32 2D of random normal values', () => {
+    const SAMPLES = 100;
+    const result = Array2D.randNormal([SAMPLES, SAMPLES], 0, 0.5);
+    expect(result.dtype).toBe('float32');
+    expect(result.shape).toEqual([SAMPLES, SAMPLES]);
+    test_util.jarqueBeraNormalityTest(result.getValues());
+    test_util.expectArrayInMeanStdRange(result.getValues(), 0, 0.5, EPSILON);
+  });
+
+  it('should return a float32 3D of random normal values', () => {
+    const SAMPLES = 50;
+    const result = Array3D.randNormal([SAMPLES, SAMPLES, SAMPLES], 0, 0.5);
+    expect(result.dtype).toBe('float32');
+    expect(result.shape).toEqual([SAMPLES, SAMPLES, SAMPLES]);
+    test_util.jarqueBeraNormalityTest(result.getValues());
+    test_util.expectArrayInMeanStdRange(result.getValues(), 0, 0.5, EPSILON);
+  });
+
+  it('should return a float32 4D of random normal values', () => {
+    const SAMPLES = 25;
+    const result =
+        Array4D.randNormal([SAMPLES, SAMPLES, SAMPLES, SAMPLES], 0, 0.5);
+    expect(result.dtype).toBe('float32');
+    expect(result.shape).toEqual([SAMPLES, SAMPLES, SAMPLES, SAMPLES]);
     test_util.jarqueBeraNormalityTest(result.getValues());
     test_util.expectArrayInMeanStdRange(result.getValues(), 0, 0.5, EPSILON);
   });

--- a/src/math/ndarray_test.ts
+++ b/src/math/ndarray_test.ts
@@ -18,6 +18,7 @@
 import * as test_util from '../test_util';
 
 import * as ndarray from './ndarray';
+import * as util from '../util';
 // tslint:disable-next-line:max-line-length
 import {Array1D, Array2D, Array3D, Array4D, DType, NDArray, Scalar} from './ndarray';
 import {GPGPUContext} from './webgl/gpgpu_context';
@@ -1318,6 +1319,59 @@ test_util.describeCustom('NDArray CPU <--> GPU with dtype', () => {
     expect(a.inGPU()).toBe(false);
   });
 }, FEATURES, customBeforeEach, customAfterEach);
+
+// NDArray.randNormal
+test_util.describeCustom('NDArray.randNormal', () => {
+  // W/S test works well with smaller sets.
+  const NUM_SAMPLES_NORMALITY = 10;
+  const NUM_SAMPLES_MEAN_STDV = 10000;
+  // Expect higher precentage of variance from standard deviation and mean.
+  const EPSILON = 0.5;
+  // Lower/Upper boundries for critical values in W/S test with 10 items
+  // (0.01 level of signifigance).
+  // http://webspace.ship.edu/pgmarr/Geo441/Lectures/Lec%205%20-%20Normality%20Testing.pdf
+  const LOWER_BOUNDRY = 2.51;
+  const UPPER_BOUNDRY = 3.875;
+
+  it('should return a float32 1D or random normal values', () => {
+    let result = NDArray.randNormal([NUM_SAMPLES_NORMALITY], 0, 1.5);
+    expect(result.dtype).toBe('float32');
+    expect(result.shape).toEqual([NUM_SAMPLES_NORMALITY]);
+    expectArrayInNormality(result.getValues(), LOWER_BOUNDRY, UPPER_BOUNDRY);
+
+    result = NDArray.randNormal([NUM_SAMPLES_MEAN_STDV], 1, 1.5);
+    expect(result.dtype).toBe('float32');
+    expect(result.shape).toEqual([NUM_SAMPLES_MEAN_STDV]);
+    test_util.expectArrayInMeanStdRange(result.getValues(), 1, 1.5, EPSILON);
+  });
+
+  function expectArrayInNormality(
+      actual: util.TypedArray|number[],
+      lowerBoundry: number,
+      upperBoundry: number) {
+    // Perform simple W/S test for normality.
+    let low = 0;
+    let high = 0;
+    let sum = 0;
+    for (let i = 0; i < actual.length; i++) {
+      let v = actual[i];
+      if (v < low) {
+        low = v;
+      } else if (v > high) {
+        high = v;
+      }
+      sum += v;
+    }
+    const mean = sum / actual.length;
+    const stdDeviation = test_util.standardDeviation(actual, mean);
+    const criticalRange = (high - low) / stdDeviation;
+
+    if (criticalRange < lowerBoundry || criticalRange > upperBoundry) {
+      throw new Error('Value out of critical boundry: ' + criticalRange +
+        ' (lower: ' + lowerBoundry + ', upper: ' + upperBoundry + ')');
+    }
+  }
+});
 
 // NDArray.fromPixels
 {

--- a/src/math/ndarray_test.ts
+++ b/src/math/ndarray_test.ts
@@ -1353,46 +1353,16 @@ test_util.describeCustom('NDArray.rand', () => {
 
 // NDArray.randNormal
 test_util.describeCustom('NDArray.randNormal', () => {
-  const NUM_SAMPLES = 10000;
+  const NUM_SAMPLES = 5000;
+  const EPSILON = 0.05;
 
   it('should return a float32 1D or random normal values', () => {
-    let result = NDArray.randNormal([NUM_SAMPLES], 0, 1.5);
+    const result = NDArray.randNormal([NUM_SAMPLES], 0, 0.5);
     expect(result.dtype).toBe('float32');
     expect(result.shape).toEqual([NUM_SAMPLES]);
     test_util.jarqueBeraNormalityTest(result.getValues());
+    test_util.expectArrayInMeanStdRange(result.getValues(), 0, 0.5, EPSILON);
   });
-
-  // function expectArrayInNormality(
-  //     actual: util.TypedArray|number[],
-  //     lowerBoundry: number,
-  //     upperBoundry: number) {
-  //   // Perform simple W/S test for normality.
-  //   let low = 0;
-  //   let high = 0;
-  //   let sum = 0;
-  //   for (let i = 0; i < actual.length; i++) {
-  //     let v = actual[i];
-  //     if (v < low) {
-  //       low = v;
-  //     } else if (v > high) {
-  //       high = v;
-  //     }
-  //     sum += v;
-  //   }
-  //   const mean = sum / actual.length;
-  //   const stdDeviation = test_util.standardDeviation(actual, mean);
-  //   const criticalRange = (high - low) / stdDeviation;
-
-  //   // Use Jarque-Bera test?
-  //   console.log('kurtosis', test_util.kurtosis(actual));
-  //   console.log('skewness', test_util.skewness(actual));
-  //   console.log('jbTest: ', test_util.jarqueBeraNormalityTest(actual));
-
-  //   // if (criticalRange < lowerBoundry || criticalRange > upperBoundry) {
-  //   //   throw new Error('Value out of critical boundry: ' + criticalRange +
-  //   //     ' (lower: ' + lowerBoundry + ', upper: ' + upperBoundry + ')');
-  //   // }
-  // }
 });
 
 // NDArray.fromPixels

--- a/src/math/ndarray_test.ts
+++ b/src/math/ndarray_test.ts
@@ -20,15 +20,7 @@ import * as util from '../util';
 
 import * as ndarray from './ndarray';
 // tslint:disable-next-line:max-line-length
-import {
-  Array1D,
-  Array2D,
-  Array3D,
-  Array4D,
-  DType,
-  NDArray,
-  Scalar
-} from './ndarray';
+import {Array1D, Array2D, Array3D, Array4D, DType, NDArray, Scalar} from './ndarray';
 import {GPGPUContext} from './webgl/gpgpu_context';
 import * as gpgpu_util from './webgl/gpgpu_util';
 import {TextureManager} from './webgl/texture_manager';
@@ -201,7 +193,7 @@ test_util.describeCustom('NDArray', () => {
     });
   });
 
-  it('NDArray.data GPU --> CPU', async() => {
+  it('NDArray.data GPU --> CPU', async () => {
     const texture = textureManager.acquireTexture([3, 2]);
     gpgpu.uploadMatrixToTexture(
         texture, 3, 2, new Float32Array([1, 2, 3, 4, 5, 6]));
@@ -214,7 +206,7 @@ test_util.describeCustom('NDArray', () => {
     expect(a.inGPU()).toBe(false);
   });
 
-  it('NDArray.val() GPU --> CPU', async() => {
+  it('NDArray.val() GPU --> CPU', async () => {
     const texture = textureManager.acquireTexture([3, 2]);
     gpgpu.uploadMatrixToTexture(
         texture, 3, 2, new Float32Array([1, 2, 3, 4, 5, 6]));
@@ -265,7 +257,9 @@ test_util.describeCustom('NDArray', () => {
     const texture = textureManager.acquireTexture([1, 3]);
     gpgpu.uploadMatrixToTexture(texture, 1, 3, new Float32Array([10, 7, 3]));
 
-    const f = () => { return Array1D.make([3], {texture}); };
+    const f = () => {
+      return Array1D.make([3], {texture});
+    };
 
     expect(f).toThrowError();
     textureManager.releaseTexture(texture, [1, 3]);

--- a/src/test_util.ts
+++ b/src/test_util.ts
@@ -27,6 +27,36 @@ import {DType, TypedArray} from './util';
 // TODO(nsthorat || smilkov): Fix this low precision for byte-backed textures.
 export const TEST_EPSILON = 1e-2;
 
+export function standardDeviation(
+    values: TypedArray|number[], mean: number) {
+  let squareDiffSum = 0;
+  for (let i = 0; i < values.length; i++) {
+    let diff = values[i] - mean;
+    squareDiffSum += diff * diff;
+  }
+  return Math.sqrt(squareDiffSum / values.length);
+}
+
+export function expectArrayInMeanStdRange(
+    actual: util.TypedArray|number[],
+    mean: number,
+    stdDev: number,
+    epsilon = TEST_EPSILON) {
+  let actualSum = 0;
+  for (let i = 0; i < actual.length; i++) {
+    actualSum += actual[i];
+  }
+  const actualMean = actualSum / actual.length;
+  const actualStdDev = standardDeviation(actual, actualMean);
+  console.log('length: ', actual.length);
+  console.log('actualSum   : ', actualSum);
+  console.log('actualMean  : ', actualMean);
+  console.log('actualStdDev: ', actualStdDev);
+
+  expectNumbersClose(actualMean, mean, epsilon);
+  expectNumbersClose(actualStdDev, stdDev, epsilon);
+}
+
 export function expectArraysClose(
     actual: TypedArray|number[], expected: TypedArray|number[],
     epsilon = TEST_EPSILON) {

--- a/src/test_util.ts
+++ b/src/test_util.ts
@@ -35,11 +35,10 @@ export function mean(values: TypedArray|number[]) {
   return sum / values.length;
 }
 
-export function standardDeviation(
-    values: TypedArray|number[], mean: number) {
+export function standardDeviation(values: TypedArray|number[], mean: number) {
   let squareDiffSum = 0;
   for (let i = 0; i < values.length; i++) {
-    let diff = values[i] - mean;
+    const diff = values[i] - mean;
     squareDiffSum += diff * diff;
   }
   return Math.sqrt(squareDiffSum / values.length);
@@ -47,13 +46,12 @@ export function standardDeviation(
 
 export function kurtosis(values: TypedArray|number[]) {
   // https://en.wikipedia.org/wiki/Kurtosis
-  let valuesMean = mean(values);
-  let n = values.length;
+  const valuesMean = mean(values);
+  const n = values.length;
   let sum2 = 0;
   let sum4 = 0;
-  let i = -1;
-  while (++i < n) {
-    let v = values[i] - valuesMean;
+  for (let i = 0; i < n; i++) {
+    const v = values[i] - valuesMean;
     sum2 += Math.pow(v, 2);
     sum4 += Math.pow(v, 4);
   }
@@ -62,41 +60,38 @@ export function kurtosis(values: TypedArray|number[]) {
 
 export function skewness(values: TypedArray|number[]) {
   // https://en.wikipedia.org/wiki/Skewness
-  let valuesMean = mean(values);
-  let n = values.length;
+  const valuesMean = mean(values);
+  const n = values.length;
   let sum2 = 0;
   let sum3 = 0;
   let i = -1;
   while (++i < n) {
-    let v = values[i] - valuesMean;
+    const v = values[i] - valuesMean;
     sum2 += Math.pow(v, 2);
     sum3 += Math.pow(v, 3);
   }
   return (1 / n) * sum3 / Math.pow((1 / (n - 1)) * sum2, 3 / 2);
 }
 
-export function jarqueBeraNormalityTest(
-    values: TypedArray|number[]) {
-  //https://en.wikipedia.org/wiki/Jarque%E2%80%93Bera_test
-
-  let n = values.length;
-  let s = skewness(values);
-  let k = kurtosis(values);
-  // return n * (Math.pow(s, 2) / Math.pow(6 + (k - 3), 2) / 24);;
-  let jb = n * ((Math.pow(s, 2) / 6) + (Math.pow(k, 2) / 24));
-
-  return jb;
+export function jarqueBeraNormalityTest(values: TypedArray|number[]) {
+  // https://en.wikipedia.org/wiki/Jarque%E2%80%93Bera_test
+  const s = skewness(values);
+  const k = kurtosis(values);
+  const jb = values.length * ((Math.pow(s, 2) / 6) + (Math.pow(k, 2) / 24));
+  // JB test requires 2-degress of freedom from Chi-Square @ 0.95:
+  const CHI_SQUARE_2DEG = 5.991;
+  if (jb > CHI_SQUARE_2DEG) {
+    throw new Error(`Invalid p-value for JB: ${jb}`);
+  }
 }
 
 export function expectArrayInMeanStdRange(
-    actual: TypedArray|number[],
-    expectedMean: number,
-    expectedStdDev: number,
+    actual: TypedArray|number[], expectedMean: number, expectedStdDev: number,
     epsilon = TEST_EPSILON) {
   const actualMean = mean(actual);
   expectNumbersClose(actualMean, expectedMean, epsilon);
   expectNumbersClose(
-    standardDeviation(actual, actualMean), expectedStdDev, epsilon);
+      standardDeviation(actual, actualMean), expectedStdDev, epsilon);
 }
 
 export function expectArraysClose(
@@ -143,13 +138,11 @@ function areClose(a: number, e: number, epsilon: number): boolean {
 }
 
 export function expectValuesInRange(
-    actual: TypedArray|number[],
-    low: number,
-    high: number) {
+    actual: TypedArray|number[], low: number, high: number) {
   for (let i = 0; i < actual.length; i++) {
     if (actual[i] < low || actual[i] > high) {
       throw new Error(
-        `Value out of range:${actual[i]} low: ${low}, high: ${high}`);
+          `Value out of range:${actual[i]} low: ${low}, high: ${high}`);
     }
   }
 }


### PR DESCRIPTION
Here is another upgrade to the NDArray unit test suite. I introduced some basic 95%-probability checking for normality using the Jarque-Bera normality test. There are some magic numbers, but they should be documented and essentially point to critical values of chi-squared: https://www.uam.es/personal_pdi/ciencias/anabz/Prest/Trabajos/Critical_Values_of_the_Chi-Squared_Distribution.pdf

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/347)
<!-- Reviewable:end -->
