### PR TITLE
Handle error in case of 404 not found variable

### DIFF
--- a/src/data/checkpoint_loader.ts
+++ b/src/data/checkpoint_loader.ts
@@ -115,6 +115,9 @@ export class CheckpointLoader {
           xhr.open('GET', this.urlPath + fname);
 
           xhr.onload = () => {
+            if (xhr.status === 404) {
+              throw new Error(`Not found variable ${varName}`);
+            }
             const values = new Float32Array(xhr.response);
             const ndarray =
                 NDArray.make(this.checkpointManifest[varName].shape, {values});

--- a/src/data/checkpoint_loader_test.ts
+++ b/src/data/checkpoint_loader_test.ts
@@ -98,4 +98,23 @@ describe('Checkpoint var loader', () => {
     // tslint:disable-next-line:no-any
     (xhrObj as any).onload();
   });
+
+  it('Load variable but 404 not found', (doneFn) => {
+    const fakeCheckpointManifest:
+        CheckpointManifest = {'fakeVar1': {filename: 'fakeFile1', shape: [10]}};
+
+    const varLoader = new CheckpointLoader('fakeModel');
+    varLoader.getCheckpointManifest().then(checkpoint => {
+      varLoader.getVariable('fakeVar1');
+      // tslint:disable-next-line:no-any
+      expect(() => (xhrObj as any).onload()).toThrowError();
+      doneFn();
+    });
+    // tslint:disable-next-line:no-any
+    (xhrObj as any).responseText = JSON.stringify(fakeCheckpointManifest);
+    // tslint:disable-next-line:no-any
+    (xhrObj as any).status = 404;
+    // tslint:disable-next-line:no-any
+    (xhrObj as any).onload();
+  });
 });


### PR DESCRIPTION
`XMLHttpRequest` does not trigger `onerror` in case of 404. But even such case, `CheckpointLoader` should throw exception as well as `onerror` case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/431)
<!-- Reviewable:end -->
