### PR TITLE
Fix bugs introduced by global tracking

### DIFF
--- a/src/data/dataset.ts
+++ b/src/data/dataset.ts
@@ -15,6 +15,7 @@
  * =============================================================================
  */
 
+import {NDArrayMath} from '../math/math';
 import {NDArray} from '../math/ndarray';
 import * as util from '../util';
 
@@ -47,7 +48,7 @@ export abstract class InMemoryDataset {
   // after normalization.
   private normalizationInfo: {[dataIndex: number]: NormalizationInfo};
 
-  constructor(protected dataShapes: number[][]) {
+  constructor(protected dataShapes: number[][], protected math: NDArrayMath) {
     this.normalizationInfo = {};
   }
 
@@ -147,7 +148,8 @@ export abstract class InMemoryDataset {
               newRange * (inputValues[j] - curLowerBound) / curRange;
         }
       }
-      newExamples.push(NDArray.make(example.shape, {values: normalizedValues}));
+      newExamples.push(NDArray.make(
+          example.shape, {values: normalizedValues}, 'float32', this.math));
     });
     return newExamples;
   }

--- a/src/data/dataset_test.ts
+++ b/src/data/dataset_test.ts
@@ -23,7 +23,8 @@ import {InMemoryDataset} from './dataset';
 
 class StubDataset extends InMemoryDataset {
   constructor(data: NDArray[][]) {
-    super(data.map(value => value[0].shape), new NDArrayMath('cpu', false));
+    const safeMode = false;
+    super(data.map(value => value[0].shape), new NDArrayMath('cpu', safeMode));
     this.dataset = data;
   }
 

--- a/src/data/dataset_test.ts
+++ b/src/data/dataset_test.ts
@@ -15,6 +15,7 @@
  * =============================================================================
  */
 
+import {NDArrayMath} from '../math/math';
 import {Array1D, Array2D, NDArray} from '../math/ndarray';
 import * as test_util from '../test_util';
 
@@ -22,7 +23,7 @@ import {InMemoryDataset} from './dataset';
 
 class StubDataset extends InMemoryDataset {
   constructor(data: NDArray[][]) {
-    super(data.map(value => value[0].shape));
+    super(data.map(value => value[0].shape), new NDArrayMath('cpu', false));
     this.dataset = data;
   }
 

--- a/src/data/input_provider_test.ts
+++ b/src/data/input_provider_test.ts
@@ -15,17 +15,21 @@
  * =============================================================================
  */
 
-import {NDArrayMathCPU} from '../math/backends/backend_cpu';
-import {NDArrayMathGPU} from '../math/backends/backend_webgl';
+import {ENV} from '../environment';
+import {NDArrayMath} from '../math/math';
 import {Array1D, Scalar} from '../math/ndarray';
-
 import {InCPUMemoryShuffledInputProviderBuilder} from './input_provider';
 
 describe('InCPUMemoryShuffledInputProviderBuilder', () => {
-  let math: NDArrayMathCPU;
+  let math: NDArrayMath;
 
   beforeEach(() => {
-    math = new NDArrayMathCPU();
+    math = new NDArrayMath('cpu', false);
+    ENV.setMath(math);
+  });
+
+  afterEach(() => {
+    ENV.reset();
   });
 
   it('ensure inputs stay in sync', () => {
@@ -73,10 +77,15 @@ describe('InCPUMemoryShuffledInputProviderBuilder', () => {
 });
 
 describe('InGPUMemoryShuffledInputProviderBuilder', () => {
-  let math: NDArrayMathGPU;
+  let math: NDArrayMath;
 
   beforeEach(() => {
-    math = new NDArrayMathGPU();
+    math = new NDArrayMath('webgl', false);
+    ENV.setMath(math);
+  });
+
+  afterEach(() => {
+    ENV.reset();
   });
 
   it('ensure inputs stay in sync', () => {

--- a/src/data/input_provider_test.ts
+++ b/src/data/input_provider_test.ts
@@ -24,7 +24,8 @@ describe('InCPUMemoryShuffledInputProviderBuilder', () => {
   let math: NDArrayMath;
 
   beforeEach(() => {
-    math = new NDArrayMath('cpu', false);
+    const safeMode = false;
+    math = new NDArrayMath('cpu', safeMode);
     ENV.setMath(math);
   });
 
@@ -80,7 +81,8 @@ describe('InGPUMemoryShuffledInputProviderBuilder', () => {
   let math: NDArrayMath;
 
   beforeEach(() => {
-    math = new NDArrayMath('webgl', false);
+    const safeMode = false;
+    math = new NDArrayMath('webgl', safeMode);
     ENV.setMath(math);
   });
 

--- a/src/data/xhr-dataset.ts
+++ b/src/data/xhr-dataset.ts
@@ -38,7 +38,9 @@ export interface XhrDatasetConfig {
   modelConfigs: {[modelName: string]: XhrModelConfig};
 }
 
-export interface XhrModelConfig { path: string; }
+export interface XhrModelConfig {
+  path: string;
+}
 
 export function getXhrDatasetConfig(jsonConfigPath: string):
     Promise<{[datasetName: string]: XhrDatasetConfig}> {
@@ -63,8 +65,10 @@ export class XhrDataset extends InMemoryDataset {
   protected xhrDatasetConfig: XhrDatasetConfig;
 
   constructor(xhrDatasetConfig: XhrDatasetConfig) {
+    const safeMode = false;
     super(
-        xhrDatasetConfig.data.map(x => x.shape), new NDArrayMath('cpu', false));
+        xhrDatasetConfig.data.map(x => x.shape),
+        new NDArrayMath('cpu', safeMode));
     this.xhrDatasetConfig = xhrDatasetConfig;
   }
 

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -298,8 +298,28 @@ function getFeaturesFromURL(): Features {
   return features;
 }
 
-export let ENV = new Environment(getFeaturesFromURL());
+function getGlobalNamespace(): {ENV: Environment} {
+  // tslint:disable-next-line:no-any
+  let ns: any;
+  if (typeof (window) !== 'undefined') {
+    ns = window;
+  } else if (typeof (global) !== 'undefined') {
+    ns = global;
+  } else {
+    throw new Error('Could not find a global object');
+  }
+  return ns;
+}
+
+export function getOrMakeEnvironment(): Environment {
+  const ns = getGlobalNamespace();
+  ns.ENV = ns.ENV || new Environment(getFeaturesFromURL());
+  return ns.ENV;
+}
 
 export function setGlobal(environment: Environment) {
-  ENV = environment;
+  const ns = getGlobalNamespace();
+  ns.ENV = environment;
 }
+
+export let ENV = getOrMakeEnvironment();

--- a/src/environment_test.ts
+++ b/src/environment_test.ts
@@ -15,19 +15,19 @@
  * =============================================================================
  */
 import * as device_util from './device_util';
-import * as environment from './environment';
 import {ENV, Environment, Features} from './environment';
 import {MathBackend} from './math/backends/backend';
 import {MathBackendCPU} from './math/backends/backend_cpu';
 import {MathBackendWebGL} from './math/backends/backend_webgl';
 
 describe('disjoint query timer enabled', () => {
+  afterEach(() => {
+    ENV.reset();
+  });
+
   it('no webgl', () => {
-    const features: Features = {'WEBGL_VERSION': 0};
-
-    const env = new Environment(features);
-
-    expect(env.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_ENABLED')).toBe(false);
+    ENV.setFeatures({'WEBGL_VERSION': 0});
+    expect(ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_ENABLED')).toBe(false);
   });
 
   it('webgl 1', () => {
@@ -51,9 +51,9 @@ describe('disjoint query timer enabled', () => {
       }
     });
 
-    const env = new Environment(features);
+    ENV.setFeatures(features);
 
-    expect(env.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_ENABLED')).toBe(true);
+    expect(ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_ENABLED')).toBe(true);
   });
 
   it('webgl 2', () => {
@@ -77,13 +77,16 @@ describe('disjoint query timer enabled', () => {
       }
     });
 
-    const env = new Environment(features);
-
-    expect(env.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_ENABLED')).toBe(true);
+    ENV.setFeatures(features);
+    expect(ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_ENABLED')).toBe(true);
   });
 });
 
 describe('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_RELIABLE', () => {
+  afterEach(() => {
+    ENV.reset();
+  });
+
   it('disjoint query timer disabled', () => {
     const features:
         Features = {'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_ENABLED': false};
@@ -117,6 +120,10 @@ describe('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_RELIABLE', () => {
 });
 
 describe('WEBGL_GET_BUFFER_SUB_DATA_ASYNC_EXTENSION_ENABLED', () => {
+  afterEach(() => {
+    ENV.reset();
+  });
+
   beforeEach(() => {
     spyOn(document, 'createElement').and.returnValue({
       getContext: (context: string) => {
@@ -157,6 +164,10 @@ describe('WEBGL_GET_BUFFER_SUB_DATA_ASYNC_EXTENSION_ENABLED', () => {
 });
 
 describe('WebGL version', () => {
+  afterEach(() => {
+    ENV.reset();
+  });
+
   it('webgl 1', () => {
     spyOn(document, 'createElement').and.returnValue({
       getContext: (context: string) => {
@@ -204,6 +215,10 @@ describe('WebGL version', () => {
 });
 
 describe('Backend', () => {
+  afterEach(() => {
+    ENV.reset();
+  });
+
   it('default ENV has cpu and webgl, and webgl is the best available', () => {
     expect(ENV.getBackend('webgl') != null).toBe(true);
     expect(ENV.getBackend('cpu') != null).toBe(true);
@@ -213,45 +228,33 @@ describe('Backend', () => {
   it('custom webgl registration', () => {
     const features:
         Features = {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2};
-    const prevEnv = environment.ENV;
-    const env = new Environment(features);
-    environment.setGlobal(env);
+    ENV.setFeatures(features);
 
     let backend: MathBackend;
-    env.registerBackend('webgl', () => {
+    ENV.registerBackend('webgl', () => {
       backend = new MathBackendWebGL();
       return backend;
     });
 
-    expect(env.getBackend('webgl')).toBe(backend);
-    expect(env.math).not.toBeNull();
-    environment.setGlobal(prevEnv);
+    expect(ENV.getBackend('webgl')).toBe(backend);
+    expect(ENV.math).not.toBeNull();
   });
 
   it('double registration fails', () => {
-    const features:
-        Features = {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2};
-    const prevEnv = environment.ENV;
-    const env = new Environment(features);
-    environment.setGlobal(env);
-
-    env.registerBackend('webgl', () => new MathBackendWebGL());
-    expect(() => env.registerBackend('webgl', () => new MathBackendWebGL()))
+    ENV.setFeatures({'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2});
+    ENV.registerBackend('webgl', () => new MathBackendWebGL());
+    expect(() => ENV.registerBackend('webgl', () => new MathBackendWebGL()))
         .toThrowError();
-    environment.setGlobal(prevEnv);
+    ENV.reset();
   });
 
   it('webgl not supported, falls back to cpu', () => {
-    const prevEnv = environment.ENV;
-    const features: Features = {'WEBGL_VERSION': 0};
-    const env = new Environment(features);
-    environment.setGlobal(env);
-
-    env.registerBackend('cpu', () => new MathBackendCPU());
-    const success = env.registerBackend('webgl', () => new MathBackendWebGL());
+    ENV.setFeatures({'WEBGL_VERSION': 0});
+    ENV.registerBackend('cpu', () => new MathBackendCPU());
+    const success = ENV.registerBackend('webgl', () => new MathBackendWebGL());
     expect(success).toBe(false);
-    expect(env.getBackend('webgl') == null).toBe(true);
-    expect(env.getBestBackend()).toBe(env.getBackend('cpu'));
-    environment.setGlobal(prevEnv);
+    expect(ENV.getBackend('webgl') == null).toBe(true);
+    expect(ENV.getBestBackend()).toBe(ENV.getBackend('cpu'));
+    ENV.reset();
   });
 });

--- a/src/graph/ops/add_test.ts
+++ b/src/graph/ops/add_test.ts
@@ -15,15 +15,14 @@
  * =============================================================================
  */
 
-import {NDArrayMathCPU} from '../../math/backends/backend_cpu';
+import {ENV} from '../../environment';
 import {Array1D, Array2D, Scalar} from '../../math/ndarray';
 import {Tensor} from '../graph';
 import {SummedTensorArrayMap, TensorArrayMap} from '../tensor_array_map';
-
 import {Add} from './add';
 
 describe('add operation', () => {
-  let math: NDArrayMathCPU;
+  const math = ENV.math;
 
   let t1: Tensor;
   let t2: Tensor;
@@ -33,7 +32,6 @@ describe('add operation', () => {
   let gradients: SummedTensorArrayMap;
 
   beforeEach(() => {
-    math = new NDArrayMathCPU();
     activations = new TensorArrayMap();
     gradients = new SummedTensorArrayMap(math);
   });

--- a/src/graph/ops/argmax_test.ts
+++ b/src/graph/ops/argmax_test.ts
@@ -15,8 +15,7 @@
  * =============================================================================
  */
 
-import {NDArrayMathCPU} from '../../math/backends/backend_cpu';
-
+import {ENV} from '../../environment';
 import {Array1D, Array2D} from '../../math/ndarray';
 import * as test_util from '../../test_util';
 import {Tensor} from '../graph';
@@ -25,14 +24,13 @@ import {TensorArrayMap} from '../tensor_array_map';
 import {ArgMax} from './argmax';
 
 describe('Argmax oper', () => {
-  let math: NDArrayMathCPU;
+  const math = ENV.math;
 
   let x: Tensor;
   let y: Tensor;
   let tensorArrayMap: TensorArrayMap;
 
   beforeEach(() => {
-    math = new NDArrayMathCPU();
     tensorArrayMap = new TensorArrayMap();
   });
 

--- a/src/graph/ops/argmaxequals_test.ts
+++ b/src/graph/ops/argmaxequals_test.ts
@@ -15,15 +15,14 @@
  * =============================================================================
  */
 
-import {NDArrayMathCPU} from '../../math/backends/backend_cpu';
+import {ENV} from '../../environment';
 import {Array1D} from '../../math/ndarray';
 import {Tensor} from '../graph';
 import {TensorArrayMap} from '../tensor_array_map';
-
 import {ArgMaxEquals} from './argmaxequals';
 
 describe('Argmax equals oper', () => {
-  let math: NDArrayMathCPU;
+  const math = ENV.math;
 
   let t1: Tensor;
   let t2: Tensor;
@@ -32,7 +31,6 @@ describe('Argmax equals oper', () => {
   let tensorArrayMap: TensorArrayMap;
 
   beforeEach(() => {
-    math = new NDArrayMathCPU();
     tensorArrayMap = new TensorArrayMap();
   });
 

--- a/src/graph/ops/concat3d_test.ts
+++ b/src/graph/ops/concat3d_test.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {NDArrayMathCPU} from '../../math/backends/backend_cpu';
+import {ENV} from '../../environment';
 import * as concat_util from '../../math/concat_util';
 import {Array3D} from '../../math/ndarray';
 import {Tensor} from '../graph';
@@ -24,7 +24,7 @@ import {TensorArrayMap} from '../tensor_array_map';
 import {Concat3D} from './concat3d';
 
 describe('concat3d operation', () => {
-  let math: NDArrayMathCPU;
+  const math = ENV.math;
 
   let x1Tensor: Tensor;
   let x2Tensor: Tensor;
@@ -33,7 +33,6 @@ describe('concat3d operation', () => {
   let tensorArrayMap: TensorArrayMap;
 
   beforeEach(() => {
-    math = new NDArrayMathCPU();
     tensorArrayMap = new TensorArrayMap();
   });
 

--- a/src/graph/ops/convolution_test.ts
+++ b/src/graph/ops/convolution_test.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {NDArrayMathCPU} from '../../math/backends/backend_cpu';
+import {ENV} from '../../environment';
 import * as conv_util from '../../math/conv_util';
 import {Array1D, Array2D, Array3D, Array4D, NDArray} from '../../math/ndarray';
 import * as test_util from '../../test_util';
@@ -32,7 +32,7 @@ function assertNoNaNs(t: NDArray) {
 }
 
 describe('Convolution', () => {
-  let math: NDArrayMathCPU;
+  const math = ENV.math;
   let wTensor: Tensor;
   let xTensor: Tensor;
   let bTensor: Tensor;
@@ -41,7 +41,6 @@ describe('Convolution', () => {
   let gradients: SummedTensorArrayMap;
 
   beforeEach(() => {
-    math = new NDArrayMathCPU();
     activations = new TensorArrayMap();
     gradients = new SummedTensorArrayMap(math);
   });

--- a/src/graph/ops/divide_test.ts
+++ b/src/graph/ops/divide_test.ts
@@ -14,16 +14,16 @@
  * limitations under the License.
  * =============================================================================
  */
-import {NDArrayMathCPU} from '../../math/backends/backend_cpu';
+
+import {ENV} from '../../environment';
 import {Array1D, Scalar} from '../../math/ndarray';
 import * as test_util from '../../test_util';
 import {Tensor} from '../graph';
 import {SummedTensorArrayMap, TensorArrayMap} from '../tensor_array_map';
-
 import {Divide} from './divide';
 
 describe('divide operation', () => {
-  let math: NDArrayMathCPU;
+  const math = ENV.math;
 
   let x1Tensor: Tensor;
   let x2Tensor: Tensor;
@@ -33,7 +33,6 @@ describe('divide operation', () => {
   let gradients: SummedTensorArrayMap;
 
   beforeEach(() => {
-    math = new NDArrayMathCPU();
     activations = new TensorArrayMap();
     gradients = new SummedTensorArrayMap(math);
   });

--- a/src/graph/ops/element_wise_activation_test.ts
+++ b/src/graph/ops/element_wise_activation_test.ts
@@ -14,25 +14,23 @@
  * limitations under the License.
  * =============================================================================
  */
-import {NDArrayMathCPU} from '../../math/backends/backend_cpu';
+import {ENV} from '../../environment';
 import {Array1D, Array2D} from '../../math/ndarray';
 import * as test_util from '../../test_util';
+import {expectArraysClose} from '../../test_util';
 import {Tensor} from '../graph';
 import {SummedTensorArrayMap, TensorArrayMap} from '../tensor_array_map';
-
 // tslint:disable-next-line:max-line-length
 import {Elu, LeakyReLU, PReLU, ReLU, Sigmoid, Square, TanH} from './element_wise_activation';
-import {expectArraysClose} from "../../test_util";
 
 describe('Element wise activation', () => {
-  let math: NDArrayMathCPU;
+  const math = ENV.math;
   let xTensor: Tensor;
   let yTensor: Tensor;
   let activations: TensorArrayMap;
   let gradients: SummedTensorArrayMap;
 
   beforeEach(() => {
-    math = new NDArrayMathCPU();
     activations = new TensorArrayMap();
     gradients = new SummedTensorArrayMap(math);
   });
@@ -69,7 +67,7 @@ describe('Element wise activation', () => {
   });
 
   it('LeakyReLU', () => {
-    const x = Array2D.new([2, 3], [3, 0, -1, 2, 9, -5]);
+    const x = Array2D.new([2, 3], [3, 0.1, -1, 2, 9, -5]);
 
     xTensor = new Tensor(x.shape);
     yTensor = new Tensor(x.shape);
@@ -79,8 +77,8 @@ describe('Element wise activation', () => {
     op.feedForward(math, activations);
 
     const y = activations.get(yTensor);
-    expectArraysClose(y.dataSync(),
-      new Float32Array([3, 0, -0.2, 2, 9, -1.0]));
+    expectArraysClose(
+        y.dataSync(), new Float32Array([3, 0.1, -0.2, 2, 9, -1.0]));
 
     // Backprop.
     const dy = Array2D.new([2, 3], [1, 2, 3, 4, 5, 6]);
@@ -90,8 +88,7 @@ describe('Element wise activation', () => {
 
     const dx = gradients.get(xTensor);
 
-    expectArraysClose(dx.dataSync(),
-      new Float32Array([1, 0, 0.6, 4, 5, 1.2]));
+    expectArraysClose(dx.dataSync(), new Float32Array([1, 2, 0.6, 4, 5, 1.2]));
   });
 
   it('PReLU', () => {
@@ -108,8 +105,8 @@ describe('Element wise activation', () => {
     op.feedForward(math, activations);
 
     const y = activations.get(yTensor);
-    expectArraysClose(y.dataSync(),
-      new Float32Array([3, 0, -0.12, 2, -0.45, -0.05]));
+    expectArraysClose(
+        y.dataSync(), new Float32Array([3, 0, -0.12, 2, -0.45, -0.05]));
 
     // Backprop.
     const dy = Array2D.new([2, 3], [1, 2, 3, 4, 5, 6]);
@@ -119,8 +116,8 @@ describe('Element wise activation', () => {
 
     const dx = gradients.get(xTensor);
 
-    expectArraysClose(dx.dataSync(),
-      new Float32Array([1, 0, 0.36, 4, 0.25, 0.06]));
+    expectArraysClose(
+        dx.dataSync(), new Float32Array([1, 0, 0.36, 4, 0.25, 0.06]));
   });
 
   it('TanH', () => {

--- a/src/graph/ops/element_wise_cost.ts
+++ b/src/graph/ops/element_wise_cost.ts
@@ -15,6 +15,8 @@
  * =============================================================================
  */
 // tslint:disable-next-line:max-line-length
+import {ENV} from '../../environment';
+// tslint:disable-next-line:max-line-length
 import {ElementWiseCostFunction, SquareCostFunc} from '../../math/cost_functions';
 import {NDArrayMath} from '../../math/math';
 import {Scalar} from '../../math/ndarray';
@@ -22,7 +24,6 @@ import * as util from '../../util';
 import {Tensor} from '../graph';
 import * as graph_util from '../graph_util';
 import {SummedTensorArrayMap, TensorArrayMap} from '../tensor_array_map';
-
 import {Operation} from './op';
 
 /**
@@ -35,7 +36,8 @@ export class ElementWiseCost extends Operation {
       protected x1Tensor: Tensor, protected x2Tensor: Tensor,
       protected yTensor: Tensor, protected func: ElementWiseCostFunction) {
     super();
-    this.oneOverNScalar = Scalar.new(1 / util.sizeFromShape(x1Tensor.shape));
+    this.oneOverNScalar =
+        ENV.math.keep(Scalar.new(1 / util.sizeFromShape(x1Tensor.shape)));
   }
 
   feedForward(math: NDArrayMath, inferenceArrays: TensorArrayMap) {

--- a/src/graph/ops/element_wise_cost_test.ts
+++ b/src/graph/ops/element_wise_cost_test.ts
@@ -15,15 +15,14 @@
  * =============================================================================
  */
 
-import {NDArrayMathCPU} from '../../math/backends/backend_cpu';
+import {ENV} from '../../environment';
 import {Array1D} from '../../math/ndarray';
 import {Tensor} from '../graph';
 import {SummedTensorArrayMap, TensorArrayMap} from '../tensor_array_map';
-
 import {MeanSquaredCost} from './element_wise_cost';
 
 describe('MeanSquaredCost', () => {
-  let math: NDArrayMathCPU;
+  const math = ENV.math;
 
   let x1Tensor: Tensor;
   let x2Tensor: Tensor;
@@ -33,7 +32,6 @@ describe('MeanSquaredCost', () => {
   let gradients: SummedTensorArrayMap;
 
   beforeEach(() => {
-    math = new NDArrayMathCPU();
     activations = new TensorArrayMap();
     gradients = new SummedTensorArrayMap(math);
   });

--- a/src/graph/ops/exp_test.ts
+++ b/src/graph/ops/exp_test.ts
@@ -15,16 +15,15 @@
  * =============================================================================
  */
 
-import {NDArrayMathCPU} from '../../math/backends/backend_cpu';
+import {ENV} from '../../environment';
 import {Array1D} from '../../math/ndarray';
 import * as test_util from '../../test_util';
 import {Tensor} from '../graph';
 import {SummedTensorArrayMap, TensorArrayMap} from '../tensor_array_map';
-
 import {Exp} from './exp';
 
 describe('exp operation', () => {
-  let math: NDArrayMathCPU;
+  const math = ENV.math;
 
   let xTensor: Tensor;
   let yTensor: Tensor;
@@ -33,7 +32,6 @@ describe('exp operation', () => {
   let gradients: SummedTensorArrayMap;
 
   beforeEach(() => {
-    math = new NDArrayMathCPU();
     activations = new TensorArrayMap();
     gradients = new SummedTensorArrayMap(math);
   });

--- a/src/graph/ops/linear_combination_test.ts
+++ b/src/graph/ops/linear_combination_test.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {NDArrayMathCPU} from '../../math/backends/backend_cpu';
+import {ENV} from '../../environment';
 import {Array1D, Scalar} from '../../math/ndarray';
 import {Tensor} from '../graph';
 import {SummedTensorArrayMap, TensorArrayMap} from '../tensor_array_map';
@@ -23,7 +23,7 @@ import {SummedTensorArrayMap, TensorArrayMap} from '../tensor_array_map';
 import {LinearCombination} from './linear_combination';
 
 describe('Linear combination', () => {
-  let math: NDArrayMathCPU;
+  const math = ENV.math;
   let x1Tensor: Tensor;
   let x2Tensor: Tensor;
   let c1Tensor: Tensor;
@@ -33,7 +33,6 @@ describe('Linear combination', () => {
   let gradients: SummedTensorArrayMap;
 
   beforeEach(() => {
-    math = new NDArrayMathCPU();
     activations = new TensorArrayMap();
     gradients = new SummedTensorArrayMap(math);
   });

--- a/src/graph/ops/log_test.ts
+++ b/src/graph/ops/log_test.ts
@@ -15,16 +15,15 @@
  * =============================================================================
  */
 
-import {NDArrayMathCPU} from '../../math/backends/backend_cpu';
+import {ENV} from '../../environment';
 import {Array1D} from '../../math/ndarray';
 import * as test_util from '../../test_util';
 import {Tensor} from '../graph';
 import {SummedTensorArrayMap, TensorArrayMap} from '../tensor_array_map';
-
 import {Log} from './log';
 
 describe('log operation', () => {
-  let math: NDArrayMathCPU;
+  const math = ENV.math;
 
   let xTensor: Tensor;
   let yTensor: Tensor;
@@ -33,7 +32,6 @@ describe('log operation', () => {
   let gradients: SummedTensorArrayMap;
 
   beforeEach(() => {
-    math = new NDArrayMathCPU();
     activations = new TensorArrayMap();
     gradients = new SummedTensorArrayMap(math);
   });

--- a/src/graph/ops/matmul_test.ts
+++ b/src/graph/ops/matmul_test.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {NDArrayMathCPU} from '../../math/backends/backend_cpu';
+import {ENV} from '../../environment';
 import {Array1D, Array2D} from '../../math/ndarray';
 import {Tensor} from '../graph';
 import {SummedTensorArrayMap, TensorArrayMap} from '../tensor_array_map';
@@ -23,7 +23,7 @@ import {SummedTensorArrayMap, TensorArrayMap} from '../tensor_array_map';
 import {MatMul} from './matmul';
 
 describe('add operation', () => {
-  let math: NDArrayMathCPU;
+  const math = ENV.math;
 
   let t1: Tensor;
   let t2: Tensor;
@@ -33,7 +33,6 @@ describe('add operation', () => {
   let gradients: SummedTensorArrayMap;
 
   beforeEach(() => {
-    math = new NDArrayMathCPU();
     activations = new TensorArrayMap();
     gradients = new SummedTensorArrayMap(math);
   });

--- a/src/graph/ops/max_pool_test.ts
+++ b/src/graph/ops/max_pool_test.ts
@@ -15,24 +15,22 @@
  * =============================================================================
  */
 
-import {NDArrayMathCPU} from '../../math/backends/backend_cpu';
+import {ENV} from '../../environment';
 import * as conv_util from '../../math/conv_util';
 import {Array3D} from '../../math/ndarray';
 import * as test_util from '../../test_util';
 import {Tensor} from '../graph';
 import {SummedTensorArrayMap, TensorArrayMap} from '../tensor_array_map';
-
 import {MaxPool} from './max_pool';
 
 describe('Max pool', () => {
-  let math: NDArrayMathCPU;
+  const math = ENV.math;
   let xTensor: Tensor;
   let yTensor: Tensor;
   let activations: TensorArrayMap;
   let gradients: SummedTensorArrayMap;
 
   beforeEach(() => {
-    math = new NDArrayMathCPU();
     activations = new TensorArrayMap();
     gradients = new SummedTensorArrayMap(math);
   });

--- a/src/graph/ops/multiply_test.ts
+++ b/src/graph/ops/multiply_test.ts
@@ -15,15 +15,14 @@
  * =============================================================================
  */
 
-import {NDArrayMathCPU} from '../../math/backends/backend_cpu';
+import {ENV} from '../../environment';
 import {Array1D, Scalar} from '../../math/ndarray';
 import {Tensor} from '../graph';
 import {SummedTensorArrayMap, TensorArrayMap} from '../tensor_array_map';
-
 import {Multiply} from './multiply';
 
 describe('divide operation', () => {
-  let math: NDArrayMathCPU;
+  const math = ENV.math;
 
   let x1Tensor: Tensor;
   let x2Tensor: Tensor;
@@ -33,7 +32,6 @@ describe('divide operation', () => {
   let gradients: SummedTensorArrayMap;
 
   beforeEach(() => {
-    math = new NDArrayMathCPU();
     activations = new TensorArrayMap();
     gradients = new SummedTensorArrayMap(math);
   });

--- a/src/graph/ops/reduce_sum.ts
+++ b/src/graph/ops/reduce_sum.ts
@@ -15,6 +15,7 @@
  * =============================================================================
  */
 
+import {ENV} from '../../environment';
 import {NDArrayMath} from '../../math/math';
 import {NDArray} from '../../math/ndarray';
 import * as util from '../../util';
@@ -32,7 +33,7 @@ export class ReduceSum extends Operation {
   constructor(private x: Tensor, private outTensor: Tensor) {
     super();
     util.assertShapesMatch(outTensor.shape, []);
-    this.ones = NDArray.ones(x.shape);
+    this.ones = ENV.math.keep(NDArray.ones(x.shape));
   }
 
   private ones: NDArray;
@@ -56,5 +57,9 @@ export class ReduceSum extends Operation {
       const dy = gradientArrays.get(this.outTensor);
       gradientArrays.add(this.x, math.scalarTimesArray(dy, this.ones));
     });
+  }
+
+  dispose() {
+    this.ones.dispose();
   }
 }

--- a/src/graph/ops/reduce_sum_test.ts
+++ b/src/graph/ops/reduce_sum_test.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {NDArrayMathCPU} from '../../math/backends/backend_cpu';
+import {ENV} from '../../environment';
 import {Array1D, Array2D, Scalar} from '../../math/ndarray';
 import {Tensor} from '../graph';
 import {TensorArrayMap} from '../tensor_array_map';
@@ -23,12 +23,11 @@ import {TensorArrayMap} from '../tensor_array_map';
 import {ReduceSum} from './reduce_sum';
 
 describe('Reduce sum operation', () => {
-  let math: NDArrayMathCPU;
+  const math = ENV.math;
   let reduceSumOp: ReduceSum;
   let activations: TensorArrayMap;
 
   beforeEach(() => {
-    math = new NDArrayMathCPU();
     activations = new TensorArrayMap();
   });
 

--- a/src/graph/ops/softmax.ts
+++ b/src/graph/ops/softmax.ts
@@ -15,12 +15,12 @@
  * =============================================================================
  */
 
+import {ENV} from '../../environment';
 import {NDArrayMath} from '../../math/math';
 import {Array1D, Scalar} from '../../math/ndarray';
 import * as util from '../../util';
 import {Tensor} from '../graph';
 import {SummedTensorArrayMap, TensorArrayMap} from '../tensor_array_map';
-
 import {Operation} from './op';
 
 export class Softmax extends Operation {
@@ -46,6 +46,7 @@ export class SoftmaxCrossEntropyCost extends Operation {
       private yTensor: Tensor) {
     super();
     this.softmaxTensor = new Tensor(logitsTensor.shape);
+    this.epsilon = ENV.math.keep(Scalar.new(1e-5));
   }
 
   feedForward(math: NDArrayMath, inferenceArrays: TensorArrayMap) {
@@ -83,7 +84,7 @@ export class SoftmaxCrossEntropyCost extends Operation {
   }
 
   private softmaxTensor: Tensor;
-  private epsilon = Scalar.new(1e-5);
+  private epsilon: Scalar;
 }
 
 export function crossEntropyCost(

--- a/src/graph/ops/softmax_test.ts
+++ b/src/graph/ops/softmax_test.ts
@@ -15,16 +15,15 @@
  * =============================================================================
  */
 
-import {NDArrayMathCPU} from '../../math/backends/backend_cpu';
+import {ENV} from '../../environment';
 import {Array1D, Scalar} from '../../math/ndarray';
 import * as test_util from '../../test_util';
 import {Tensor} from '../graph';
 import {SummedTensorArrayMap, TensorArrayMap} from '../tensor_array_map';
-
 import {SoftmaxCrossEntropyCost} from './softmax';
 
 describe('softmax cross entropy cost', () => {
-  let math: NDArrayMathCPU;
+  const math = ENV.math;
   let logitsTensor: Tensor;
   let labelTensor: Tensor;
   let yTensor: Tensor;
@@ -32,7 +31,6 @@ describe('softmax cross entropy cost', () => {
   let gradients: SummedTensorArrayMap;
 
   beforeEach(() => {
-    math = new NDArrayMathCPU();
     activations = new TensorArrayMap();
     gradients = new SummedTensorArrayMap(math);
   });

--- a/src/graph/ops/subtract_test.ts
+++ b/src/graph/ops/subtract_test.ts
@@ -15,15 +15,14 @@
  * =============================================================================
  */
 
-import {NDArrayMathCPU} from '../../math/backends/backend_cpu';
+import {ENV} from '../../environment';
 import {Array1D, Array2D, Scalar} from '../../math/ndarray';
 import {Tensor} from '../graph';
 import {SummedTensorArrayMap, TensorArrayMap} from '../tensor_array_map';
-
 import {Subtract} from './subtract';
 
 describe('add operation', () => {
-  let math: NDArrayMathCPU;
+  const math = ENV.math;
 
   let t1: Tensor;
   let t2: Tensor;
@@ -33,7 +32,6 @@ describe('add operation', () => {
   let gradients: SummedTensorArrayMap;
 
   beforeEach(() => {
-    math = new NDArrayMathCPU();
     activations = new TensorArrayMap();
     gradients = new SummedTensorArrayMap(math);
   });

--- a/src/graph/optimizers/adadelta_optimizer_test.ts
+++ b/src/graph/optimizers/adadelta_optimizer_test.ts
@@ -15,18 +15,16 @@
  * =============================================================================
  */
 import {InputProvider} from '../../data/input_provider';
-import {NDArrayMathCPU} from '../../math/backends/backend_cpu';
+import {ENV} from '../../environment';
 import {Array1D, NDArray} from '../../math/ndarray';
 import * as test_util from '../../test_util';
 import {Graph} from '../graph';
 import {Session} from '../session';
-
 import {AdadeltaOptimizer} from './adadelta_optimizer';
 
 describe('adadelta optimizer', () => {
   it('basic', () => {
-    const safeMode = true;
-    const math = new NDArrayMathCPU(safeMode);
+    const math = ENV.math;
 
     const inputProvider: InputProvider = {
       getNextCopy() {

--- a/src/graph/optimizers/adagrad_optimizer_test.ts
+++ b/src/graph/optimizers/adagrad_optimizer_test.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 import {InputProvider} from '../../data/input_provider';
-import {NDArrayMathCPU} from '../../math/backends/backend_cpu';
+import {ENV} from '../../environment';
 import {Array1D, NDArray} from '../../math/ndarray';
 import * as test_util from '../../test_util';
 import {Graph} from '../graph';
@@ -25,8 +25,7 @@ import {AdagradOptimizer} from './adagrad_optimizer';
 
 describe('adagrad optimizer', () => {
   it('basic', () => {
-    const safeMode = true;
-    const math = new NDArrayMathCPU(safeMode);
+    const math = ENV.math;
 
     const inputProvider: InputProvider = {
       getNextCopy() {

--- a/src/graph/optimizers/adam_optimizer_test.ts
+++ b/src/graph/optimizers/adam_optimizer_test.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 import {InputProvider} from '../../data/input_provider';
-import {NDArrayMathCPU} from '../../math/backends/backend_cpu';
+import {ENV} from '../../environment';
 import {Array1D, NDArray} from '../../math/ndarray';
 import * as test_util from '../../test_util';
 import {Graph} from '../graph';
@@ -25,8 +25,7 @@ import {AdamOptimizer} from './adam_optimizer';
 
 describe('adam optimizer', () => {
   it('basic', () => {
-    const safeMode = true;
-    const math = new NDArrayMathCPU(safeMode);
+    const math = ENV.math;
 
     const inputProvider: InputProvider = {
       getNextCopy() {

--- a/src/graph/optimizers/adamax_optimizer_test.ts
+++ b/src/graph/optimizers/adamax_optimizer_test.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 import {InputProvider} from '../../data/input_provider';
-import {NDArrayMathCPU} from '../../math/backends/backend_cpu';
+import {ENV} from '../../environment';
 import {Array1D, NDArray} from '../../math/ndarray';
 import * as test_util from '../../test_util';
 import {Graph} from '../graph';
@@ -25,8 +25,7 @@ import {AdamaxOptimizer} from './adamax_optimizer';
 
 describe('adamax optimizer', () => {
   it('adamax', () => {
-    const safeMode = true;
-    const math = new NDArrayMathCPU(safeMode);
+    const math = ENV.math;
 
     const inputProvider: InputProvider = {
       getNextCopy() {

--- a/src/graph/optimizers/momentum_optimizer_test.ts
+++ b/src/graph/optimizers/momentum_optimizer_test.ts
@@ -15,18 +15,16 @@
  * =============================================================================
  */
 import {InputProvider} from '../../data/input_provider';
-import {NDArrayMathCPU} from '../../math/backends/backend_cpu';
+import {ENV} from '../../environment';
 import {Array1D, NDArray} from '../../math/ndarray';
 import * as test_util from '../../test_util';
 import {Graph} from '../graph';
 import {Session} from '../session';
-
 import {MomentumOptimizer} from './momentum_optimizer';
 
 describe('momentum optimizer', () => {
   it('basic', () => {
-    const safeMode = true;
-    const math = new NDArrayMathCPU(safeMode);
+    const math = ENV.math;
 
     const inputProvider: InputProvider = {
       getNextCopy() {

--- a/src/graph/optimizers/rmsprop_optimizer_test.ts
+++ b/src/graph/optimizers/rmsprop_optimizer_test.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 import {InputProvider} from '../../data/input_provider';
-import {NDArrayMathCPU} from '../../math/backends/backend_cpu';
+import {ENV} from '../../environment';
 import {Array1D, NDArray} from '../../math/ndarray';
 import * as test_util from '../../test_util';
 import {Graph} from '../graph';
@@ -24,8 +24,7 @@ import {RMSPropOptimizer} from './rmsprop_optimizer';
 
 describe('rmsprop optimizer', () => {
   it('basic', () => {
-    const safeMode = true;
-    const math = new NDArrayMathCPU(safeMode);
+    const math = ENV.math;
 
     const inputProvider: InputProvider = {
       getNextCopy() {

--- a/src/graph/optimizers/sgd_optimizer_test.ts
+++ b/src/graph/optimizers/sgd_optimizer_test.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 import {InputProvider} from '../../data/input_provider';
-import {NDArrayMathCPU} from '../../math/backends/backend_cpu';
+import {ENV} from '../../environment';
 import {Array1D} from '../../math/ndarray';
 import * as test_util from '../../test_util';
 import {Graph} from '../graph';
@@ -24,8 +24,7 @@ import {SGDOptimizer} from './sgd_optimizer';
 
 describe('sgd optimizer', () => {
   it('basic', () => {
-    const safeMode = true;
-    const math = new NDArrayMathCPU(safeMode);
+    const math = ENV.math;
 
     const inputProvider: InputProvider = {
       getNextCopy() {

--- a/src/graph/session.ts
+++ b/src/graph/session.ts
@@ -174,7 +174,10 @@ export class Session {
 
     if (this.prevBatchSize !== batchSize) {
       this.prevBatchSize = batchSize;
-      this.batchSizeScalar = Scalar.new(batchSize);
+      if (this.batchSizeScalar != null) {
+        this.batchSizeScalar.dispose();
+      }
+      this.batchSizeScalar = this.math.keep(Scalar.new(batchSize));
     }
 
     const feed = new FeedDictionary(feedEntries);
@@ -194,8 +197,8 @@ export class Session {
     optimizer.beforeBatch(
         this.math, batchSize, runtime, activations, gradients);
 
-    return this.math.scope((keep, track) => {
-      let cost = track(Scalar.new(0));
+    return this.math.scope(() => {
+      let cost = Scalar.new(0);
 
       for (let i = 0; i < batchSize; ++i) {
         session_util.disposeAndInitializeOperationOutputs(

--- a/src/graph/session_test.ts
+++ b/src/graph/session_test.ts
@@ -269,7 +269,8 @@ describe('Session', () => {
   });
 
   it('Safe mode math, no math scope eval throws', () => {
-    const math = new NDArrayMath('webgl', true);
+    const safeMode = true;
+    const math = new NDArrayMath('webgl', safeMode);
     ENV.setMath(math);
 
     expect(() => {
@@ -282,7 +283,8 @@ describe('Session', () => {
   });
 
   it('Safe mode math, math scope eval does not throw', () => {
-    const math = new NDArrayMath('webgl', true);
+    const safeMode = true;
+    const math = new NDArrayMath('webgl', safeMode);
     ENV.setMath(math);
 
     math.scope(() => {
@@ -297,7 +299,8 @@ describe('Session', () => {
   });
 
   it('Safe mode math, math scope train does not throw', () => {
-    const math = new NDArrayMath('webgl', true);
+    const safeMode = true;
+    const math = new NDArrayMath('webgl', safeMode);
     ENV.setMath(math);
 
     const inputProvider: InputProvider = {
@@ -324,7 +327,8 @@ describe('Session', () => {
   });
 
   it('Safe mode math, no math scope train throws', () => {
-    const math = new NDArrayMath('webgl', true);
+    const safeMode = true;
+    const math = new NDArrayMath('webgl', safeMode);
     ENV.setMath(math);
 
     const inputProvider: InputProvider = {

--- a/src/graph/session_test.ts
+++ b/src/graph/session_test.ts
@@ -16,11 +16,10 @@
  */
 
 import {InputProvider} from '../data/input_provider';
-import {NDArrayMathCPU} from '../math/backends/backend_cpu';
-import {NDArrayMathGPU} from '../math/backends/backend_webgl';
+import {ENV} from '../environment';
+import {NDArrayMath} from '../math/math';
 import {Array1D, NDArray, Scalar} from '../math/ndarray';
 import * as test_util from '../test_util';
-
 import {Graph, Tensor} from './graph';
 import {SGDOptimizer} from './optimizers/sgd_optimizer';
 import {FeedDictionary, FeedEntry, Session} from './session';
@@ -31,7 +30,7 @@ describe('FeedDictionary', () => {
   });
 
   it('ctor populates dict from only feed entry', () => {
-    const math = new NDArrayMathCPU();
+    const math = ENV.math;
     math.scope(() => {
       const e: FeedEntry = {tensor: new Tensor([]), data: NDArray.zeros([1])};
       const d = new FeedDictionary([e]);
@@ -67,7 +66,7 @@ describe('Session', () => {
   beforeEach(() => g = new Graph());
 
   it('mnist fc', () => {
-    const math = new NDArrayMathCPU();
+    const math = ENV.math;
     const input = g.placeholder('input', [28 * 28]);
     const fc0W = g.variable('fc0W', NDArray.zeros([32, 28 * 28]));
     const fc0B = g.variable('fc0B', NDArray.zeros([32]));
@@ -90,17 +89,16 @@ describe('Session', () => {
   });
 
   it('y=x^2 + 3: CPU', () => {
-    const math = new NDArrayMathCPU();
     const x = g.placeholder('x', [2]);
     const y = g.add(g.square(x), g.constant(3));
-    const session = new Session(g, math);
+    const session = new Session(g, ENV.math);
     const yVal = session.eval(y, [{tensor: x, data: Array1D.new([5, 4])}]);
     const expected = new Float32Array([28, 19]);
     test_util.expectArraysClose(yVal.getValues(), expected);
   });
 
   it('y=x^2 + 3: GPU', () => {
-    const math = new NDArrayMathGPU();
+    const math = ENV.math;
     const x = g.placeholder('x', [2]);
     const y = g.add(g.square(x), g.constant(3));
     const session = new Session(g, math);
@@ -113,7 +111,7 @@ describe('Session', () => {
   });
 
   it('Non-placeholder feed: y=x^2 + 3 (feed x^2)', () => {
-    const math = new NDArrayMathGPU();
+    const math = ENV.math;
     const x = g.placeholder('x', [2]);
     const xSquared = g.square(x);
     const y = g.add(xSquared, g.constant(3));
@@ -128,7 +126,7 @@ describe('Session', () => {
   });
 
   it('Eval multiple tensors that share graph: y=x^2 + 3, z=x^2 + 2', () => {
-    const math = new NDArrayMathGPU();
+    const math = ENV.math;
     const x = g.placeholder('x', [2]);
     const xSquared = g.square(x);
     const y = g.add(xSquared, g.constant(3));
@@ -146,7 +144,7 @@ describe('Session', () => {
   });
 
   it('Eval 2 tensors that share a split graph: y=x^2 + x, z=y + 1', () => {
-    const math = new NDArrayMathGPU();
+    const math = ENV.math;
     const x = g.placeholder('x', [2]);
     const xSquared = g.square(x);
     const y = g.add(xSquared, x);
@@ -165,7 +163,7 @@ describe('Session', () => {
   });
 
   it('Backprop through a  with 2 outputs, input is scalar', () => {
-    const math = new NDArrayMathCPU();
+    const math = ENV.math;
     const two = Scalar.new(2);
     const one = Scalar.new(1);
     const negOne = Scalar.new(-1);
@@ -202,7 +200,7 @@ describe('Session', () => {
   });
 
   it('Backprop through a node with 2 outputs, input is Array1D', () => {
-    const math = new NDArrayMathCPU();
+    const math = ENV.math;
     const x = g.placeholder('x', [2]);
     const y = g.square(x);
     const z = g.add(x, g.constant(3));
@@ -225,7 +223,7 @@ describe('Session', () => {
   });
 
   it('Specify which variables to update (var_list)', () => {
-    const math = new NDArrayMathCPU();
+    const math = ENV.math;
     const x = g.placeholder('x', [2]);
     const b0 = g.variable('b0', NDArray.zeros([2]));
     const p = g.add(x, b0);
@@ -271,8 +269,8 @@ describe('Session', () => {
   });
 
   it('Safe mode math, no math scope eval throws', () => {
-    const safeMode = true;
-    const math = new NDArrayMathCPU(safeMode);
+    const math = new NDArrayMath('webgl', true);
+    ENV.setMath(math);
 
     expect(() => {
       const x = g.placeholder('x', [2]);
@@ -280,11 +278,13 @@ describe('Session', () => {
       const session = new Session(g, math);
       session.eval(y, [{tensor: x, data: Array1D.new([5, 4])}]);
     }).toThrowError();
+    ENV.reset();
   });
 
   it('Safe mode math, math scope eval does not throw', () => {
-    const safeMode = true;
-    const math = new NDArrayMathCPU(safeMode);
+    const math = new NDArrayMath('webgl', true);
+    ENV.setMath(math);
+
     math.scope(() => {
       const x = g.placeholder('x', [2]);
       const y = g.square(x);
@@ -293,11 +293,12 @@ describe('Session', () => {
       const expected = new Float32Array([25, 16]);
       test_util.expectArraysClose(yVal.getValues(), expected);
     });
+    ENV.reset();
   });
 
   it('Safe mode math, math scope train does not throw', () => {
-    const safeMode = true;
-    const math = new NDArrayMathCPU(safeMode);
+    const math = new NDArrayMath('webgl', true);
+    ENV.setMath(math);
 
     const inputProvider: InputProvider = {
       getNextCopy() {
@@ -319,11 +320,12 @@ describe('Session', () => {
       const dwdx = session.gradientArrayMap.get(x).getValues();
       test_util.expectArraysClose(dwdx, new Float32Array([5, 9]));
     });
+    ENV.reset();
   });
 
   it('Safe mode math, no math scope train throws', () => {
-    const safeMode = true;
-    const math = new NDArrayMathCPU(safeMode);
+    const math = new NDArrayMath('webgl', true);
+    ENV.setMath(math);
 
     const inputProvider: InputProvider = {
       getNextCopy() {
@@ -341,5 +343,7 @@ describe('Session', () => {
       const w = g.reduceSum(g.add(y, z));
       session.train(w, [{tensor: x, data: inputProvider}], 1, optimizer);
     }).toThrowError();
+
+    ENV.reset();
   });
 });

--- a/src/graph/session_util_test.ts
+++ b/src/graph/session_util_test.ts
@@ -17,7 +17,7 @@
 
 // tslint:disable-next-line:max-line-length
 import {InputProvider} from '../data/input_provider';
-import {NDArrayMathCPU} from '../math/backends/backend_cpu';
+import {ENV} from '../environment';
 import {NDArray} from '../math/ndarray';
 // tslint:disable-next-line:max-line-length
 import {ConstantNode, Graph, Node, PlaceholderNode, Tensor, VariableNode} from './graph';
@@ -30,7 +30,6 @@ class TestNode extends Node {
 }
 
 describe('getTerminatingNodesFromFeedDictionary', () => {
-
   it('returns an empty node array from an empty FeedDictionary', () => {
     expect(session_util.getTerminatingNodesFromFeedDictionary(
                new FeedDictionary()))
@@ -38,7 +37,7 @@ describe('getTerminatingNodesFromFeedDictionary', () => {
   });
 
   it('returns the only node in the feed dictionary', () => {
-    const math = new NDArrayMathCPU();
+    const math = ENV.math;
     math.scope(() => {
       const node = new TestNode(new Graph(), '', {}, new Tensor([]));
       const fd =
@@ -50,7 +49,7 @@ describe('getTerminatingNodesFromFeedDictionary', () => {
   });
 
   it('returns every node from the feed dictionary', () => {
-    const math = new NDArrayMathCPU();
+    const math = ENV.math;
     math.scope(() => {
       const n0 = new TestNode(new Graph(), '', {}, new Tensor([]));
       const n1 = new TestNode(new Graph(), '', {}, new Tensor([]));
@@ -78,12 +77,11 @@ describe('getTerminatingNodesFromFeedDictionary', () => {
 describe('addPersistentArraysToTensorArrayMap', () => {
   let map: TensorArrayMap;
   let g: Graph;
-  let math: NDArrayMathCPU;
+  const math = ENV.math;
 
   beforeEach(() => {
     map = new TensorArrayMap();
     g = new Graph();
-    math = new NDArrayMathCPU();
   });
 
   it('does nothing with empty evaluationSet', () => {
@@ -155,10 +153,9 @@ describe('addPersistentArraysToTensorArrayMap', () => {
 
 describe('loadInputsFromFeedDictionaryToTensorArrayMap', () => {
   let map: TensorArrayMap;
-  let math: NDArrayMathCPU;
+  const math = ENV.math;
 
   beforeEach(() => {
-    math = new NDArrayMathCPU();
     map = new TensorArrayMap();
   });
 
@@ -255,11 +252,10 @@ describe('loadInputsFromFeedDictionaryToTensorArrayMap', () => {
 
 describe('releaseFeedDictionaryInputsFromTensorArrayMap', () => {
   let map: TensorArrayMap;
-  let math: NDArrayMathCPU;
+  const math = ENV.math;
 
   beforeEach(() => {
     map = new TensorArrayMap();
-    math = new NDArrayMathCPU();
   });
 
   it('doesn\'t remove anything when feed dictionary is empty', () => {

--- a/src/graph/tensor_array_map_test.ts
+++ b/src/graph/tensor_array_map_test.ts
@@ -15,9 +15,8 @@
  * =============================================================================
  */
 
-import {NDArrayMathCPU} from '../math/backends/backend_cpu';
+import {ENV} from '../environment';
 import {Array1D, NDArray} from '../math/ndarray';
-
 import {Tensor} from './graph';
 import {SummedTensorArrayMap, TensorArrayMap} from './tensor_array_map';
 
@@ -114,9 +113,8 @@ describe('TensorArrayMap.delete', () => {
 describe('SummedTensorArrayMap.add', () => {
   let map: SummedTensorArrayMap;
   let t: Tensor;
-  let math: NDArrayMathCPU;
+  const math = ENV.math;
   beforeEach(() => {
-    math = new NDArrayMathCPU();
     map = new SummedTensorArrayMap(math);
     t = new Tensor([]);
   });

--- a/src/graph_runner.ts
+++ b/src/graph_runner.ts
@@ -248,7 +248,7 @@ export class GraphRunner {
       return;
     }
 
-    this.math.scope((keep, track) => {
+    this.math.scope(keep => {
       const feeds: FeedEntry[][] = [];
       const inferenceValues: NDArray[] = [];
 
@@ -261,8 +261,7 @@ export class GraphRunner {
           const nextCopy =
               (feedEntry.data as InputProvider).getNextCopy(this.math);
 
-          ndarrayFeedEntries.push(
-              {tensor: feedEntry.tensor, data: track(nextCopy)});
+          ndarrayFeedEntries.push({tensor: feedEntry.tensor, data: nextCopy});
         }
         feeds.push(ndarrayFeedEntries);
         inferenceValues.push(

--- a/src/graph_runner_test.ts
+++ b/src/graph_runner_test.ts
@@ -15,13 +15,13 @@
  * =============================================================================
  */
 
+import {ENV} from './environment';
 import {Graph, Tensor} from './graph/graph';
 import {Optimizer} from './graph/optimizers/optimizer';
 import {SGDOptimizer} from './graph/optimizers/sgd_optimizer';
 import {CostReduction, FeedEntry, Session} from './graph/session';
 // tslint:disable-next-line:max-line-length
 import {GraphRunner, GraphRunnerEventObserver, MetricReduction} from './graph_runner';
-import {NDArrayMathCPU} from './math/backends/backend_cpu';
 import {NDArrayMath} from './math/math';
 import {Array1D, NDArray, Scalar} from './math/ndarray';
 
@@ -35,7 +35,7 @@ function fakeTrainBatch(
 }
 
 describe('Model runner', () => {
-  let math: NDArrayMath;
+  const math = ENV.math;
   let g: Graph;
   let session: Session;
   let optimizer: SGDOptimizer;
@@ -65,7 +65,6 @@ describe('Model runner', () => {
     // Workaround to avoid jasmine callback timeout.
     originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000;
-    math = new NDArrayMathCPU();
     g = new Graph();
     optimizer = new SGDOptimizer(FAKE_LEARNING_RATE);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,8 +46,8 @@ export {CostReduction, FeedEntry, Session} from './graph/session';
 export {GraphRunner, GraphRunnerEventObserver, MetricReduction} from './graph_runner';
 // tslint:disable-next-line:max-line-length
 export {ConstantInitializer, Initializer, NDArrayInitializer, OnesInitializer, RandomNormalInitializer, RandomTruncatedNormalInitializer, RandomUniformInitializer, VarianceScalingInitializer, ZerosInitializer} from './initializers';
-export {NDArrayMathCPU} from './math/backends/backend_cpu';
-export {NDArrayMathGPU} from './math/backends/backend_webgl';
+export {MathBackendCPU, NDArrayMathCPU} from './math/backends/backend_cpu';
+export {MathBackendWebGL, NDArrayMathGPU} from './math/backends/backend_webgl';
 export {MatrixOrientation} from './math/backends/types/matmul';
 export {GPGPUContext} from './math/backends/webgl/gpgpu_context';
 // tslint:disable-next-line:max-line-length

--- a/src/math/activation_functions_test.ts
+++ b/src/math/activation_functions_test.ts
@@ -14,20 +14,15 @@
  * limitations under the License.
  * =============================================================================
  */
-import {NDArrayMathCPU} from '../math/backends/backend_cpu';
+import {ENV} from '../environment';
 import * as test_util from '../test_util';
 import * as util from '../util';
-
 // tslint:disable-next-line:max-line-length
 import {EluFunc, LeakyReluFunc, ReLUFunc, SigmoidFunc, TanHFunc} from './activation_functions';
 import {Array1D} from './ndarray';
 
 describe('Activation functions', () => {
-  let math: NDArrayMathCPU;
-
-  beforeEach(() => {
-    math = new NDArrayMathCPU();
-  });
+  const math = ENV.math;
 
   it('Tanh output', () => {
     const x = Array1D.new([1, 3, -2, 100, -100, 0]);

--- a/src/math/backends/backend.ts
+++ b/src/math/backends/backend.ts
@@ -32,6 +32,7 @@ export interface NDArrayStorage {
       id: number,
       pixels: ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement,
       numChannels: number): void;
+  time(query: () => NDArray): Promise<number>;
 }
 
 /**

--- a/src/math/backends/backend_cpu.ts
+++ b/src/math/backends/backend_cpu.ts
@@ -86,6 +86,12 @@ export class MathBackendCPU implements MathBackend {
   disposeData(id: number): void {
     delete this.data[id];
   }
+  async time(query: () => NDArray): Promise<number> {
+    const start = performance.now();
+    query();
+    return performance.now() - start;
+  }
+
   async read<T extends keyof DataTypes>(id: number): Promise<DataTypes[T]> {
     return this.data[id];
   }

--- a/src/math/backends/backend_cpu.ts
+++ b/src/math/backends/backend_cpu.ts
@@ -80,7 +80,12 @@ export class MathBackendCPU implements MathBackend {
     }
     this.data[id] = values;
   }
+  async read<T extends keyof DataTypes>(id: number): Promise<DataTypes[T]> {
+    this.throwIfNoData(id);
+    return this.data[id];
+  }
   readSync<T extends keyof DataTypes>(id: number): DataTypes[T] {
+    this.throwIfNoData(id);
     return this.data[id];
   }
   disposeData(id: number): void {
@@ -91,9 +96,14 @@ export class MathBackendCPU implements MathBackend {
     query();
     return performance.now() - start;
   }
-
-  async read<T extends keyof DataTypes>(id: number): Promise<DataTypes[T]> {
-    return this.data[id];
+  private throwIfNoData(id: number) {
+    if (!(id in this.data)) {
+      throw new Error(
+          `No data found for NDArray with id ${id}. ` +
+          `Use dl.ENV.math instead of constructing your own NDArrayMath. ` +
+          `If you need to construct your own math, make sure this array is ` +
+          `allocated after the math construction`);
+    }
   }
 
   clone<T extends NDArray>(x: T): T {
@@ -803,7 +813,11 @@ export class MathBackendCPU implements MathBackend {
     const values = x.getValues();
     for (let i = 0; i < values.length; ++i) {
       const value = values[i];
-      resultValues[i] = value > 0 ? 1 : (value < 0 ? alpha : value);
+      if (util.isValNaN(value, x.dtype)) {
+        resultValues[i] = util.getNaN(x.dtype);
+      } else {
+        resultValues[i] = value > 0 ? 1 : alpha;
+      }
     }
     return NDArray.make(x.shape, {values: resultValues}) as T;
   }
@@ -1372,6 +1386,11 @@ ENV.registerBackend('cpu', () => new MathBackendCPU());
 // TODO(nsthorat): Deprecate this once we export non-abstract NDArrayMath.
 export class NDArrayMathCPU extends NDArrayMath {
   constructor(safeMode = false) {
+    console.warn(
+        'new NDArrayMathCPU() is deprecated. Please use the global ' +
+        'dl.ENV.math. In rare cases, to construct your own NDArrayMath ' +
+        'that runs on CPU, use math = new NDArrayMath(\'cpu\', safeMode); ' +
+        'and make sure to set it as global: dl.ENV.setMath(math);');
     super('cpu', safeMode);
     ENV.setMath(this);
   }

--- a/src/math/backends/backend_webgl.ts
+++ b/src/math/backends/backend_webgl.ts
@@ -94,6 +94,7 @@ export class MathBackendWebGL implements MathBackend {
     }
   }
   readSync<T extends keyof DataTypes>(id: number): DataTypes[T] {
+    this.throwIfNoData(id);
     let values: Float32Array;
     const {texture, textureType, texShape, numChannels, dtype} =
         this.texData[id];
@@ -107,6 +108,7 @@ export class MathBackendWebGL implements MathBackend {
     return float32ToTypedArray(values, dtype);
   }
   async read<T extends keyof DataTypes>(id: number): Promise<DataTypes[T]> {
+    this.throwIfNoData(id);
     const {texture, textureType, texShape} = this.texData[id];
     if (ENV.get('WEBGL_GET_BUFFER_SUB_DATA_ASYNC_EXTENSION_ENABLED') &&
         textureType === TextureType.DEFAULT) {
@@ -115,14 +117,22 @@ export class MathBackendWebGL implements MathBackend {
     }
 
     if (!ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_ENABLED')) {
-      return await this.readSync(id);
+      return this.readSync(id);
     }
 
     // Construct an empty query. We're just interested in getting a callback
     // when the GPU command queue has executed until this point in time.
-    const queryFn = () => {};
-    await this.gpgpu.runQuery(queryFn);
+    await this.gpgpu.runQuery(() => {});
     return this.readSync(id);
+  }
+  async time(query: () => NDArray): Promise<number> {
+    if (!ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_ENABLED')) {
+      const start = performance.now();
+      const a = query();
+      await a.data();
+      return performance.now() - start;
+    }
+    return this.gpgpu.runQuery(query);
   }
   disposeData(id: number): void {
     if (id in this.texData) {
@@ -130,6 +140,16 @@ export class MathBackendWebGL implements MathBackend {
       this.textureManager.releaseTexture(texture, texShape);
       delete this.texData[id];
     }
+  }
+
+  getTexture(id: number): WebGLTexture {
+    this.throwIfNoData(id);
+    return this.texData[id].texture;
+  }
+
+  getTextureData(id: number): TextureData {
+    this.throwIfNoData(id);
+    return this.texData[id];
   }
 
   private gpgpu: GPGPUContext;
@@ -157,6 +177,7 @@ export class MathBackendWebGL implements MathBackend {
   }
 
   clone<G extends keyof DataTypes, T extends NDArray<G>>(x: T): T {
+    this.throwIfNoData(x.id);
     const {texShape} = this.texData[x.id];
     // Pretend the source was in logical shape that matches the texture shape.
     const source = x.as2D(texShape[0], texShape[1]);
@@ -496,8 +517,8 @@ export class MathBackendWebGL implements MathBackend {
   }
 
   preluDer<T extends NDArray>(a: T, b: T): T {
-    const program = new BinaryOpProgram(binaryop_gpu.PRELU_DER,
-      a.shape, b.shape);
+    const program =
+        new BinaryOpProgram(binaryop_gpu.PRELU_DER, a.shape, b.shape);
     return this.compileAndRun(program, [a, b]) as T;
   }
 
@@ -661,8 +682,10 @@ export class MathBackendWebGL implements MathBackend {
       output = this.makeOutputArray(program.outputShape, inputs[0].dtype);
     }
     const inputsData: Array<ArrayData<T>> = inputs.map(input => {
+      this.throwIfNoData(input.id);
       return {array: input, texData: this.texData[input.id]};
     });
+    this.throwIfNoData(output.id);
     const outputData = {array: output, texData: this.texData[output.id]};
     const key = gpgpu_math.makeShaderKey(program, inputsData, outputData);
     const binary = this.getAndSaveBinary(key, () => {
@@ -693,6 +716,12 @@ export class MathBackendWebGL implements MathBackend {
 
     if (this.gpgpuCreatedLocally) {
       this.gpgpu.dispose();
+    }
+  }
+
+  private throwIfNoData(id: number) {
+    if (!(id in this.texData)) {
+      throw new Error(`No data found for id ${id}`);
     }
   }
 }

--- a/src/math/backends/backend_webgl.ts
+++ b/src/math/backends/backend_webgl.ts
@@ -721,7 +721,11 @@ export class MathBackendWebGL implements MathBackend {
 
   private throwIfNoData(id: number) {
     if (!(id in this.texData)) {
-      throw new Error(`No data found for id ${id}`);
+      throw new Error(
+          `No data found for NDArray with id ${id}. ` +
+          `Use dl.ENV.math instead of constructing your own NDArrayMath. ` +
+          `If you need to construct your own math, make sure this array is ` +
+          `allocated after the math construction`);
     }
   }
 }
@@ -731,6 +735,11 @@ ENV.registerBackend('webgl', () => new MathBackendWebGL());
 // TODO(nsthorat): Deprecate this once we export non-abstract NDArrayMath.
 export class NDArrayMathGPU extends NDArrayMath {
   constructor(gpgpu?: GPGPUContext, safeMode = false) {
+    console.warn(
+        'new NDArrayMathGPU() is deprecated. Please use the global ' +
+        'dl.ENV.math. In rare cases, to construct your own NDArrayMath ' +
+        'that runs on GPU, use math = new NDArrayMath(\'webgl\', safeMode); ' +
+        'and make sure to set it as global: dl.ENV.setMath(math);');
     super(new MathBackendWebGL(gpgpu), safeMode);
     ENV.setMath(this);
   }

--- a/src/math/backends/webgl/gpgpu_context.ts
+++ b/src/math/backends/webgl/gpgpu_context.ts
@@ -17,7 +17,6 @@
 
 import {ENV} from '../../../environment';
 import * as util from '../../../util';
-
 import * as gpgpu_util from './gpgpu_util';
 import * as tex_util from './tex_util';
 import * as webgl_util from './webgl_util';
@@ -43,7 +42,6 @@ export class GPGPUContext {
     } else {
       this.gl = gpgpu_util.createWebGLContext();
     }
-
     // WebGL 2.0 enables texture floats without an extension.
     if (ENV.get('WEBGL_VERSION') === 1) {
       this.textureFloatExtension =

--- a/src/math/backends/webgl/gpgpu_util.ts
+++ b/src/math/backends/webgl/gpgpu_util.ts
@@ -270,7 +270,6 @@ function decodeDownloadTargetArrayBuffer(
     downloadTarget: Float32Array|Uint8Array, rows: number, columns: number,
     channelsPerPixel: number): Float32Array {
   const isFloatTexture = ENV.get('WEBGL_FLOAT_TEXTURE_ENABLED');
-
   if (isFloatTexture) {
     const matrix = new Float32Array(rows * columns);
     tex_util.decodeMatrixFromUnpackedArray(

--- a/src/math/backends/webgl/unaryop_gpu.ts
+++ b/src/math/backends/webgl/unaryop_gpu.ts
@@ -77,7 +77,7 @@ export function LEAKY_RELU(alpha: number) {
 
 export function STEP(alpha = 0.0) {
   return CHECK_NAN_SNIPPET + `
-    return (x == x) ? (x > 0.0 ? 1.0 : float(${alpha})) : x;
+    return x > 0.0 ? 1.0 : float(${alpha});
   `;
 }
 

--- a/src/math/cost_functions.ts
+++ b/src/math/cost_functions.ts
@@ -15,6 +15,7 @@
  * =============================================================================
  */
 
+import {ENV} from '../environment';
 import {NDArrayMath} from './math';
 import {NDArray, Scalar} from './ndarray';
 
@@ -28,7 +29,11 @@ export interface ElementWiseCostFunction {
 }
 
 export class SquareCostFunc implements ElementWiseCostFunction {
-  private halfOne = Scalar.new(0.5);
+  constructor() {
+    this.halfOne = ENV.math.keep(Scalar.new(0.5));
+  }
+
+  private halfOne: Scalar;
 
   cost<T extends NDArray>(math: NDArrayMath, x1: T, x2: T): T {
     const diff = math.subStrict(x1, x2);

--- a/src/math/cost_functions_test.ts
+++ b/src/math/cost_functions_test.ts
@@ -15,20 +15,13 @@
  * =============================================================================
  */
 
-import {NDArrayMathCPU} from '../math/backends/backend_cpu';
 import * as test_util from '../test_util';
-
+import {MathTests} from '../test_util';
 import {SquareCostFunc} from './cost_functions';
 import {Array1D} from './ndarray';
 
-describe('Cost functions', () => {
-  let math: NDArrayMathCPU;
-
-  beforeEach(() => {
-    math = new NDArrayMathCPU();
-  });
-
-  it('Square cost', () => {
+const tests: MathTests = it => {
+  it('Square cost', math => {
     const y = Array1D.new([1, 3, -2]);
     const target = Array1D.new([0, 3, -1.5]);
     const square = new SquareCostFunc();
@@ -40,7 +33,7 @@ describe('Cost functions', () => {
     test_util.expectNumbersClose(cost.get(2), 0.25 / 2);
   });
 
-  it('Square derivative', () => {
+  it('Square derivative', math => {
     const y = Array1D.new([1, 3, -2]);
     const target = Array1D.new([0, 3, -1.5]);
     const square = new SquareCostFunc();
@@ -50,4 +43,11 @@ describe('Cost functions', () => {
     test_util.expectNumbersClose(dy.get(1), 0);
     test_util.expectNumbersClose(dy.get(2), -0.5);
   });
-});  // Close describe.
+};
+
+test_util.describeMathCPU('Square cost', [tests]);
+test_util.describeMathGPU('Square cost', [tests], [
+  {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 1},
+  {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2},
+  {'WEBGL_FLOAT_TEXTURE_ENABLED': false, 'WEBGL_VERSION': 1}
+]);

--- a/src/math/math.ts
+++ b/src/math/math.ts
@@ -244,13 +244,8 @@ export class NDArrayMath implements NDArrayStorage, NDArrayManager {
     return result;
   }
 
-  /**
-   * Tracks an NDArray in the current scope to be automatically cleaned up
-   * when the current scope ends, and returns the value.
-   *
-   * @param result The NDArray to track in the current scope.
-   */
-  private track<G extends keyof DataTypes, T extends NDArray<G>>(result: T): T {
+  /** @deprecated This is a no-op. */
+  track<G extends keyof DataTypes, T extends NDArray<G>>(result: T): T {
     if (this.activeScope == null) {
       if (this.safeMode) {
         throw new Error(
@@ -1269,8 +1264,7 @@ export class NDArrayMath implements NDArrayStorage, NDArrayManager {
    * @return {NDArray}
    */
   prelu<T extends NDArray>(x: T, alpha: T): T {
-    return this.backendEngine.executeKernel(
-               'PReLU', {inputs: {x, alpha}}) as T;
+    return this.backendEngine.executeKernel('PReLU', {inputs: {x, alpha}}) as T;
   }
 
   /**
@@ -1280,8 +1274,8 @@ export class NDArrayMath implements NDArrayStorage, NDArrayManager {
    * @return {NDArray}
    */
   preluDer<T extends NDArray>(x: T, alpha: T): T {
-    return this.backendEngine.executeKernel(
-               'PReLUDer', {inputs: {x, alpha}}) as T;
+    return this.backendEngine.executeKernel('PReLUDer', {inputs: {x, alpha}}) as
+        T;
   }
 
   /**

--- a/src/math/math.ts
+++ b/src/math/math.ts
@@ -51,6 +51,10 @@ export class NDArrayMath implements NDArrayStorage, NDArrayManager {
   private backend: MathBackend;
   private customBackend = false;
 
+  time(query: () => NDArray): Promise<number> {
+    return this.backend.time(query);
+  }
+
   getNumArrays() {
     return this.numArrays;
   }
@@ -114,7 +118,9 @@ export class NDArrayMath implements NDArrayStorage, NDArrayManager {
     this.startScope();
 
     const keepFn = <T extends NDArray>(ndarray: T): T => this.keep(ndarray);
-    const trackFn = <T extends NDArray>(ndarray: T): T => this.track(ndarray);
+    // TODO(smilkov): trackFn is a no-op since we have global tracking.
+    // Remove when we break backward compatibility.
+    const trackFn = <T extends NDArray>(ndarray: T): T => ndarray;
     const result = scopeFn(keepFn, trackFn);
 
     if (result instanceof Promise) {
@@ -244,7 +250,7 @@ export class NDArrayMath implements NDArrayStorage, NDArrayManager {
    *
    * @param result The NDArray to track in the current scope.
    */
-  track<G extends keyof DataTypes, T extends NDArray<G>>(result: T): T {
+  private track<G extends keyof DataTypes, T extends NDArray<G>>(result: T): T {
     if (this.activeScope == null) {
       if (this.safeMode) {
         throw new Error(
@@ -686,8 +692,8 @@ export class NDArrayMath implements NDArrayStorage, NDArrayManager {
     const reduceShape = shapes[1];
     const reduceSize = util.sizeFromShape(reduceShape);
     return this.executeOp('mean', () => {
-      return this.scope((keep, track) => {
-        const res = this.divide(x, track(Scalar.new(reduceSize)));
+      return this.scope(keep => {
+        const res = this.divide(x, Scalar.new(reduceSize));
         return this.sum(res, axis, keepDims);
       });
     });

--- a/src/math/onehot_test.ts
+++ b/src/math/onehot_test.ts
@@ -15,32 +15,17 @@
  * =============================================================================
  */
 
-import {NDArrayMathCPU} from '../math/backends/backend_cpu';
-import {NDArrayMathGPU} from '../math/backends/backend_webgl';
 import * as test_util from '../test_util';
-
-import {NDArrayMath} from './math';
+import {MathTests} from '../test_util';
 import {Array1D} from './ndarray';
 
-function executeTests(mathFactory: () => NDArrayMath) {
-  let math: NDArrayMath;
-
-  beforeEach(() => {
-    math = mathFactory();
-    math.startScope();
-  });
-
-  afterEach(() => {
-    math.endScope(null);
-    math.dispose();
-  });
-
-  it('Depth 1 throws error', () => {
+const tests: MathTests = it => {
+  it('Depth 1 throws error', math => {
     const indices = Array1D.new([0, 0, 0]);
     expect(() => math.oneHot(indices, 1)).toThrowError();
   });
 
-  it('Depth 2, diagonal', () => {
+  it('Depth 2, diagonal', math => {
     const indices = Array1D.new([0, 1]);
     const res = math.oneHot(indices, 2);
     const expected = new Float32Array([1, 0, 0, 1]);
@@ -48,7 +33,7 @@ function executeTests(mathFactory: () => NDArrayMath) {
     test_util.expectArraysClose(res.getValues(), expected);
   });
 
-  it('Depth 2, transposed diagonal', () => {
+  it('Depth 2, transposed diagonal', math => {
     const indices = Array1D.new([1, 0]);
     const res = math.oneHot(indices, 2);
     const expected = new Float32Array([0, 1, 1, 0]);
@@ -56,7 +41,7 @@ function executeTests(mathFactory: () => NDArrayMath) {
     test_util.expectArraysClose(res.getValues(), expected);
   });
 
-  it('Depth 3, 4 events', () => {
+  it('Depth 3, 4 events', math => {
     const indices = Array1D.new([2, 1, 2, 0]);
     const res = math.oneHot(indices, 3);
     const expected = new Float32Array([0, 0, 1, 0, 1, 0, 0, 0, 1, 1, 0, 0]);
@@ -64,19 +49,18 @@ function executeTests(mathFactory: () => NDArrayMath) {
     test_util.expectArraysClose(res.getValues(), expected);
   });
 
-  it('Depth 2 onValue=3, offValue=-2', () => {
+  it('Depth 2 onValue=3, offValue=-2', math => {
     const indices = Array1D.new([0, 1]);
     const res = math.oneHot(indices, 2, 3, -2);
     const expected = new Float32Array([3, -2, -2, 3]);
     expect(res.shape).toEqual([2, 2]);
     test_util.expectArraysClose(res.getValues(), expected);
   });
-}
+};
 
-describe('mathCPU oneHot', () => {
-  executeTests(() => new NDArrayMathCPU());
-});
-
-describe('mathGPU oneHot', () => {
-  executeTests(() => new NDArrayMathGPU());
-});
+test_util.describeMathCPU('oneHot', [tests]);
+test_util.describeMathGPU('oneHot', [tests], [
+  {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 1},
+  {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2},
+  {'WEBGL_FLOAT_TEXTURE_ENABLED': false, 'WEBGL_VERSION': 1}
+]);

--- a/src/math/unaryop_test.ts
+++ b/src/math/unaryop_test.ts
@@ -186,12 +186,12 @@ import {Array1D, Array2D, Scalar} from './ndarray';
 {
   const tests: MathTests = it => {
     it('with 1d ndarray', math => {
-      const a = Array1D.new([1, -2, -.01, 3, -0.1]);
+      const a = Array1D.new([1, -2, -.01, 3, -0.1, 0.1]);
 
       const result = math.step(a);
 
       test_util.expectArraysClose(
-          result.getValues(), new Float32Array([1, 0, 0, 1, 0]));
+          result.getValues(), new Float32Array([1, 0, 0, 1, 0, 1]));
 
       a.dispose();
     });
@@ -217,6 +217,14 @@ import {Array1D, Array2D, Scalar} from './ndarray';
           result.getValues(), new Float32Array([1, 0, 0, 1, NaN]));
 
       a.dispose();
+    });
+
+    it('step with alpha 0.2', math => {
+      const a = Array1D.new([1, -2, 0.1]);
+      const alpha = 0.2;
+      const result = math.step(a, alpha);
+      test_util.expectArraysClose(
+          result.getValues(), new Float32Array([1, alpha, 1]));
     });
   };
 


### PR DESCRIPTION
- Call keep for private ndarrays in classes
- Use global math whenever possible
- Create math before allocating any arrays
- Export environment to the global namespace (`window` in browsers,  `global` in nodejs)
- Remove uses of `track`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/460)
<!-- Reviewable:end -->
