### PR TITLE
Support add broadcast in graph (2d, 1d)

### DIFF
--- a/src/graph/graph.ts
+++ b/src/graph/graph.ts
@@ -269,6 +269,7 @@ export class Graph {
   /**
    * Computes LeakyReLU of x element-wise.
    * @param x The input tensor to the LeakyReLU.
+   * @param alpha Negative slope coefficient.
    * @return The tensor representing the LeakyReLU operation.
    */
   leakyRelu(x: Tensor, alpha: number): Tensor {
@@ -314,6 +315,7 @@ export class Graph {
   /**
    * Creates a softmax cross-entropy cost operation in the graph.
    * @param x The input tensor to classify.
+   * @param target The label tensor.
    * @return The tensor representing the softmax cross-entropy cost operation.
    */
   softmaxCrossEntropyCost(x: Tensor, target: Tensor): Tensor {

--- a/src/graph/graph.ts
+++ b/src/graph/graph.ts
@@ -522,7 +522,9 @@ export class AddNode extends Node {
   constructor(graph: Graph, private t1: Tensor, private t2: Tensor) {
     super(
         graph, 'Add', {t1, t2},
-        new Tensor(util.sizeFromShape(t1.shape) === 1 ? t2.shape : t1.shape));
+        new Tensor(util.sizeFromShape(t1.shape) === 1 
+            ? t2.shape 
+            : (t1.shape.length < t2.shape.length ? t2.shape : t1.shape)));
   }
 
   validate() {
@@ -530,11 +532,13 @@ export class AddNode extends Node {
         util.sizeFromShape(this.t1.shape) === 1 ||
             util.sizeFromShape(this.t2.shape) === 1 ||
             util.arraysEqual(this.t1.shape, this.t2.shape) ||
-            this.t1.shape.length === 2 && this.t2.shape.length === 1 &&
-                this.t1.shape[1] === this.t2.shape[0],
+            (this.t1.shape.length === 2 && this.t2.shape.length === 1 &&
+                this.t1.shape[1] === this.t2.shape[0]) ||
+            (this.t1.shape.length === 1 && this.t2.shape.length === 2 &&
+                this.t1.shape[0] === this.t2.shape[1]),
         'Error adding add operation op: one of inputs must be scalar, ' +
-        'it is a special broadcast case, or the ' +
-            `shapes ${this.t1.shape} and ${this.t2.shape} must match.`);
+            `shapes ${this.t1.shape} and ${this.t2.shape} must match,` +
+            'or one of them can be broadcasted (2D and 1D).');
   }
 }
 

--- a/src/graph/graph.ts
+++ b/src/graph/graph.ts
@@ -529,8 +529,11 @@ export class AddNode extends Node {
     util.assert(
         util.sizeFromShape(this.t1.shape) === 1 ||
             util.sizeFromShape(this.t2.shape) === 1 ||
-            util.arraysEqual(this.t1.shape, this.t2.shape),
-        'Error adding add operation op: one of inputs must be scalar or the ' +
+            util.arraysEqual(this.t1.shape, this.t2.shape) ||
+            this.t1.shape.length === 2 && this.t2.shape.length === 1 &&
+                this.t1.shape[1] === this.t2.shape[0],
+        'Error adding add operation op: one of inputs must be scalar, ' +
+        'it is a special broadcast case, or the ' +
             `shapes ${this.t1.shape} and ${this.t2.shape} must match.`);
   }
 }

--- a/src/graph/graph_test.ts
+++ b/src/graph/graph_test.ts
@@ -228,6 +228,15 @@ describe('Add validation', () => {
   it('Same size does not throw', () => {
     expect(g.add(new Tensor([5, 4]), new Tensor([5, 4])).shape).toEqual([5, 4]);
   });
+
+  it('Special broadcast case does not throw', () => {
+    expect(g.add(new Tensor([5, 3]), new Tensor([3])).shape).toEqual([5, 3]);
+  });
+
+  it('Another different shapes throws', () => {
+    expect(() => g.add(new Tensor([5, 3]), new Tensor([5])))
+        .toThrowError();
+  });
 });
 
 describe('Subtract validation', () => {

--- a/src/graph/graph_test.ts
+++ b/src/graph/graph_test.ts
@@ -229,11 +229,15 @@ describe('Add validation', () => {
     expect(g.add(new Tensor([5, 4]), new Tensor([5, 4])).shape).toEqual([5, 4]);
   });
 
-  it('Special broadcast case does not throw', () => {
+  it('1D broadcasted to 2D does not throw', () => {
     expect(g.add(new Tensor([5, 3]), new Tensor([3])).shape).toEqual([5, 3]);
   });
 
-  it('Another different shapes throws', () => {
+  it('Another 1D broadcasted to 2D does not throw', () => {
+    expect(g.add(new Tensor([3]), new Tensor([7, 3])).shape).toEqual([7, 3]);
+  });
+
+  it('Non-matching broadcast throws', () => {
     expect(() => g.add(new Tensor([5, 3]), new Tensor([5])))
         .toThrowError();
   });

--- a/src/graph/ops/add.ts
+++ b/src/graph/ops/add.ts
@@ -76,8 +76,11 @@ export class Add extends Operation {
             this.x2Tensor.shape.length === 2 &&
             this.x1Tensor.shape[0] === this.x2Tensor.shape[1]) {
           const sum = math.sum(dy as Array2D, 0);
-          const gradient = math.divide(sum, Scalar.new(this.x2Tensor.shape[0]));
-          gradientArrays.add(this.x1Tensor, gradient);
+          if (this.dySizeScalar == null) {
+            this.dySizeScalar = Scalar.new(this.x2Tensor.shape[0]);
+          }
+          gradientArrays.add(
+              this.x1Tensor, math.divide(sum, this.dySizeScalar));
         } else if (util.isScalarShape(this.x1Tensor.shape)) {
           const sum = math.sum(dy);
           if (this.dySizeScalar == null) {
@@ -95,8 +98,11 @@ export class Add extends Operation {
             this.x2Tensor.shape.length === 1 &&
             this.x1Tensor.shape[1] === this.x2Tensor.shape[0]) {
           const sum = math.sum(dy as Array2D, 0);
-          const gradient = math.divide(sum, Scalar.new(this.x1Tensor.shape[0]));
-          gradientArrays.add(this.x2Tensor, gradient);
+          if (this.dySizeScalar == null) {
+            this.dySizeScalar = Scalar.new(this.x1Tensor.shape[0]);
+          }
+          gradientArrays.add(
+              this.x2Tensor, math.divide(sum, this.dySizeScalar));
         } else if (util.isScalarShape(this.x2Tensor.shape)) {
           const sum = math.sum(dy);
           if (this.dySizeScalar == null) {

--- a/src/graph/ops/add_test.ts
+++ b/src/graph/ops/add_test.ts
@@ -192,4 +192,52 @@ describe('add operation', () => {
 
     expect(() => new Add(t1, t2, y)).toThrowError();
   });
+
+  it('2D array + 1D array broadcast', () => {
+    const x1 = Array2D.new([2, 3], [1, 2, 3, 4, 5, 6]);
+    const x2 = Array1D.new([0, 1, 0]);
+
+    t1 = new Tensor(x1.shape);
+    t2 = new Tensor(x2.shape);
+    y = new Tensor(x1.shape);
+
+    activations.set(t1, x1);
+    activations.set(t2, x2);
+
+    addOp = new Add(t1, t2, y);
+    addOp.feedForward(math, activations);
+    const yVal = activations.get(y);
+    
+    expect(yVal.shape).toEqual([2, 3]);
+    expect(yVal.getValues()).toEqual(new Float32Array([1, 3, 3, 4, 6, 6]));
+
+    const dy = Array2D.new([2, 3], [2, 4, 6, 8, 10, 12]);
+    gradients.add(y, dy);
+
+    addOp.backProp(math, activations, gradients);
+
+    const dx1 = gradients.get(t1);
+    const dx2 = gradients.get(t2);
+
+    expect(dx1.shape).toEqual(x1.shape);
+    expect(dx1.getValues()).toEqual(dy.getValues());
+
+    expect(dx2.shape).toEqual(x2.shape);
+    expect(dx2.getValues()).toEqual(new Float32Array([5, 7, 9]));
+  });
+
+  it('throws when shapes do not meet for the special broadcast case', () => {
+    const x1 = Array2D.new([2, 3], [1, 2, 3, 4, 5, 6]);
+    const x2 = Array1D.new([1, 2]);
+
+    t1 = new Tensor(x1.shape);
+    t2 = new Tensor(x2.shape);
+    y = new Tensor(x1.shape);
+
+    activations.set(t1, x1);
+    activations.set(t2, x2);
+
+    expect(() => new Add(t1, t2, y)).toThrowError();
+  });
+
 });

--- a/src/graph/ops/add_test.ts
+++ b/src/graph/ops/add_test.ts
@@ -207,7 +207,7 @@ describe('add operation', () => {
     addOp = new Add(t1, t2, y);
     addOp.feedForward(math, activations);
     const yVal = activations.get(y);
-    
+
     expect(yVal.shape).toEqual([2, 3]);
     expect(yVal.getValues()).toEqual(new Float32Array([1, 3, 3, 4, 6, 6]));
 
@@ -226,7 +226,40 @@ describe('add operation', () => {
     expect(dx2.getValues()).toEqual(new Float32Array([5, 7, 9]));
   });
 
-  it('throws when shapes do not meet for the special broadcast case', () => {
+  it('1D array + 2D array broadcast', () => {
+    const x1 = Array1D.new([0, 1, 0]);
+    const x2 = Array2D.new([2, 3], [1, 2, 3, 4, 5, 6]);
+
+    t1 = new Tensor(x1.shape);
+    t2 = new Tensor(x2.shape);
+    y = new Tensor(x1.shape);
+
+    activations.set(t1, x1);
+    activations.set(t2, x2);
+
+    addOp = new Add(t1, t2, y);
+    addOp.feedForward(math, activations);
+    const yVal = activations.get(y);
+
+    expect(yVal.shape).toEqual([2, 3]);
+    expect(yVal.getValues()).toEqual(new Float32Array([1, 3, 3, 4, 6, 6]));
+
+    const dy = Array2D.new([2, 3], [2, 4, 6, 8, 10, 12]);
+    gradients.add(y, dy);
+
+    addOp.backProp(math, activations, gradients);
+
+    const dx1 = gradients.get(t1);
+    const dx2 = gradients.get(t2);
+
+    expect(dx1.shape).toEqual(x1.shape);
+    expect(dx1.getValues()).toEqual(new Float32Array([5, 7, 9]));
+
+    expect(dx2.shape).toEqual(x2.shape);
+    expect(dx2.getValues()).toEqual(dy.getValues());
+  });
+
+  it('throws when shapes do not match for broadcasting', () => {
     const x1 = Array2D.new([2, 3], [1, 2, 3, 4, 5, 6]);
     const x2 = Array1D.new([1, 2]);
 


### PR DESCRIPTION
This update enables to do add broadcasting in graph. Currently, it supports two basic, typical cases that can be used for batch computation: 
- Add(Array2D (shape: n, m), Array1D (shape: m))
- Add(Array1D (shape: m), Array2D (shape: n, m))

It can be used for implementing batch computation of bias addition.

Thank you for your review!
Minsuk Kahng

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/364)
<!-- Reviewable:end -->
