### PR TITLE
Add extra precision to NaN checks in Shader compiler.

### DIFF
--- a/src/math/backends/webgl/shader_compiler.ts
+++ b/src/math/backends/webgl/shader_compiler.ts
@@ -238,11 +238,15 @@ const SHADER_PREFIX = `
   const vec2 halfCR = vec2(0.5, 0.5);
 
   bool isNaN(float val) {
-    return val == val ? false : true;
+    float v1 = val * val;
+    float v2 = val * val;
+    return v1 == v2 ? false : true;
   }
 
   bool hasNaN(vec4 values) {
-    return any(notEqual(values, values));
+    vec4 v1 = values * values;
+    vec4 v2 = values * values;
+    return any(notEqual(v1, v2));
   }
 
   float getNaN(vec4 values) {

--- a/src/math/backends/webgl/unaryop_gpu.ts
+++ b/src/math/backends/webgl/unaryop_gpu.ts
@@ -76,7 +76,7 @@ export function LEAKY_RELU(alpha: number) {
 }
 
 export function STEP(alpha = 0.0) {
-  return `
+  return CHECK_NAN_SNIPPET + `
     return (x == x) ? (x > 0.0 ? 1.0 : float(${alpha})) : x;
   `;
 }


### PR DESCRIPTION
This additional multiplication step ensures that GPUs don't take optimizations for close-to-zero values (typically NaN on win64). This makes all tests pass on my win64 machine (AMD-FX-8350 eight-core @ 4.00ghz + NVIDIA GeForce GTX 1050 4GB)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/395)
<!-- Reviewable:end -->
