### PR TITLE
Concat3d validation with different axis

### DIFF
--- a/src/graph/graph_test.ts
+++ b/src/graph/graph_test.ts
@@ -335,12 +335,12 @@ describe('Concat3d validation', () => {
   });
 
   it('Axis=1 different shapes throws', () => {
-    expect(() => g.concat3d(new Tensor([5, 4, 1]), new Tensor([1, 2, 1]), 0))
+    expect(() => g.concat3d(new Tensor([5, 4, 1]), new Tensor([1, 2, 1]), 1))
         .toThrowError();
   });
 
   it('Axis=2 different shapes throws', () => {
-    expect(() => g.concat3d(new Tensor([5, 4, 1]), new Tensor([1, 2, 1]), 0))
+    expect(() => g.concat3d(new Tensor([5, 4, 1]), new Tensor([1, 2, 1]), 2))
         .toThrowError();
   });
 


### PR DESCRIPTION
Fix some specs in concat3d validation to check with a proper axis.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/387)
<!-- Reviewable:end -->
