### PR TITLE
Back off Chi-Square precision for rand-normal tests to 0.999

### DIFF
--- a/src/test_util.ts
+++ b/src/test_util.ts
@@ -78,8 +78,9 @@ export function jarqueBeraNormalityTest(values: TypedArray|number[]) {
   const s = skewness(values);
   const k = kurtosis(values);
   const jb = values.length * ((Math.pow(s, 2) / 6) + (Math.pow(k, 2) / 24));
-  // JB test requires 2-degress of freedom from Chi-Square @ 0.95:
-  const CHI_SQUARE_2DEG = 5.991;
+  // JB test requires 2-degress of freedom from Chi-Square @ 0.999:
+  // http://www.itl.nist.gov/div898/handbook/eda/section3/eda3674.htm
+  const CHI_SQUARE_2DEG = 13.816;
   if (jb > CHI_SQUARE_2DEG) {
     throw new Error(`Invalid p-value for JB: ${jb}`);
   }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/354)
<!-- Reviewable:end -->
