### PR TITLE
Math.relu() GPU should use NaN check + precision fix for Math.asin().

### DIFF
--- a/src/math/unaryop_test.ts
+++ b/src/math/unaryop_test.ts
@@ -591,7 +591,7 @@ import {Array1D, Array2D, Scalar} from './ndarray';
       for (let i = 0; i < a.size; i++) {
         expected[i] = Math.asin(values[i]);
       }
-      test_util.expectArraysClose(result.getValues(), expected, 1e-2);
+      test_util.expectArraysClose(result.getValues(), expected);
 
       a.dispose();
     });

--- a/src/math/unaryop_test.ts
+++ b/src/math/unaryop_test.ts
@@ -591,7 +591,7 @@ import {Array1D, Array2D, Scalar} from './ndarray';
       for (let i = 0; i < a.size; i++) {
         expected[i] = Math.asin(values[i]);
       }
-      test_util.expectArraysClose(result.getValues(), expected, 1e-3);
+      test_util.expectArraysClose(result.getValues(), expected, 1e-2);
 
       a.dispose();
     });

--- a/src/math/webgl/unaryop_gpu.ts
+++ b/src/math/webgl/unaryop_gpu.ts
@@ -49,7 +49,7 @@ export const ABS = `
   return abs(x);
 `;
 
-export const RELU = `
+export const RELU = CHECK_NAN_SNIPPET + `
   return (x < 0.0) ? 0.0 : x;
 `;
 


### PR DESCRIPTION
This fixes all unit-tests on my G-Linux thinkpad X1 carbon V3. Win64 is another topic and I'll tackle those in another CL when I'm on a different machine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/358)
<!-- Reviewable:end -->
