### PR TITLE
Correct backprop for add operation with broadcast

### DIFF
--- a/src/graph/ops/add.ts
+++ b/src/graph/ops/add.ts
@@ -76,18 +76,10 @@ export class Add extends Operation {
             this.x2Tensor.shape.length === 2 &&
             this.x1Tensor.shape[0] === this.x2Tensor.shape[1]) {
           const sum = math.sum(dy as Array2D, 0);
-          if (this.dySizeScalar == null) {
-            this.dySizeScalar = Scalar.new(this.x2Tensor.shape[0]);
-          }
-          gradientArrays.add(
-              this.x1Tensor, math.divide(sum, this.dySizeScalar));
+          gradientArrays.add(this.x1Tensor, sum);
         } else if (util.isScalarShape(this.x1Tensor.shape)) {
           const sum = math.sum(dy);
-          if (this.dySizeScalar == null) {
-            this.dySizeScalar = Scalar.new(dy.size);
-          }
-          gradientArrays.add(
-              this.x1Tensor, math.divide(sum, this.dySizeScalar));
+          gradientArrays.add(this.x1Tensor, sum);
         } else {
           gradientArrays.add(this.x1Tensor, math.clone(dy));
         }
@@ -98,18 +90,10 @@ export class Add extends Operation {
             this.x2Tensor.shape.length === 1 &&
             this.x1Tensor.shape[1] === this.x2Tensor.shape[0]) {
           const sum = math.sum(dy as Array2D, 0);
-          if (this.dySizeScalar == null) {
-            this.dySizeScalar = Scalar.new(this.x1Tensor.shape[0]);
-          }
-          gradientArrays.add(
-              this.x2Tensor, math.divide(sum, this.dySizeScalar));
+          gradientArrays.add(this.x2Tensor, sum);
         } else if (util.isScalarShape(this.x2Tensor.shape)) {
           const sum = math.sum(dy);
-          if (this.dySizeScalar == null) {
-            this.dySizeScalar = Scalar.new(dy.size);
-          }
-          gradientArrays.add(
-              this.x2Tensor, math.divide(sum, this.dySizeScalar));
+          gradientArrays.add(this.x2Tensor, sum);
         } else {
           gradientArrays.add(this.x2Tensor, math.clone(dy));
         }

--- a/src/graph/ops/add_test.ts
+++ b/src/graph/ops/add_test.ts
@@ -143,7 +143,7 @@ describe('add operation', () => {
     expect(dx1.getValues()).toEqual(dy.getValues());
 
     expect(dx2.shape).toEqual(x2.shape);
-    expect(dx2.get()).toEqual(7);
+    expect(dx2.get()).toEqual(42);
   });
 
   it('scalar + array', () => {
@@ -173,7 +173,7 @@ describe('add operation', () => {
     const dx2 = gradients.get(t2);
 
     expect(dx1.shape).toEqual(x1.shape);
-    expect(dx1.get()).toEqual(7);
+    expect(dx1.get()).toEqual(42);
 
     expect(dx2.shape).toEqual(x2.shape);
     expect(dx2.getValues()).toEqual(dy.getValues());
@@ -223,7 +223,7 @@ describe('add operation', () => {
     expect(dx1.getValues()).toEqual(dy.getValues());
 
     expect(dx2.shape).toEqual(x2.shape);
-    expect(dx2.getValues()).toEqual(new Float32Array([5, 7, 9]));
+    expect(dx2.getValues()).toEqual(new Float32Array([10, 14, 18]));
   });
 
   it('1D array + 2D array broadcast', () => {
@@ -253,7 +253,7 @@ describe('add operation', () => {
     const dx2 = gradients.get(t2);
 
     expect(dx1.shape).toEqual(x1.shape);
-    expect(dx1.getValues()).toEqual(new Float32Array([5, 7, 9]));
+    expect(dx1.getValues()).toEqual(new Float32Array([10, 14, 18]));
 
     expect(dx2.shape).toEqual(x2.shape);
     expect(dx2.getValues()).toEqual(dy.getValues());

--- a/src/graph/ops/subtract.ts
+++ b/src/graph/ops/subtract.ts
@@ -68,10 +68,7 @@ export class Subtract extends Operation {
       if (graph_util.shouldBackProp(this.t1)) {
         if (util.isScalarShape(this.t1.shape)) {
           const sum = math.sum(dy);
-          if (this.dySizeScalar == null) {
-            this.dySizeScalar = Scalar.new(dy.size);
-          }
-          gradientArrays.add(this.t1, math.divide(sum, this.dySizeScalar));
+          gradientArrays.add(this.t1, sum);
         } else {
           gradientArrays.add(this.t1, math.clone(dy));
         }
@@ -81,10 +78,7 @@ export class Subtract extends Operation {
         if (util.isScalarShape(this.t2.shape)) {
           const sum = math.sum(dy);
           const negSum = math.neg(sum);
-          if (this.dySizeScalar == null) {
-            this.dySizeScalar = Scalar.new(dy.size);
-          }
-          gradientArrays.add(this.t2, math.divide(negSum, this.dySizeScalar));
+          gradientArrays.add(this.t2, negSum);
         } else {
           gradientArrays.add(this.t2, math.neg(dy));
         }

--- a/src/graph/ops/subtract_test.ts
+++ b/src/graph/ops/subtract_test.ts
@@ -145,7 +145,7 @@ describe('add operation', () => {
     expect(dx1.getValues()).toEqual(dy.getValues());
 
     expect(dx2.shape).toEqual(x2.shape);
-    expect(dx2.get()).toEqual(-7);
+    expect(dx2.get()).toEqual(-42);
   });
 
   it('scalar - ndarray', () => {
@@ -175,7 +175,7 @@ describe('add operation', () => {
     const dx2 = gradients.get(t2);
 
     expect(dx1.shape).toEqual(x1.shape);
-    expect(dx1.get()).toEqual(7);
+    expect(dx1.get()).toEqual(42);
 
     expect(dx2.shape).toEqual(x2.shape);
     expect(dx2.getValues()).toEqual(new Float32Array([


### PR DESCRIPTION
Hi Daniel and Nikhil,

Although I'm not 100% sure, I think when we compute backprop for add involving broadcast, we need to use sum, not average. Could you check if my PL is correct? I might miss something.

I identified this issue while I perform 2d+1d in my tool. When I update code to this PL, it works better. I have also tried to derive this backpropagation equation. I hope you can double-check with this.

To be short, I want you to check whether the answer for the following line is 7 (avg) or 42 (sum).
https://github.com/minsukkahng/deeplearnjs/blob/71e7ed105591f958a642313d9590f5cd3142c8df/src/graph/ops/add_test.ts#L146

Thanks,
Brian

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/398)
<!-- Reviewable:end -->
