### PR TITLE
Lint cleanup + README Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ $ yarn prep # Installs dependencies.
 ```
 
 We recommend using [Visual Studio Code](https://code.visualstudio.com/) for
-development. Make sure to install [TSLint VSCode extension](https://marketplace.visualstudio.com/items?itemName=eg2.tslint) and the `clang-format` command line tool with the [Clang-Format VSCode extension](https://marketplace.visualstudio.com/items?itemName=xaver.clang-format) for auto-formatting.
+development. Make sure to install [TSLint VSCode extension](https://marketplace.visualstudio.com/items?itemName=eg2.tslint) and the `clang-format` command line tool with the [Clang-Format VSCode extension](https://marketplace.visualstudio.com/items?itemName=xaver.clang-format) for auto-formatting (Be sure to use the [NPM/Yarn clang-format binary](https://github.com/angular/clang-format)).
+
 
 To interactively develop any of the demos (e.g. `demos/nn-art/`):
 

--- a/src/math/ndarray_test.ts
+++ b/src/math/ndarray_test.ts
@@ -205,7 +205,7 @@ test_util.describeCustom('NDArray', () => {
     });
   });
 
-  it('NDArray.data GPU --> CPU', async() => {
+  it('NDArray.data GPU --> CPU', async () => {
     const texture = textureManager.acquireTexture([3, 2]);
     gpgpu.uploadMatrixToTexture(
         texture, 3, 2, new Float32Array([1, 2, 3, 4, 5, 6]));
@@ -218,7 +218,7 @@ test_util.describeCustom('NDArray', () => {
     expect(a.inGPU()).toBe(false);
   });
 
-  it('NDArray.val() GPU --> CPU', async() => {
+  it('NDArray.val() GPU --> CPU', async () => {
     const texture = textureManager.acquireTexture([3, 2]);
     gpgpu.uploadMatrixToTexture(
         texture, 3, 2, new Float32Array([1, 2, 3, 4, 5, 6]));
@@ -1038,7 +1038,6 @@ test_util.describeCustom('NDArray.like', () => {
     expect(b.shape).toEqual([2, 2, 1, 1]);
     expect(b.getValues()).toEqual(new Uint8Array([1, 1, 1, 1]));
   });
-
 });
 
 test_util.describeCustom('Scalar.new', () => {
@@ -1892,7 +1891,6 @@ test_util.describeCustom('NDArray.randTruncatedNormal', () => {
   });
 
   it('should return a 4D int32 array', () => {
-
     const shape: [number, number, number, number] = [5, 5, 5, 5];
     const result = Array4D.randTruncatedNormal(shape, 0, 5, 'int32', SEED);
     expect(result.dtype).toBe('int32');


### PR DESCRIPTION
I've been using my personal (non-Google issued) Ubuntu workstation for a few PRs. I noticed that clang-format kept ignoring tslint: rules and looked into the issue tonight. It turns out that `clang-format` from sources doesn't understand typescript rules. It's best to use the npm supplied version from angular to work properly. (Goobuntu workstations supply a google3-head version of clang-format FYI).

I fixed something I commited tonight (spacing lint problem) and updated the README for other contributors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/422)
<!-- Reviewable:end -->
