### PR TITLE
Update usage of build-npm script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ npm-debug.log
 .DS_Store
 dist/
 .idea/
+deeplearn-*.tgz

--- a/README.md
+++ b/README.md
@@ -142,10 +142,12 @@ To do a dry run and test building an npm package:
 
 ```bash
 $ ./scripts/build-npm.sh
->> Stored npm package at dist/deeplearn-VERSION.tgz
+...
+Stored standalone library at dist/deeplearn(.min).js
+deeplearn-VERSION.tgz
 ```
 
-To install it locally, run `npm install ./dist/deeplearn-VERSION.tgz`.
+To install it locally, run `npm install ./deeplearn-VERSION.tgz`.
 
 > On Windows, use bash (available through git) to use the scripts above.
 


### PR DESCRIPTION
build-npm.sh creates a npm package in root directory not `dist`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/437)
<!-- Reviewable:end -->
