### PR TITLE
Fixes#370: Makes dumping scripts Python 3 compatible

### DIFF
--- a/scripts/dump_checkpoints/pytorch_checkpoint_dumper.py
+++ b/scripts/dump_checkpoints/pytorch_checkpoint_dumper.py
@@ -23,6 +23,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from six import iteritems
+
 import argparse
 import os
 import re
@@ -88,14 +90,14 @@ class PytorchCheckpointDumper(CheckpointDumper):
   def build_and_dump_vars(self):
     """Builds and dumps variables and a manifest file.
     """
-    for var_name, var_weights in self.state_dictionary.iteritems():
+    for (var_name, var_weights) in iteritems(self.state_dictionary):
       if (self.should_ignore(var_name)):
         print('Ignoring ' + var_name)
         continue
 
       var_filename = self.var_name_to_filename(var_name)
-      var_shape = map(int, list(var_weights.size()))
-      tensor = var_weights.numpy()
+      var_shape = list(map(int, list(var_weights.size())))
+      tensor = var_weights.cpu().numpy()
 
       self.dump_weights(var_name, var_filename, var_shape, tensor)
 

--- a/scripts/dump_checkpoints/tensorflow_checkpoint_dumper.py
+++ b/scripts/dump_checkpoints/tensorflow_checkpoint_dumper.py
@@ -23,6 +23,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from six import iteritems
+
 import argparse
 import json
 import os
@@ -87,7 +89,7 @@ class TensorflowCheckpointDumper(CheckpointDumper):
     """
     var_to_shape_map = self.reader.get_variable_to_shape_map()
 
-    for var_name, var_shape in var_to_shape_map.iteritems():
+    for (var_name, var_shape) in iteritems(var_to_shape_map):
       if self.should_ignore(var_name) or var_name == 'global_step':
         print('Ignoring ' + var_name)
         continue


### PR DESCRIPTION
Currently, weights dumping script is not Python 3 compatible. This PR fixes it making it compatible with Python 2 as well as 3. Fixes #370.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/372)
<!-- Reviewable:end -->
