### PR TITLE
Add selu math

### DIFF
--- a/src/math/math.ts
+++ b/src/math/math.ts
@@ -1245,6 +1245,15 @@ export abstract class NDArrayMath {
   protected abstract eluDerInternal<T extends NDArray>(ndarray: T): T;
 
   /**
+   * Computes scaled exponential linear element-wise.
+   * @hidden
+   */
+  selu<T extends NDArray>(ndarray: T): T {
+    return this.executeOp('selu', () => this.seluInternal(ndarray));
+  }
+  protected abstract seluInternal<T extends NDArray>(ndarray: T): T;
+
+  /**
    * Computes leaky rectified linear element-wise
    * @param {T} ndarray the input NDArray
    * @param alpha scaleing factor for negative values, defaults to 0.2

--- a/src/math/math_cpu.ts
+++ b/src/math/math_cpu.ts
@@ -587,6 +587,25 @@ export class NDArrayMathCPU extends NDArrayMath {
     return NDArray.make(ndarray.shape, {values: resultValues}) as T;
   }
 
+  protected seluInternal<T extends NDArray>(ndarray: T): T {
+    // Stable and Attracting Fixed Point (0, 1) for Normalized Weights.
+    // see: https://arxiv.org/abs/1706.02515
+    const scaleAlpha = 1.7580993408473768599402175208123;
+    const scale = 1.0507009873554804934193349852946;
+
+    const resultValues = new Float32Array(ndarray.size);
+    const values = ndarray.dataSync();
+    for (let i = 0; i < values.length; ++i) {
+      const v = values[i];
+      if (v >= 0) {
+        resultValues[i] = scale * v;
+      } else {
+        resultValues[i] = scaleAlpha * (Math.exp(v) - 1);
+      }
+    }
+    return NDArray.make(ndarray.shape, {values: resultValues}) as T;
+  }
+
   protected leakyReluInternal<T extends NDArray>(ndarray: T, alpha: number) {
     const resultValues = new Float32Array(ndarray.size);
     const values = ndarray.dataSync();

--- a/src/math/math_gpu.ts
+++ b/src/math/math_gpu.ts
@@ -429,6 +429,11 @@ export class NDArrayMathGPU extends NDArrayMath {
     return this.compileAndRun(program, [a]) as T;
   }
 
+  protected seluInternal<T extends NDArray>(a: T): T {
+    const program = new UnaryOpProgram(a.shape, unary_op.SELU);
+    return this.compileAndRun(program, [a]) as T;
+  }
+
   protected leakyReluInternal<T extends NDArray>(a: T, alpha: number): T {
     const program = new UnaryOpProgram(a.shape, unary_op.LEAKY_RELU(alpha));
     return this.compileAndRun(program, [a]) as T;

--- a/src/math/unaryop_test.ts
+++ b/src/math/unaryop_test.ts
@@ -868,3 +868,32 @@ import {Array1D, Array2D, Scalar} from './ndarray';
     {'WEBGL_FLOAT_TEXTURE_ENABLED': false, 'WEBGL_VERSION': 1}
   ]);
 }
+
+// math.selu
+{
+  const tests: MathTests = it => {
+    it('calculate selu', math => {
+      const a = Array1D.new([1, -1, 0]);
+      const result = math.selu(a);
+
+      expect(result.shape).toEqual(a.shape);
+      test_util.expectArraysClose(
+          result.dataSync(), new Float32Array([1.0507, -1.1113, 0]));
+    });
+
+    it('selu propagates NaN', math => {
+      const a = Array1D.new([1, NaN]);
+      const result = math.selu(a);
+      expect(result.shape).toEqual(a.shape);
+      test_util.expectArraysClose(
+          result.dataSync(), new Float32Array([1.0507, NaN]));
+    });
+
+  };
+  test_util.describeMathCPU('selu', [tests]);
+  test_util.describeMathGPU('selu', [tests], [
+    {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 1},
+    {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2},
+    {'WEBGL_FLOAT_TEXTURE_ENABLED': false, 'WEBGL_VERSION': 1}
+  ]);
+}

--- a/src/math/webgl/unaryop_gpu.ts
+++ b/src/math/webgl/unaryop_gpu.ts
@@ -61,6 +61,14 @@ export const ELU_DER = `
   return (x >= 0.0) ? 1.0 : exp(x);
 `;
 
+export const SELU = `
+  // Stable and Attracting Fixed Point (0, 1) for Normalized Weights.
+  // see: https://arxiv.org/abs/1706.02515
+  float scaleAlpha = 1.7580993408473768599402175208123;
+  float scale = 1.0507009873554804934193349852946;
+  return (x >= 0.0) ? scale * x : scaleAlpha * (exp(x) - 1.0);
+`;
+
 export function LEAKY_RELU(alpha: number) {
   return `
     return (x >= 0.0) ? x : ${alpha} * x;


### PR DESCRIPTION
We can use same scaling parameters with [the ones TensorFlow uses](https://github.com/tensorflow/tensorflow/blob/c2ce4f68c744e6d328746b144ff1fcf98ac99e6c/tensorflow/compiler/tf2xla/kernels/elu_op.cc#L72-L75), In short,`alpha` and `scaledAlpha` instead of `lambda` as in original paper.

```
alpha = 1.0507009873554804934193349852946
lambda = 1.0507009873554804934193349852946
scaledAlpha = alpha * lambda = 1.7580993408473768599402175208123
```

see: https://arxiv.org/abs/1706.02515

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/377)
<!-- Reviewable:end -->
