### PR TITLE
Add delayed upload mode in MathBackendWebGL

### DIFF
--- a/demos/imagenet/imagenet.ts
+++ b/demos/imagenet/imagenet.ts
@@ -235,6 +235,8 @@ export class ImagenetDemo extends ImagenetDemoPolymer {
           this.backend.getTextureData(activationNDArray.id).texShape,
           activationNDArray.shape[0], activationNDArray.shape[2],
           this.inferenceCanvas.width, numRows);
+      // Unclear why, but unless we wait for the gpu to fully end, we get a
+      // flicker effect.
       await maxValues.data();
       await minValues.data();
     });

--- a/demos/imagenet/imagenet.ts
+++ b/demos/imagenet/imagenet.ts
@@ -75,6 +75,13 @@ export class ImagenetDemo extends ImagenetDemoPolymer {
     this.webcamVideoElement =
         this.querySelector('#webcamVideo') as HTMLVideoElement;
 
+    const gl = gpgpu_util.createWebGLContext(this.inferenceCanvas);
+    this.gpgpu = new GPGPUContext(gl);
+    this.backend = new MathBackendWebGL(this.gpgpu);
+    const safeMode = false;
+    this.math = new NDArrayMath(this.backend, safeMode);
+    ENV.setMath(this.math);
+
     this.layerNames = [
       'conv_1', 'maxpool_1', 'fire2', 'fire3', 'maxpool_2', 'fire4', 'fire5',
       'maxpool_3', 'fire6', 'fire7', 'fire8', 'fire9', 'conv10'
@@ -100,13 +107,6 @@ export class ImagenetDemo extends ImagenetDemoPolymer {
         });
       }
     });
-
-    const gl = gpgpu_util.createWebGLContext(this.inferenceCanvas);
-    this.gpgpu = new GPGPUContext(gl);
-    this.backend = new MathBackendWebGL(this.gpgpu);
-    const safeMode = false;
-    this.math = new NDArrayMath(this.backend, safeMode);
-    ENV.setMath(this.math);
 
     this.renderGrayscaleChannelsCollageShader =
         imagenet_util.getRenderGrayscaleChannelsCollageShader(this.gpgpu);
@@ -177,20 +177,26 @@ export class ImagenetDemo extends ImagenetDemoPolymer {
 
     const isWebcam = this.selectedInputName === 'webcam';
 
-    await this.math.scope(async keep => {
+    await this.math.scope(async () => {
       if (!this.isMediaLoaded) {
         return;
       }
 
       const element =
           isWebcam ? this.webcamVideoElement : this.staticImgElement;
-      const image = Array3D.fromPixels(element);
+      const image = Array3D.fromPixels(element, 3, this.math);
 
-      const inferenceResult = await this.squeezeNet.predictWithActivation(
-          image, this.selectedLayerName);
+      const inferenceResult =
+          this.squeezeNet.predictWithActivation(image, this.selectedLayerName);
 
       const topClassesToProbability = await this.squeezeNet.getTopKClasses(
           inferenceResult.logits, TOP_K_CLASSES);
+
+      const endTime = performance.now();
+
+      const elapsed = Math.floor(1000 * (endTime - startTime)) / 1000;
+      (this.querySelector('#totalTime') as HTMLDivElement).innerHTML =
+          `last inference time: ${elapsed} ms`;
 
       let count = 0;
       for (const className in topClassesToProbability) {
@@ -203,12 +209,6 @@ export class ImagenetDemo extends ImagenetDemoPolymer {
                 .toString();
         count++;
       }
-
-      const endTime = performance.now();
-
-      const elapsed = Math.floor(1000 * (endTime - startTime)) / 1000;
-      (this.querySelector('#totalTime') as HTMLDivElement).innerHTML =
-          `last inference time: ${elapsed} ms`;
 
       // Render activations.
       const activationNDArray = inferenceResult.activation;
@@ -235,8 +235,9 @@ export class ImagenetDemo extends ImagenetDemoPolymer {
           this.backend.getTextureData(activationNDArray.id).texShape,
           activationNDArray.shape[0], activationNDArray.shape[2],
           this.inferenceCanvas.width, numRows);
+      await maxValues.data();
+      await minValues.data();
     });
-
     requestAnimationFrame(() => this.animate());
   }
 }

--- a/models/knn_image_classifier/package.json
+++ b/models/knn_image_classifier/package.json
@@ -2,9 +2,9 @@
   "name": "deeplearn-knn-image-classifier",
   "version": "0.2.1",
   "description": "A KNN Image Classifier model in deeplearn.js",
-  "main": "dist/index.js",
+  "main": "dist/knn_image_classifier/index.js",
   "unpkg": "dist/bundle.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/knn_image_classifier/index.d.ts",
   "peerDependencies": {
     "deeplearn": "0.3.15"
   },

--- a/models/mobilenet/package.json
+++ b/models/mobilenet/package.json
@@ -2,9 +2,9 @@
   "name": "deeplearn-mobilenet",
   "version": "0.1.3",
   "description": "Pretrained MobileNet model in deeplearn.js",
-  "main": "dist/index.js",
+  "main": "dist/mobilenet/index.js",
   "unpkg": "dist/bundle.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/mobilenet/index.d.ts",
   "peerDependencies": {
     "deeplearn": "0.3.15"
   },

--- a/models/mobilenet/tsconfig.json
+++ b/models/mobilenet/tsconfig.json
@@ -1,8 +1,11 @@
 {
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
   "include": [
     "index.ts",
-    "mobiletnet.ts",
+    "mobilenet.ts",
     "../util.ts"
   ],
   "exclude": [

--- a/models/squeezenet/package.json
+++ b/models/squeezenet/package.json
@@ -2,9 +2,9 @@
   "name": "deeplearn-squeezenet",
   "version": "0.1.7",
   "description": "Pretrained SqueezeNet model in deeplearn.js",
-  "main": "dist/index.js",
+  "main": "dist/squeezenet/index.js",
   "unpkg": "dist/bundle.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/squeezenet/index.d.ts",
   "peerDependencies": {
     "deeplearn": "0.3.15"
   },

--- a/models/yolo_mobilenet/tsconfig.json
+++ b/models/yolo_mobilenet/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
   "include": [
     "index.ts",
     "yolo_mobilenet.ts"

--- a/src/data/dataset.ts
+++ b/src/data/dataset.ts
@@ -15,7 +15,6 @@
  * =============================================================================
  */
 
-import {NDArrayMath} from '../math/math';
 import {NDArray} from '../math/ndarray';
 import * as util from '../util';
 
@@ -48,7 +47,7 @@ export abstract class InMemoryDataset {
   // after normalization.
   private normalizationInfo: {[dataIndex: number]: NormalizationInfo};
 
-  constructor(protected dataShapes: number[][], protected math: NDArrayMath) {
+  constructor(protected dataShapes: number[][]) {
     this.normalizationInfo = {};
   }
 
@@ -148,8 +147,8 @@ export abstract class InMemoryDataset {
               newRange * (inputValues[j] - curLowerBound) / curRange;
         }
       }
-      newExamples.push(NDArray.make(
-          example.shape, {values: normalizedValues}, 'float32', this.math));
+      newExamples.push(
+          NDArray.make(example.shape, {values: normalizedValues}, 'float32'));
     });
     return newExamples;
   }

--- a/src/data/dataset_test.ts
+++ b/src/data/dataset_test.ts
@@ -15,7 +15,6 @@
  * =============================================================================
  */
 
-import {NDArrayMath} from '../math/math';
 import {Array1D, Array2D, NDArray} from '../math/ndarray';
 import * as test_util from '../test_util';
 
@@ -23,8 +22,7 @@ import {InMemoryDataset} from './dataset';
 
 class StubDataset extends InMemoryDataset {
   constructor(data: NDArray[][]) {
-    const safeMode = false;
-    super(data.map(value => value[0].shape), new NDArrayMath('cpu', safeMode));
+    super(data.map(value => value[0].shape));
     this.dataset = data;
   }
 

--- a/src/data/xhr-dataset.ts
+++ b/src/data/xhr-dataset.ts
@@ -15,7 +15,6 @@
  * =============================================================================
  */
 
-import {NDArrayMath} from '../math/math';
 import {NDArray} from '../math/ndarray';
 import * as util from '../util';
 
@@ -38,9 +37,7 @@ export interface XhrDatasetConfig {
   modelConfigs: {[modelName: string]: XhrModelConfig};
 }
 
-export interface XhrModelConfig {
-  path: string;
-}
+export interface XhrModelConfig { path: string; }
 
 export function getXhrDatasetConfig(jsonConfigPath: string):
     Promise<{[datasetName: string]: XhrDatasetConfig}> {
@@ -65,10 +62,7 @@ export class XhrDataset extends InMemoryDataset {
   protected xhrDatasetConfig: XhrDatasetConfig;
 
   constructor(xhrDatasetConfig: XhrDatasetConfig) {
-    const safeMode = false;
-    super(
-        xhrDatasetConfig.data.map(x => x.shape),
-        new NDArrayMath('cpu', safeMode));
+    super(xhrDatasetConfig.data.map(x => x.shape));
     this.xhrDatasetConfig = xhrDatasetConfig;
   }
 
@@ -82,9 +76,9 @@ export class XhrDataset extends InMemoryDataset {
       const ndarrays: T[] = [];
       for (let i = 0; i < data.length / inputSize; i++) {
         const values = data.subarray(i * inputSize, (i + 1) * inputSize);
-        const ndarray = NDArray.make(
-                            info.shape, {values: new Float32Array(values)},
-                            'float32', this.math) as T;
+        const ndarray =
+            NDArray.make(
+                info.shape, {values: new Float32Array(values)}, 'float32') as T;
         ndarrays.push(ndarray);
       }
       return ndarrays;

--- a/src/math/backends/backend_webgl.ts
+++ b/src/math/backends/backend_webgl.ts
@@ -790,10 +790,12 @@ export class MathBackendWebGL implements MathBackend {
   }
 
   private cacheOnCPU(id: number, float32Values: Float32Array) {
-    // When we don't need immediate upload
-    const deleteFromGPU = this.delayedStorage;
+    // In delayed storage mode, when the user reads data, we don't keep a copy
+    // on the gpu, to minimize likelihood of memory leak. We re-upload to gpu
+    // the next time a gpgpu program needs the texture.
+    const dontKeepCopyOnGPU = this.delayedStorage;
     const {texture, texShape, dtype} = this.texData[id];
-    if (deleteFromGPU) {
+    if (dontKeepCopyOnGPU) {
       this.texData[id].texture = null;
       this.textureManager.releaseTexture(texture, texShape);
     }

--- a/src/math/backends/backend_webgl.ts
+++ b/src/math/backends/backend_webgl.ts
@@ -67,17 +67,10 @@ export class MathBackendWebGL implements MathBackend {
       id: number,
       pixels: ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement,
       numChannels: number): void {
-    let texture: WebGLTexture;
     const texShape: [number, number] = [pixels.height, pixels.width];
-    if (id in this.texData &&
-        util.arraysEqual(this.texData[id].texShape, texShape)) {
-      texture = this.texData[id].texture;
-    } else {
-      if (id in this.texData) {
-        this.disposeData(id);
-      }
-      texture = this.textureManager.acquireTexture(texShape);
-    }
+    const texture = id in this.texData ?
+        this.texData[id].texture :
+        this.textureManager.acquireTexture(texShape);
     this.texData[id] = {
       values: null,
       texture,

--- a/src/math/backends/backend_webgl_test.ts
+++ b/src/math/backends/backend_webgl_test.ts
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import * as test_util from '../../test_util';
+import {Tests} from '../../test_util';
+import {MathBackendWebGL} from './backend_webgl';
+
+const tests: Tests = () => {
+  it('delayed storage, reading', () => {
+    const delayedStorage = true;
+    const backend = new MathBackendWebGL(null, delayedStorage);
+    const texManager = backend.getTextureManager();
+    backend.write(0, new Float32Array([1, 2, 3]), 'float32', [3]);
+    expect(texManager.getNumUsedTextures()).toBe(0);
+    backend.getTexture(0);
+    expect(texManager.getNumUsedTextures()).toBe(1);
+    test_util.expectArraysClose(
+        backend.readSync(0), new Float32Array([1, 2, 3]));
+    expect(texManager.getNumUsedTextures()).toBe(0);
+    backend.getTexture(0);
+    expect(texManager.getNumUsedTextures()).toBe(1);
+    backend.disposeData(0);
+    expect(texManager.getNumUsedTextures()).toBe(0);
+  });
+
+  it('delayed storage, overwriting', () => {
+    const delayedStorage = true;
+    const backend = new MathBackendWebGL(null, delayedStorage);
+    const texManager = backend.getTextureManager();
+    backend.write(0, new Float32Array([1, 2, 3]), 'float32', [3]);
+    backend.getTexture(0);
+    expect(texManager.getNumUsedTextures()).toBe(1);
+    // overwrite.
+    backend.write(0, new Float32Array([4, 5, 6]), 'float32', [3]);
+    expect(texManager.getNumUsedTextures()).toBe(0);
+    test_util.expectArraysClose(
+        backend.readSync(0), new Float32Array([4, 5, 6]));
+    backend.getTexture(0);
+    expect(texManager.getNumUsedTextures()).toBe(1);
+    test_util.expectArraysClose(
+        backend.readSync(0), new Float32Array([4, 5, 6]));
+    expect(texManager.getNumUsedTextures()).toBe(0);
+  });
+
+  it('immediate storage reading', () => {
+    const delayedStorage = false;
+    const backend = new MathBackendWebGL(null, delayedStorage);
+    const texManager = backend.getTextureManager();
+    backend.write(0, new Float32Array([1, 2, 3]), 'float32', [3]);
+    expect(texManager.getNumUsedTextures()).toBe(1);
+    test_util.expectArraysClose(
+        backend.readSync(0), new Float32Array([1, 2, 3]));
+    expect(texManager.getNumUsedTextures()).toBe(1);
+    backend.disposeData(0);
+    expect(texManager.getNumUsedTextures()).toBe(0);
+  });
+
+  it('immediate storage overwriting', () => {
+    const delayedStorage = false;
+    const backend = new MathBackendWebGL(null, delayedStorage);
+    const texManager = backend.getTextureManager();
+    backend.write(0, new Float32Array([1, 2, 3]), 'float32', [3]);
+    expect(texManager.getNumUsedTextures()).toBe(1);
+    backend.write(0, new Float32Array([4, 5, 6]), 'float32', [3]);
+    expect(texManager.getNumUsedTextures()).toBe(1);
+    test_util.expectArraysClose(
+        backend.readSync(0), new Float32Array([4, 5, 6]));
+    expect(texManager.getNumUsedTextures()).toBe(1);
+    backend.disposeData(0);
+    expect(texManager.getNumUsedTextures()).toBe(0);
+  });
+
+  it('disposal of backend disposes all textures', () => {
+    const delayedStorage = false;
+    const backend = new MathBackendWebGL(null, delayedStorage);
+    const texManager = backend.getTextureManager();
+    backend.write(0, new Float32Array([1, 2, 3]), 'float32', [3]);
+    backend.write(1, new Float32Array([4, 5, 6]), 'float32', [3]);
+    expect(texManager.getNumUsedTextures()).toBe(2);
+    backend.dispose();
+    expect(texManager.getNumUsedTextures()).toBe(0);
+  });
+};
+
+test_util.describeCustom('backend_webgl', tests, [
+  {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 1},
+  {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2},
+  {'WEBGL_FLOAT_TEXTURE_ENABLED': false, 'WEBGL_VERSION': 1}
+]);

--- a/src/math/backends/webgl/tex_util.ts
+++ b/src/math/backends/webgl/tex_util.ts
@@ -30,6 +30,7 @@ export interface TextureData {
   textureType: TextureType;
   dtype: keyof DataTypes;
   numChannels?: number;
+  values: DataTypes[keyof DataTypes];
 }
 
 export function getUnpackedMatrixTextureShapeWidthHeight(

--- a/src/math/backends/webgl/texture_manager.ts
+++ b/src/math/backends/webgl/texture_manager.ts
@@ -23,6 +23,7 @@ export class TextureManager {
   private freeTextures: {[shape: string]: WebGLTexture[]} = {};
   private logEnabled = false;
   private allocatedTextures: WebGLTexture[] = [];
+  private usedTextureCount: {[shape: string]: number} = {};
 
   constructor(private gpgpu: GPGPUContext) {}
 
@@ -31,6 +32,10 @@ export class TextureManager {
     if (!(shapeKey in this.freeTextures)) {
       this.freeTextures[shapeKey] = [];
     }
+    if (!(shapeKey in this.usedTextureCount)) {
+      this.usedTextureCount[shapeKey] = 0;
+    }
+    this.usedTextureCount[shapeKey]++;
 
     if (this.freeTextures[shapeKey].length > 0) {
       this.numFreeTextures--;
@@ -54,6 +59,7 @@ export class TextureManager {
     this.freeTextures[shapeKey].push(texture);
     this.numFreeTextures++;
     this.numUsedTextures--;
+    this.usedTextureCount[shapeKey]--;
     this.log();
   }
 
@@ -81,6 +87,7 @@ export class TextureManager {
     });
     this.freeTextures = null;
     this.allocatedTextures = null;
+    this.usedTextureCount = null;
     this.numUsedTextures = 0;
     this.numFreeTextures = 0;
   }

--- a/src/math/math.ts
+++ b/src/math/math.ts
@@ -46,7 +46,7 @@ export interface NDArrayManager {
 
 export class NDArrayMath implements NDArrayStorage, NDArrayManager {
   protected backendEngine: BackendEngine;
-  private numArrays = 0;
+  private registeredArrays = new Set();
   private backend: MathBackend;
   private customBackend = false;
 
@@ -55,12 +55,15 @@ export class NDArrayMath implements NDArrayStorage, NDArrayManager {
   }
 
   getNumArrays() {
-    return this.numArrays;
+    return this.registeredArrays.size;
   }
 
   register<T extends keyof DataTypes>(a: NDArray<T>): void {
+    if (this.registeredArrays.has(a.id)) {
+      throw new Error(`NDArray with id ${a.id} was already registered`);
+    }
+    this.registeredArrays.add(a.id);
     this.backendEngine.track(a);
-    this.numArrays++;
   }
 
   writePixels(
@@ -2309,11 +2312,13 @@ export class NDArrayMath implements NDArrayStorage, NDArrayManager {
   }
 
   disposeData(id: number): void {
-    this.backend.disposeData(id);
-    // TODO(nsthorat): Construct an error and save the stack trace for
-    // debugging when in debug mode. Creating a stack trace is too expensive
-    // to do unconditionally.
-    this.numArrays--;
+    if (this.registeredArrays.has(id)) {
+      this.registeredArrays.delete(id);
+      this.backend.disposeData(id);
+      // TODO(nsthorat): Construct an error and save the stack trace for
+      // debugging when in debug mode. Creating a stack trace is too expensive
+      // to do unconditionally.
+    }
   }
 }
 

--- a/src/math/math_test.ts
+++ b/src/math/math_test.ts
@@ -52,6 +52,18 @@ import {Array1D, Array2D, Array3D, Scalar} from './ndarray';
       expect(math.getNumArrays()).toBe(0);
     });
 
+    it('multiple disposes does not affect num arrays', math => {
+      expect(math.getNumArrays()).toBe(0);
+      const a = Array1D.new([1, 2, 3]);
+      const b = Array1D.new([1, 2, 3]);
+      expect(math.getNumArrays()).toBe(2);
+      a.dispose();
+      a.dispose();
+      expect(math.getNumArrays()).toBe(1);
+      b.dispose();
+      expect(math.getNumArrays()).toBe(0);
+    });
+
     it('scope returns NDArray[]', async math => {
       const a = Array1D.new([1, 2, 3]);
       const b = Array1D.new([0, -1, 1]);
@@ -98,16 +110,16 @@ import {Array1D, Array2D, Array3D, Scalar} from './ndarray';
 
     it('scope returns Promise<NDArray>', async math => {
       const a = Array1D.new([1, 2, 3]);
-      let b = Array1D.new([0, 0, 0]);
+      const b = Array1D.new([0, 0, 0]);
 
       expect(math.getNumArrays()).toBe(2);
 
       await math.scope(async () => {
         const result = math.scope(() => {
-          b = math.add(a, b) as Array1D;
-          b = math.add(a, b) as Array1D;
-          b = math.add(a, b) as Array1D;
-          return math.add(a, b);
+          let c = math.add(a, b) as Array1D;
+          c = math.add(a, c) as Array1D;
+          c = math.add(a, c) as Array1D;
+          return math.add(a, c);
         });
 
         const data = await result.data();

--- a/src/math/ndarray.ts
+++ b/src/math/ndarray.ts
@@ -91,6 +91,8 @@ export class NDArray<T extends keyof DataTypes = keyof DataTypes> {
     if (this.id == null) {
       this.id = NDArray.nextId++;
       this.math.register(this);
+    }
+    if (values != null) {
       this.math.write(this.id, values, this.dtype, this.shape);
     }
   }

--- a/src/math/ndarray.ts
+++ b/src/math/ndarray.ts
@@ -276,7 +276,6 @@ export class NDArray<T extends keyof DataTypes = keyof DataTypes> {
     }
     const vals = this.getValues();
     vals[index] = value;
-    this.math.disposeData(this.id);
     this.math.write(this.id, vals, this.dtype, this.shape);
   }
 
@@ -310,7 +309,6 @@ export class NDArray<T extends keyof DataTypes = keyof DataTypes> {
     this.throwIfDisposed();
     const vals = this.getValues();
     vals.fill(value);
-    this.math.disposeData(this.id);
     this.math.write(this.id, vals, this.dtype, this.shape);
   }
 

--- a/src/math/ndarray.ts
+++ b/src/math/ndarray.ts
@@ -128,7 +128,9 @@ export class NDArray<T extends keyof DataTypes = keyof DataTypes> {
   /** Creates a ndarray with the same values/shape as the specified ndarray. */
   static like<G extends keyof DataTypes, T extends NDArray<G>>(another: T): T {
     const newValues = copyTypedArray(another.getValues(), another.dtype);
-    return NDArray.make(another.shape, {values: newValues}, another.dtype) as T;
+    return NDArray.make(
+               another.shape, {values: newValues}, another.dtype,
+               another.math) as T;
   }
 
   /**
@@ -169,8 +171,9 @@ export class NDArray<T extends keyof DataTypes = keyof DataTypes> {
     const ndarrayData: NDArrayData<'int32'> = {};
     const shape: [number, number, number] =
         [pixels.height, pixels.width, numChannels];
-    const res = NDArray.make(shape, ndarrayData, 'int32') as Array3D<'int32'>;
     math = math || ENV.math;
+    const res =
+        NDArray.make(shape, ndarrayData, 'int32', math) as Array3D<'int32'>;
     math.writePixels(res.id, pixels, numChannels);
     return res;
   }
@@ -190,7 +193,7 @@ export class NDArray<T extends keyof DataTypes = keyof DataTypes> {
         this.size === util.sizeFromShape(newShape),
         'new shape and old shape must have the same number of elements.');
 
-    return NDArray.make(newShape, data, this.dtype);
+    return NDArray.make(newShape, data, this.dtype, this.math);
   }
 
   /**
@@ -242,7 +245,7 @@ export class NDArray<T extends keyof DataTypes = keyof DataTypes> {
     // TODO(dsmilkov): Migrate casting to the backend.
     const vals = this.dataSync();
     const newVals = toTypedArray(vals, dtype);
-    return NDArray.make<G>(this.shape, {values: newVals}, dtype);
+    return NDArray.make<G>(this.shape, {values: newVals}, dtype, this.math);
   }
 
   get rank(): number {
@@ -829,7 +832,7 @@ export class Array4D<T extends keyof DataTypes = keyof DataTypes> extends
 }
 
 function copyTypedArray<T extends keyof DataTypes>(
-    array: DataTypes[T]|number[]|boolean[], dtype: T): DataTypes[T] {
+    array: DataTypes[T] | number[] | boolean[], dtype: T): DataTypes[T] {
   if (dtype == null || dtype === 'float32') {
     return new Float32Array(array as number[]);
   } else if (dtype === 'int32') {

--- a/src/math/ndarray.ts
+++ b/src/math/ndarray.ts
@@ -832,7 +832,7 @@ export class Array4D<T extends keyof DataTypes = keyof DataTypes> extends
 }
 
 function copyTypedArray<T extends keyof DataTypes>(
-    array: DataTypes[T] | number[] | boolean[], dtype: T): DataTypes[T] {
+    array: DataTypes[T]|number[]|boolean[], dtype: T): DataTypes[T] {
   if (dtype == null || dtype === 'float32') {
     return new Float32Array(array as number[]);
   } else if (dtype === 'int32') {


### PR DESCRIPTION
- Add delayed upload mode in `MathBackendWebGL`. When delayed mode is `true`, newly constructed `NDArray`s won't get immediately uploaded to the GPU. Also when user reads back the values, the backing texture gets disposed to reduce probability of memory leaks. Delayed mode is `true` by default.
- Fix `math.getNumArrays()`
- Fix memory leaks in Squeezenet
- Fix bugs in `models/*/package.json` (`tsc` creates different dir structure under `dist/` once we added dependency on `../util.ts`)
- Fix imagenet demo flickering

After this PR is merged, I'll release new npm versions in this order:
1) deeplearn
2) deeplearn-squeezenet
3) deeplearn-knn-image-classifier

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/466)
<!-- Reviewable:end -->
