### PR TITLE
Add math.vjp, custom gradients, softmax gradients, softmaxCrossEntropyWithLogits + gradients.

### DIFF
--- a/src/math/backends/backend_engine.ts
+++ b/src/math/backends/backend_engine.ts
@@ -100,11 +100,11 @@ export class BackendEngine {
   }
 
   customGradient<G extends DataType, T extends NDArray<G>>(
-      name: string, f: () => {
+      f: () => {
         value: T,
         gradients: (dy: T, y: T) => TapeNodeInputGradientArrays
       },
-      inputs: NamedArrayMap): T {
+      inputs: NamedArrayMap, name: string): T {
     this.customGradientDepth++;
 
     let gradientsFunc: (dy: T, y: T) => TapeNodeInputGradientArrays;
@@ -118,14 +118,11 @@ export class BackendEngine {
     this.customGradientDepth--;
 
     if (this.activeTape != null && this.customGradientDepth === 0) {
-      const inputAndArgs =
-          tape_util.stripUndefinedInputsFromInputConfig({inputs});
-
       const evaluatedNode: TapeNode<T> = {
         id: this.nextTapeNodeId++,
         type: 'customGradient',
         name,
-        inputAndArgs,
+        inputAndArgs: {inputs},
         output: result,
         gradient: gradientsFunc
       };

--- a/src/math/backends/backend_engine.ts
+++ b/src/math/backends/backend_engine.ts
@@ -109,6 +109,8 @@ export class BackendEngine {
       return f();
     }, gradientsMode);
 
+    this.customGradientDepth--;
+
     if (this.activeTape != null && this.customGradientDepth === 0) {
       const inputAndArgs =
           tape_util.stripUndefinedInputsFromInputConfig({inputs});
@@ -121,10 +123,10 @@ export class BackendEngine {
         output: result,
         gradient
       };
+
       this.activeTape.push(evaluatedNode);
     }
 
-    this.customGradientDepth--;
     return result;
   }
 

--- a/src/math/backends/tape_types.ts
+++ b/src/math/backends/tape_types.ts
@@ -24,7 +24,7 @@ export type Tape = Array<TapeNode<TapeNodeOutput>>;
 
 export type TapeNodeOutput = NDArray|NamedArrayMap;
 
-export type TapeNodeType = 'kernel'|'subtape';
+export type TapeNodeType = 'kernel'|'customGradient';
 
 export interface TapeNode<T extends TapeNodeOutput> {
   id: number;
@@ -34,7 +34,6 @@ export interface TapeNode<T extends TapeNodeOutput> {
 
   output: T;
   gradient: (dy: T, y: T) => TapeNodeInputGradientArrays;
-  subtape?: Tape;
 }
 
 export interface TapeNodeInputConfig {

--- a/src/math/backends/tape_util.ts
+++ b/src/math/backends/tape_util.ts
@@ -177,9 +177,8 @@ export function backpropagateGradients(
     for (const inputName in node.inputAndArgs.inputs) {
       if (!(inputName in inputGradients)) {
         throw new Error(
-            `Cannot backprop through input ` +
-            `${node.name}.${inputName}. Gradients found: ` +
-            `${Object.keys(inputGradients)}.`);
+            `Cannot backprop through input ${inputName}. ` +
+            `Available gradients found: ${Object.keys(inputGradients)}.`);
       }
 
       // Call the gradient function.

--- a/src/math/element_wise_arithmetic_test.ts
+++ b/src/math/element_wise_arithmetic_test.ts
@@ -685,11 +685,11 @@ import {Array1D, Array2D, Array3D, Scalar} from './ndarray';
 
       expect(gradients.a.shape).toEqual(a.shape);
       expect(gradients.a.dtype).toEqual('float32');
-      test_util.expectArraysClose(gradients.a, [1, 10, 20]);
+      test_util.expectArraysClose(gradients.a, [1, 10, 20], 1e-1);
 
       expect(gradients.b.shape).toEqual(b.shape);
       expect(gradients.b.dtype).toEqual('float32');
-      test_util.expectArraysClose(gradients.b, [-1, -10, -20]);
+      test_util.expectArraysClose(gradients.b, [-1, -10, -20], 1e-1);
     });
 
     it('gradients: basic 2D arrays', math => {
@@ -701,11 +701,11 @@ import {Array1D, Array2D, Array3D, Scalar} from './ndarray';
 
       expect(gradients.a.shape).toEqual(a.shape);
       expect(gradients.a.dtype).toEqual('float32');
-      test_util.expectArraysClose(gradients.a, [1, 10, 15, 20]);
+      test_util.expectArraysClose(gradients.a, [1, 10, 15, 20], 1e-1);
 
       expect(gradients.b.shape).toEqual(b.shape);
       expect(gradients.b.dtype).toEqual('float32');
-      test_util.expectArraysClose(gradients.b, [-1, -10, -15, -20]);
+      test_util.expectArraysClose(gradients.b, [-1, -10, -15, -20], 1e-1);
     });
   };
 

--- a/src/math/element_wise_arithmetic_test.ts
+++ b/src/math/element_wise_arithmetic_test.ts
@@ -247,32 +247,32 @@ import {Array1D, Array2D, Array3D, Scalar} from './ndarray';
     it('gradient: Array1D', math => {
       const a = Array1D.new([1, 2, 3]);
       const b = Array1D.new([3, 4, 5]);
-      const dy = Array1D.new([1, 10, 100]);
+      const dy = Array1D.new([1, 10, 20]);
       const vjp = math.vjp(() => math.multiply(a, b), {a, b}, dy);
 
       expect(vjp.a.shape).toEqual(a.shape);
       expect(vjp.b.dtype).toEqual('float32');
-      test_util.expectArraysClose(vjp.a, [3 * 1, 4 * 10, 5 * 100]);
+      test_util.expectArraysClose(vjp.a, [3 * 1, 4 * 10, 5 * 20]);
 
       expect(vjp.b.shape).toEqual(b.shape);
       expect(vjp.b.dtype).toEqual('float32');
-      test_util.expectArraysClose(vjp.b, [1 * 1, 2 * 10, 3 * 100]);
+      test_util.expectArraysClose(vjp.b, [1 * 1, 2 * 10, 3 * 20]);
     });
 
     it('gradient: Array2D', math => {
       const a = Array2D.new([2, 2], [3, 1, 2, 3]);
       const b = Array2D.new([2, 2], [1, 3, 4, 5]);
-      const dy = Array2D.new([2, 2], [1, 10, 100, 1000]);
+      const dy = Array2D.new([2, 2], [1, 10, 15, 20]);
 
       const vjp = math.vjp(() => math.multiply(a, b), {a, b}, dy);
 
       expect(vjp.a.shape).toEqual(a.shape);
       expect(vjp.a.dtype).toEqual('float32');
-      test_util.expectArraysClose(vjp.a, [1 * 1, 3 * 10, 4 * 100, 5 * 1000]);
+      test_util.expectArraysClose(vjp.a, [1 * 1, 3 * 10, 4 * 15, 5 * 20], 1e-1);
 
       expect(vjp.b.shape).toEqual(b.shape);
       expect(vjp.b.dtype).toEqual('float32');
-      test_util.expectArraysClose(vjp.b, [3 * 1, 1 * 10, 2 * 100, 3 * 1000]);
+      test_util.expectArraysClose(vjp.b, [3 * 1, 1 * 10, 2 * 15, 3 * 20], 1e-1);
     });
   };
 
@@ -375,19 +375,19 @@ import {Array1D, Array2D, Array3D, Scalar} from './ndarray';
     it('gradients: Scalar ^ Scalar', math => {
       const a = Scalar.new(5);
       const b = Scalar.new(2, 'int32');
-      const dy = Scalar.new(8);
+      const dy = Scalar.new(3);
 
       const gradients = math.vjp(() => math.pow(a, b), a, dy);
 
       expect(gradients.shape).toEqual(a.shape);
       expect(gradients.dtype).toEqual('float32');
-      test_util.expectArraysClose(gradients, [2 * 5 * 8], 1e-1);
+      test_util.expectArraysClose(gradients, [2 * 5 * 3], 1e-1);
     });
 
     it('gradients: NDArray ^ NDArray', math => {
       const a = Array1D.new([-1, .5, 2]);
       const b = Array1D.new([3, 2, -1], 'int32');
-      const dy = Array1D.new([1, 10, 100]);
+      const dy = Array1D.new([1, 5, 10]);
 
       const gradients = math.vjp(() => math.pow(a, b), a, dy);
 
@@ -396,8 +396,8 @@ import {Array1D, Array2D, Array3D, Scalar} from './ndarray';
       test_util.expectArraysClose(
           gradients,
           [
-            3 * Math.pow(-1, 2) * 1, 2 * Math.pow(.5, 1) * 10,
-            -1 * Math.pow(2, -2) * 100
+            3 * Math.pow(-1, 2) * 1, 2 * Math.pow(.5, 1) * 5,
+            -1 * Math.pow(2, -2) * 10
           ],
           1e-1);
     });
@@ -679,33 +679,33 @@ import {Array1D, Array2D, Array3D, Scalar} from './ndarray';
     it('gradients: basic 1D arrays', math => {
       const a = Array1D.new([1, 2, 3]);
       const b = Array1D.new([3, 2, 1]);
-      const dy = Array1D.new([1, 10, 100]);
+      const dy = Array1D.new([1, 10, 20]);
 
       const gradients = math.vjp(() => math.subtract(a, b), {a, b}, dy);
 
       expect(gradients.a.shape).toEqual(a.shape);
       expect(gradients.a.dtype).toEqual('float32');
-      test_util.expectArraysClose(gradients.a, [1, 10, 100]);
+      test_util.expectArraysClose(gradients.a, [1, 10, 20]);
 
       expect(gradients.b.shape).toEqual(b.shape);
       expect(gradients.b.dtype).toEqual('float32');
-      test_util.expectArraysClose(gradients.b, [-1, -10, -100]);
+      test_util.expectArraysClose(gradients.b, [-1, -10, -20]);
     });
 
     it('gradients: basic 2D arrays', math => {
       const a = Array2D.new([2, 2], [0, 1, 2, 3]);
       const b = Array2D.new([2, 2], [3, 2, 1, 0]);
-      const dy = Array2D.new([2, 2], [1, 10, 100, 1000]);
+      const dy = Array2D.new([2, 2], [1, 10, 15, 20]);
 
       const gradients = math.vjp(() => math.subtract(a, b), {a, b}, dy);
 
       expect(gradients.a.shape).toEqual(a.shape);
       expect(gradients.a.dtype).toEqual('float32');
-      test_util.expectArraysClose(gradients.a, [1, 10, 100, 1000]);
+      test_util.expectArraysClose(gradients.a, [1, 10, 15, 20]);
 
       expect(gradients.b.shape).toEqual(b.shape);
       expect(gradients.b.dtype).toEqual('float32');
-      test_util.expectArraysClose(gradients.b, [-1, -10, -100, -1000]);
+      test_util.expectArraysClose(gradients.b, [-1, -10, -15, -20]);
     });
   };
 

--- a/src/math/element_wise_arithmetic_test.ts
+++ b/src/math/element_wise_arithmetic_test.ts
@@ -228,22 +228,7 @@ import {Array1D, Array2D, Array3D, Scalar} from './ndarray';
       test_util.expectArraysClose(result, expected);
     });
 
-    it('Scalar dy = 1', math => {
-      const a = Scalar.new(5);
-      const b = Scalar.new(2);
-
-      const vjp = math.vjp(() => math.multiply(a, b), {a, b}, Scalar.new(1));
-
-      expect(vjp.a.shape).toEqual(a.shape);
-      expect(vjp.a.dtype).toEqual('float32');
-      test_util.expectArraysClose(vjp.a, b);
-
-      expect(vjp.b.shape).toEqual(b.shape);
-      expect(vjp.b.dtype).toEqual('float32');
-      test_util.expectArraysClose(vjp.b, a);
-    });
-
-    it('gradient: Scalar dy != 1', math => {
+    it('gradient: Scalar', math => {
       const a = Scalar.new(5);
       const b = Scalar.new(2);
       const dy = Scalar.new(4);
@@ -259,21 +244,7 @@ import {Array1D, Array2D, Array3D, Scalar} from './ndarray';
       test_util.expectArraysClose(vjp.b, [a.get() * dy.get()]);
     });
 
-    it('gradient: Array1D dy = 1', math => {
-      const a = Array1D.new([1, 2, 3]);
-      const b = Array1D.new([3, 4, 5]);
-      const vjp = math.gradients(() => math.sum(math.multiply(a, b)), {a, b});
-
-      expect(vjp.a.shape).toEqual(a.shape);
-      expect(vjp.b.dtype).toEqual('float32');
-      test_util.expectArraysClose(vjp.a, b);
-
-      expect(vjp.b.shape).toEqual(b.shape);
-      expect(vjp.b.dtype).toEqual('float32');
-      test_util.expectArraysClose(vjp.b, a);
-    });
-
-    it('gradient: Array1D dy != 1', math => {
+    it('gradient: Array1D', math => {
       const a = Array1D.new([1, 2, 3]);
       const b = Array1D.new([3, 4, 5]);
       const dy = Array1D.new([1, 10, 100]);
@@ -288,22 +259,7 @@ import {Array1D, Array2D, Array3D, Scalar} from './ndarray';
       test_util.expectArraysClose(vjp.b, [1 * 1, 2 * 10, 3 * 100]);
     });
 
-    it('gradient: Array2D dy = 1', math => {
-      const a = Array2D.new([2, 2], [3, 1, 2, 3]);
-      const b = Array2D.new([2, 2], [1, 3, 4, 5]);
-
-      const vjp = math.gradients(() => math.sum(math.multiply(a, b)), {a, b});
-
-      expect(vjp.a.shape).toEqual(a.shape);
-      expect(vjp.a.dtype).toEqual('float32');
-      test_util.expectArraysClose(vjp.a, [1, 3, 4, 5]);
-
-      expect(vjp.b.shape).toEqual(b.shape);
-      expect(vjp.b.dtype).toEqual('float32');
-      test_util.expectArraysClose(vjp.b, [3, 1, 2, 3]);
-    });
-
-    it('gradient: Array2D dy != 1', math => {
+    it('gradient: Array2D', math => {
       const a = Array2D.new([2, 2], [3, 1, 2, 3]);
       const b = Array2D.new([2, 2], [1, 3, 4, 5]);
       const dy = Array2D.new([2, 2], [1, 10, 100, 1000]);
@@ -416,18 +372,7 @@ import {Array1D, Array2D, Array3D, Scalar} from './ndarray';
       expect(() => math.powStrict(a, b as any)).toThrowError();
     });
 
-    it('gradients: Scalar ^ Scalar, dy = 1', math => {
-      const a = Scalar.new(5);
-      const b = Scalar.new(2, 'int32');
-
-      const gradients = math.gradients(() => math.pow(a, b), a);
-
-      expect(gradients.shape).toEqual(a.shape);
-      expect(gradients.dtype).toEqual('float32');
-      test_util.expectArraysClose(gradients, [2 * 5], 1e-1);
-    });
-
-    it('gradients: Scalar ^ Scalar, dy != 1', math => {
+    it('gradients: Scalar ^ Scalar', math => {
       const a = Scalar.new(5);
       const b = Scalar.new(2, 'int32');
       const dy = Scalar.new(8);
@@ -439,21 +384,7 @@ import {Array1D, Array2D, Array3D, Scalar} from './ndarray';
       test_util.expectArraysClose(gradients, [2 * 5 * 8], 1e-1);
     });
 
-    it('gradients: NDArray ^ NDArray, dy = 1', math => {
-      const a = Array1D.new([-1, .5, 2]);
-      const b = Array1D.new([3, 2, -1], 'int32');
-
-      const gradients = math.gradients(() => math.sum(math.pow(a, b)), a);
-
-      expect(gradients.shape).toEqual(a.shape);
-      expect(gradients.dtype).toEqual('float32');
-      test_util.expectArraysClose(
-          gradients,
-          [3 * Math.pow(-1, 2), 2 * Math.pow(.5, 1), -1 * Math.pow(2, -2)],
-          1e-1);
-    });
-
-    it('gradients: NDArray ^ NDArray, dy != 1', math => {
+    it('gradients: NDArray ^ NDArray', math => {
       const a = Array1D.new([-1, .5, 2]);
       const b = Array1D.new([3, 2, -1], 'int32');
       const dy = Array1D.new([1, 10, 100]);

--- a/src/math/element_wise_arithmetic_test.ts
+++ b/src/math/element_wise_arithmetic_test.ts
@@ -20,80 +20,9 @@ import {MathTests} from '../test_util';
 import * as util from '../util';
 import {Array1D, Array2D, Array3D, Scalar} from './ndarray';
 
-// element-wise mul / div
+// divide
 {
   const tests: MathTests = it => {
-    it('elementWiseMul same-shaped ndarrays', math => {
-      const a = Array2D.new([2, 2], [1, 2, -3, -4]);
-      const b = Array2D.new([2, 2], [5, 3, 4, -7]);
-      const expected = [5, 6, -12, 28];
-      const result = math.elementWiseMul(a, b);
-
-      expect(result.shape).toEqual([2, 2]);
-      test_util.expectArraysClose(result, expected);
-    });
-
-    it('elementWiseMul propagates NaNs', math => {
-      const a = Array2D.new([2, 2], [1, 3, 4, 0]);
-      const b = Array2D.new([2, 2], [NaN, 3, NaN, 3]);
-
-      const result = math.elementWiseMul(a, b);
-      test_util.expectArraysClose(result, [NaN, 9, NaN, 0]);
-    });
-
-    it('elementWiseMul throws when passed ndarrays of different shapes',
-       math => {
-         const a = Array2D.new([2, 3], [1, 2, -3, -4, 5, 6]);
-         const b = Array2D.new([2, 2], [5, 3, 4, -7]);
-
-         expect(() => math.elementWiseMul(a, b)).toThrowError();
-         expect(() => math.elementWiseMul(b, a)).toThrowError();
-       });
-
-    it('multiply same-shaped ndarrays', math => {
-      const a = Array2D.new([2, 2], [1, 2, -3, -4]);
-      const b = Array2D.new([2, 2], [5, 3, 4, -7]);
-      const expected = [5, 6, -12, 28];
-      const result = math.multiply(a, b);
-
-      expect(result.shape).toEqual([2, 2]);
-      test_util.expectArraysClose(result, expected);
-    });
-
-    it('multiply broadcasting ndarrays', math => {
-      const a = Array2D.new([2, 2], [1, 2, -3, -4]);
-      const b = Scalar.new(2);
-      const expected = [2, 4, -6, -8];
-      const result = math.multiply(a, b);
-
-      expect(result.shape).toEqual([2, 2]);
-      test_util.expectArraysClose(result, expected);
-    });
-
-    it('multiply broadcasting same rank NDArrays different shape', math => {
-      const a = Array2D.new([2, 2], [1, 2, -3, -4]);
-      const b = Array2D.new([2, 1], [2, 3]);
-
-      const result = math.multiply(a, b);
-
-      expect(result.shape).toEqual([2, 2]);
-      const expected = [2, 4, -9, -12];
-
-      test_util.expectArraysClose(result, expected);
-    });
-
-    it('multiply broadcast 2D + 1D', math => {
-      const a = Array2D.new([2, 2], [1, 2, -3, -4]);
-      const b = Array1D.new([1, 2]);
-
-      const result = math.multiply(a, b);
-
-      expect(result.shape).toEqual([2, 2]);
-      const expected = [1, 4, -3, -8];
-
-      test_util.expectArraysClose(result, expected);
-    });
-
     it('divide', math => {
       const a = Array2D.new([2, 3], [1, 2, 3, 4, 5, 6]);
       const c = Array2D.new([2, 3], [1, 2, 3, 4, 2, 5]);
@@ -217,84 +146,189 @@ import {Array1D, Array2D, Array3D, Scalar} from './ndarray';
     });
   };
 
-  test_util.describeMathCPU('element-wise mul/div', [tests]);
-  test_util.describeMathGPU('element-wise mul/div', [tests], [
+  test_util.describeMathCPU('divide', [tests]);
+  test_util.describeMathGPU('divide', [tests], [
     {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 1},
     {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2},
     {'WEBGL_FLOAT_TEXTURE_ENABLED': false, 'WEBGL_VERSION': 1}
   ]);
 }
 
-// Multiply gradients
+// multiply
 {
   const tests: MathTests = it => {
-    it('Scalar', math => {
+    it('elementWiseMul same-shaped ndarrays', math => {
+      const a = Array2D.new([2, 2], [1, 2, -3, -4]);
+      const b = Array2D.new([2, 2], [5, 3, 4, -7]);
+      const expected = [5, 6, -12, 28];
+      const result = math.elementWiseMul(a, b);
+
+      expect(result.shape).toEqual([2, 2]);
+      test_util.expectArraysClose(result, expected);
+    });
+
+    it('elementWiseMul propagates NaNs', math => {
+      const a = Array2D.new([2, 2], [1, 3, 4, 0]);
+      const b = Array2D.new([2, 2], [NaN, 3, NaN, 3]);
+
+      const result = math.elementWiseMul(a, b);
+      test_util.expectArraysClose(result, [NaN, 9, NaN, 0]);
+    });
+
+    it('elementWiseMul throws when passed ndarrays of different shapes',
+       math => {
+         const a = Array2D.new([2, 3], [1, 2, -3, -4, 5, 6]);
+         const b = Array2D.new([2, 2], [5, 3, 4, -7]);
+
+         expect(() => math.elementWiseMul(a, b)).toThrowError();
+         expect(() => math.elementWiseMul(b, a)).toThrowError();
+       });
+
+    it('same-shaped ndarrays', math => {
+      const a = Array2D.new([2, 2], [1, 2, -3, -4]);
+      const b = Array2D.new([2, 2], [5, 3, 4, -7]);
+      const expected = [5, 6, -12, 28];
+      const result = math.multiply(a, b);
+
+      expect(result.shape).toEqual([2, 2]);
+      test_util.expectArraysClose(result, expected);
+    });
+
+    it('broadcasting ndarrays', math => {
+      const a = Array2D.new([2, 2], [1, 2, -3, -4]);
+      const b = Scalar.new(2);
+      const expected = [2, 4, -6, -8];
+      const result = math.multiply(a, b);
+
+      expect(result.shape).toEqual([2, 2]);
+      test_util.expectArraysClose(result, expected);
+    });
+
+    it('broadcasting same rank NDArrays different shape', math => {
+      const a = Array2D.new([2, 2], [1, 2, -3, -4]);
+      const b = Array2D.new([2, 1], [2, 3]);
+
+      const result = math.multiply(a, b);
+
+      expect(result.shape).toEqual([2, 2]);
+      const expected = [2, 4, -9, -12];
+
+      test_util.expectArraysClose(result, expected);
+    });
+
+    it('broadcast 2D + 1D', math => {
+      const a = Array2D.new([2, 2], [1, 2, -3, -4]);
+      const b = Array1D.new([1, 2]);
+
+      const result = math.multiply(a, b);
+
+      expect(result.shape).toEqual([2, 2]);
+      const expected = [1, 4, -3, -8];
+
+      test_util.expectArraysClose(result, expected);
+    });
+
+    it('Scalar dy = 1', math => {
       const a = Scalar.new(5);
       const b = Scalar.new(2);
 
-      const {value, gradients} =
-          math.valueAndGradients(() => math.multiply(a, b), {a, b});
+      const vjp = math.vjp(() => math.multiply(a, b), {a, b}, Scalar.new(1));
 
-      expect(value.dtype).toEqual('float32');
-      test_util.expectArraysClose(value, [10]);
+      expect(vjp.a.shape).toEqual(a.shape);
+      expect(vjp.a.dtype).toEqual('float32');
+      test_util.expectArraysClose(vjp.a, b);
 
-      expect(gradients.a.shape).toEqual(a.shape);
-      expect(gradients.a.dtype).toEqual('float32');
-      test_util.expectArraysClose(gradients.a, [2]);
-
-      expect(gradients.b.shape).toEqual(b.shape);
-      expect(gradients.b.dtype).toEqual('float32');
-      test_util.expectArraysClose(gradients.b, [5]);
+      expect(vjp.b.shape).toEqual(b.shape);
+      expect(vjp.b.dtype).toEqual('float32');
+      test_util.expectArraysClose(vjp.b, a);
     });
 
-    it('Array1D', math => {
+    it('gradient: Scalar dy != 1', math => {
+      const a = Scalar.new(5);
+      const b = Scalar.new(2);
+      const dy = Scalar.new(4);
+
+      const vjp = math.vjp(() => math.multiply(a, b), {a, b}, dy);
+
+      expect(vjp.a.shape).toEqual(a.shape);
+      expect(vjp.a.dtype).toEqual('float32');
+      test_util.expectArraysClose(vjp.a, [b.get() * dy.get()]);
+
+      expect(vjp.b.shape).toEqual(b.shape);
+      expect(vjp.b.dtype).toEqual('float32');
+      test_util.expectArraysClose(vjp.b, [a.get() * dy.get()]);
+    });
+
+    it('gradient: Array1D dy = 1', math => {
       const a = Array1D.new([1, 2, 3]);
       const b = Array1D.new([3, 4, 5]);
+      const vjp = math.gradients(() => math.sum(math.multiply(a, b)), {a, b});
 
-      const {value, gradients} =
-          math.valueAndGradients(() => math.sum(math.multiply(a, b)), {a, b});
+      expect(vjp.a.shape).toEqual(a.shape);
+      expect(vjp.b.dtype).toEqual('float32');
+      test_util.expectArraysClose(vjp.a, b);
 
-      expect(value.dtype).toEqual('float32');
-      test_util.expectArraysClose(value, [26]);
-
-      expect(gradients.a.shape).toEqual(a.shape);
-      expect(gradients.b.dtype).toEqual('float32');
-      test_util.expectArraysClose(gradients.a, [3, 4, 5]);
-
-      expect(gradients.b.shape).toEqual(b.shape);
-      expect(gradients.b.dtype).toEqual('float32');
-      test_util.expectArraysClose(gradients.b, [1, 2, 3]);
+      expect(vjp.b.shape).toEqual(b.shape);
+      expect(vjp.b.dtype).toEqual('float32');
+      test_util.expectArraysClose(vjp.b, a);
     });
 
-    it('Array2D', math => {
+    it('gradient: Array1D dy != 1', math => {
+      const a = Array1D.new([1, 2, 3]);
+      const b = Array1D.new([3, 4, 5]);
+      const dy = Array1D.new([1, 10, 100]);
+      const vjp = math.vjp(() => math.multiply(a, b), {a, b}, dy);
+
+      expect(vjp.a.shape).toEqual(a.shape);
+      expect(vjp.b.dtype).toEqual('float32');
+      test_util.expectArraysClose(vjp.a, [3 * 1, 4 * 10, 5 * 100]);
+
+      expect(vjp.b.shape).toEqual(b.shape);
+      expect(vjp.b.dtype).toEqual('float32');
+      test_util.expectArraysClose(vjp.b, [1 * 1, 2 * 10, 3 * 100]);
+    });
+
+    it('gradient: Array2D dy = 1', math => {
       const a = Array2D.new([2, 2], [3, 1, 2, 3]);
       const b = Array2D.new([2, 2], [1, 3, 4, 5]);
 
-      const {value, gradients} =
-          math.valueAndGradients(() => math.sum(math.multiply(a, b)), {a, b});
+      const vjp = math.gradients(() => math.sum(math.multiply(a, b)), {a, b});
 
-      expect(value.dtype).toEqual('float32');
-      test_util.expectArraysClose(value, [29], 1e-1);
+      expect(vjp.a.shape).toEqual(a.shape);
+      expect(vjp.a.dtype).toEqual('float32');
+      test_util.expectArraysClose(vjp.a, [1, 3, 4, 5]);
 
-      expect(gradients.a.shape).toEqual(a.shape);
-      expect(gradients.a.dtype).toEqual('float32');
-      test_util.expectArraysClose(gradients.a, [1, 3, 4, 5]);
+      expect(vjp.b.shape).toEqual(b.shape);
+      expect(vjp.b.dtype).toEqual('float32');
+      test_util.expectArraysClose(vjp.b, [3, 1, 2, 3]);
+    });
 
-      expect(gradients.b.shape).toEqual(b.shape);
-      expect(gradients.b.dtype).toEqual('float32');
-      test_util.expectArraysClose(gradients.b, [3, 1, 2, 3]);
+    it('gradient: Array2D dy != 1', math => {
+      const a = Array2D.new([2, 2], [3, 1, 2, 3]);
+      const b = Array2D.new([2, 2], [1, 3, 4, 5]);
+      const dy = Array2D.new([2, 2], [1, 10, 100, 1000]);
+
+      const vjp = math.vjp(() => math.multiply(a, b), {a, b}, dy);
+
+      expect(vjp.a.shape).toEqual(a.shape);
+      expect(vjp.a.dtype).toEqual('float32');
+      test_util.expectArraysClose(vjp.a, [1 * 1, 3 * 10, 4 * 100, 5 * 1000]);
+
+      expect(vjp.b.shape).toEqual(b.shape);
+      expect(vjp.b.dtype).toEqual('float32');
+      test_util.expectArraysClose(vjp.b, [3 * 1, 1 * 10, 2 * 100, 3 * 1000]);
     });
   };
 
-  test_util.describeMathCPU('valueAndGradients multiply', [tests]);
-  test_util.describeMathGPU('valueAndGradients multiply', [tests], [
+  test_util.describeMathCPU('multiply', [tests]);
+  test_util.describeMathGPU('multiply', [tests], [
     {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 1},
     {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2},
     {'WEBGL_FLOAT_TEXTURE_ENABLED': false, 'WEBGL_VERSION': 1}
   ]);
 }
 
-// element-wise pow
+// pow
 {
   const tests: MathTests = it => {
     it('same-shaped ndarrays', math => {
@@ -381,45 +415,35 @@ import {Array1D, Array2D, Array3D, Scalar} from './ndarray';
       // tslint:disable-next-line
       expect(() => math.powStrict(a, b as any)).toThrowError();
     });
-  };
 
-  test_util.describeMathCPU('element-wise pow', [tests]);
-  test_util.describeMathGPU('element-wise pow', [tests], [
-    {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 1},
-    {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2},
-    {'WEBGL_FLOAT_TEXTURE_ENABLED': false, 'WEBGL_VERSION': 1}
-  ]);
-}
-
-// Pow gradients
-{
-  const tests: MathTests = it => {
-    it('Scalar ^ Scalar', math => {
+    it('gradients: Scalar ^ Scalar, dy = 1', math => {
       const a = Scalar.new(5);
       const b = Scalar.new(2, 'int32');
 
-      const {value, gradients} =
-          math.valueAndGradients(() => math.pow(a, b), a);
-
-      expect(value.shape).toEqual([]);
-      expect(value.dtype).toEqual('float32');
-      test_util.expectArraysClose(value, [25]);
+      const gradients = math.gradients(() => math.pow(a, b), a);
 
       expect(gradients.shape).toEqual(a.shape);
       expect(gradients.dtype).toEqual('float32');
-      test_util.expectArraysClose(gradients, [10], 1e-1);
+      test_util.expectArraysClose(gradients, [2 * 5], 1e-1);
     });
 
-    it('NDArray ^ NDArray', math => {
+    it('gradients: Scalar ^ Scalar, dy != 1', math => {
+      const a = Scalar.new(5);
+      const b = Scalar.new(2, 'int32');
+      const dy = Scalar.new(8);
+
+      const gradients = math.vjp(() => math.pow(a, b), a, dy);
+
+      expect(gradients.shape).toEqual(a.shape);
+      expect(gradients.dtype).toEqual('float32');
+      test_util.expectArraysClose(gradients, [2 * 5 * 8], 1e-1);
+    });
+
+    it('gradients: NDArray ^ NDArray, dy = 1', math => {
       const a = Array1D.new([-1, .5, 2]);
       const b = Array1D.new([3, 2, -1], 'int32');
 
-      const {value, gradients} =
-          math.valueAndGradients(() => math.sum(math.pow(a, b)), a);
-
-      expect(value.shape).toEqual([]);
-      expect(value.dtype).toEqual('float32');
-      test_util.expectArraysClose(value, [-1 + .25 + .5]);
+      const gradients = math.gradients(() => math.sum(math.pow(a, b)), a);
 
       expect(gradients.shape).toEqual(a.shape);
       expect(gradients.dtype).toEqual('float32');
@@ -428,10 +452,28 @@ import {Array1D, Array2D, Array3D, Scalar} from './ndarray';
           [3 * Math.pow(-1, 2), 2 * Math.pow(.5, 1), -1 * Math.pow(2, -2)],
           1e-1);
     });
+
+    it('gradients: NDArray ^ NDArray, dy != 1', math => {
+      const a = Array1D.new([-1, .5, 2]);
+      const b = Array1D.new([3, 2, -1], 'int32');
+      const dy = Array1D.new([1, 10, 100]);
+
+      const gradients = math.vjp(() => math.pow(a, b), a, dy);
+
+      expect(gradients.shape).toEqual(a.shape);
+      expect(gradients.dtype).toEqual('float32');
+      test_util.expectArraysClose(
+          gradients,
+          [
+            3 * Math.pow(-1, 2) * 1, 2 * Math.pow(.5, 1) * 10,
+            -1 * Math.pow(2, -2) * 100
+          ],
+          1e-1);
+    });
   };
 
-  test_util.describeMathCPU('pow valueAndGradients', [tests]);
-  test_util.describeMathGPU('pow valueAndGradients', [tests], [
+  test_util.describeMathCPU('pow', [tests]);
+  test_util.describeMathGPU('pow', [tests], [
     {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 1},
     {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2},
     {'WEBGL_FLOAT_TEXTURE_ENABLED': false, 'WEBGL_VERSION': 1}
@@ -491,6 +533,84 @@ import {Array1D, Array2D, Array3D, Scalar} from './ndarray';
       test_util.expectArraysClose(result, expected);
     });
 
+    it('A + B', math => {
+      const a = Array1D.new([2, 5, 1]);
+      const b = Array1D.new([4, 2, -1]);
+
+      const result = math.add(a, b);
+
+      const expected = [6, 7, 0];
+      test_util.expectArraysClose(result, expected);
+    });
+
+    it('A + B propagates NaNs', math => {
+      const a = Array1D.new([2, 5, NaN]);
+      const b = Array1D.new([4, 2, -1]);
+
+      const res = math.add(a, b);
+      test_util.expectArraysClose(res, [6, 7, NaN]);
+    });
+
+    it('A + B throws when passed ndarrays with different shape', math => {
+      const a = Array1D.new([2, 5, 1, 5]);
+      const b = Array1D.new([4, 2, -1]);
+
+      expect(() => math.add(a, b)).toThrowError();
+      expect(() => math.add(b, a)).toThrowError();
+    });
+
+    it('2D+scalar broadcast', math => {
+      const a = Array2D.new([2, 3], [1, 2, 3, 4, 5, 6]);
+      const b = Scalar.new(2);
+      const res = math.add(a, b);
+      expect(res.shape).toEqual([2, 3]);
+      test_util.expectArraysClose(res, [3, 4, 5, 6, 7, 8]);
+    });
+
+    it('scalar+1D broadcast', math => {
+      const a = Scalar.new(2);
+      const b = Array1D.new([1, 2, 3, 4, 5, 6]);
+      const res = math.add(a, b);
+      expect(res.shape).toEqual([6]);
+      test_util.expectArraysClose(res, [3, 4, 5, 6, 7, 8]);
+    });
+
+    it('2D+2D broadcast each with 1 dim', math => {
+      const a = Array2D.new([1, 3], [1, 2, 5]);
+      const b = Array2D.new([2, 1], [7, 3]);
+      const res = math.add(a, b);
+      expect(res.shape).toEqual([2, 3]);
+      test_util.expectArraysClose(res, [8, 9, 12, 4, 5, 8]);
+    });
+
+    it('2D+2D broadcast inner dim of b', math => {
+      const a = Array2D.new([2, 3], [1, 2, 5, 4, 5, 6]);
+      const b = Array2D.new([2, 1], [7, 3]);
+      const res = math.add(a, b);
+      expect(res.shape).toEqual([2, 3]);
+      test_util.expectArraysClose(res, [8, 9, 12, 7, 8, 9]);
+    });
+
+    it('3D+scalar', math => {
+      const a = Array3D.new([2, 3, 1], [1, 2, 3, 4, 5, 6]);
+      const b = Scalar.new(-1);
+      const res = math.add(a, b);
+      expect(res.shape).toEqual([2, 3, 1]);
+      test_util.expectArraysClose(res, [0, 1, 2, 3, 4, 5]);
+    });
+  };
+
+  test_util.describeMathCPU('add', [tests]);
+  test_util.describeMathGPU('add', [tests], [
+    {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 1},
+    {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2},
+    {'WEBGL_FLOAT_TEXTURE_ENABLED': false, 'WEBGL_VERSION': 1}
+  ]);
+}
+
+// subtract
+{
+  const tests: MathTests = it => {
     it('c - A', math => {
       const c = Scalar.new(5);
       const a = Array1D.new([7, 2, 3]);
@@ -625,125 +745,41 @@ import {Array1D, Array2D, Array3D, Scalar} from './ndarray';
       test_util.expectArraysClose(res, [2, 3, 4, 5, 6, 7]);
     });
 
-    it('A + B', math => {
-      const a = Array1D.new([2, 5, 1]);
-      const b = Array1D.new([4, 2, -1]);
-
-      const result = math.add(a, b);
-
-      const expected = [6, 7, 0];
-      test_util.expectArraysClose(result, expected);
-    });
-
-    it('A + B propagates NaNs', math => {
-      const a = Array1D.new([2, 5, NaN]);
-      const b = Array1D.new([4, 2, -1]);
-
-      const res = math.add(a, b);
-      test_util.expectArraysClose(res, [6, 7, NaN]);
-    });
-
-    it('A + B throws when passed ndarrays with different shape', math => {
-      const a = Array1D.new([2, 5, 1, 5]);
-      const b = Array1D.new([4, 2, -1]);
-
-      expect(() => math.add(a, b)).toThrowError();
-      expect(() => math.add(b, a)).toThrowError();
-    });
-
-    it('2D+scalar broadcast', math => {
-      const a = Array2D.new([2, 3], [1, 2, 3, 4, 5, 6]);
-      const b = Scalar.new(2);
-      const res = math.add(a, b);
-      expect(res.shape).toEqual([2, 3]);
-      test_util.expectArraysClose(res, [3, 4, 5, 6, 7, 8]);
-    });
-
-    it('scalar+1D broadcast', math => {
-      const a = Scalar.new(2);
-      const b = Array1D.new([1, 2, 3, 4, 5, 6]);
-      const res = math.add(a, b);
-      expect(res.shape).toEqual([6]);
-      test_util.expectArraysClose(res, [3, 4, 5, 6, 7, 8]);
-    });
-
-    it('2D+2D broadcast each with 1 dim', math => {
-      const a = Array2D.new([1, 3], [1, 2, 5]);
-      const b = Array2D.new([2, 1], [7, 3]);
-      const res = math.add(a, b);
-      expect(res.shape).toEqual([2, 3]);
-      test_util.expectArraysClose(res, [8, 9, 12, 4, 5, 8]);
-    });
-
-    it('2D+2D broadcast inner dim of b', math => {
-      const a = Array2D.new([2, 3], [1, 2, 5, 4, 5, 6]);
-      const b = Array2D.new([2, 1], [7, 3]);
-      const res = math.add(a, b);
-      expect(res.shape).toEqual([2, 3]);
-      test_util.expectArraysClose(res, [8, 9, 12, 7, 8, 9]);
-    });
-
-    it('3D+scalar', math => {
-      const a = Array3D.new([2, 3, 1], [1, 2, 3, 4, 5, 6]);
-      const b = Scalar.new(-1);
-      const res = math.add(a, b);
-      expect(res.shape).toEqual([2, 3, 1]);
-      test_util.expectArraysClose(res, [0, 1, 2, 3, 4, 5]);
-    });
-  };
-
-  test_util.describeMathCPU('element-wise add/sub', [tests]);
-  test_util.describeMathGPU('element-wise add/sub', [tests], [
-    {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 1},
-    {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2},
-    {'WEBGL_FLOAT_TEXTURE_ENABLED': false, 'WEBGL_VERSION': 1}
-  ]);
-}
-
-// subtract gradient
-{
-  const tests: MathTests = it => {
-    it('basic 1D arrays', math => {
+    it('gradients: basic 1D arrays', math => {
       const a = Array1D.new([1, 2, 3]);
       const b = Array1D.new([3, 2, 1]);
+      const dy = Array1D.new([1, 10, 100]);
 
-      const {value, gradients} =
-          math.valueAndGradients(() => math.sum(math.subtract(a, b)), {a, b});
-
-      expect(value.shape).toEqual([]);
-      test_util.expectArraysClose(value, [-2 + 0 + 2]);
+      const gradients = math.vjp(() => math.subtract(a, b), {a, b}, dy);
 
       expect(gradients.a.shape).toEqual(a.shape);
       expect(gradients.a.dtype).toEqual('float32');
-      test_util.expectArraysClose(gradients.a, [1, 1, 1]);
+      test_util.expectArraysClose(gradients.a, [1, 10, 100]);
 
       expect(gradients.b.shape).toEqual(b.shape);
       expect(gradients.b.dtype).toEqual('float32');
-      test_util.expectArraysClose(gradients.b, [-1, -1, -1]);
+      test_util.expectArraysClose(gradients.b, [-1, -10, -100]);
     });
 
-    it('basic 2D arrays', math => {
+    it('gradients: basic 2D arrays', math => {
       const a = Array2D.new([2, 2], [0, 1, 2, 3]);
       const b = Array2D.new([2, 2], [3, 2, 1, 0]);
+      const dy = Array2D.new([2, 2], [1, 10, 100, 1000]);
 
-      const {value, gradients} =
-          math.valueAndGradients(() => math.sum(math.subtract(a, b)), {a, b});
-
-      expect(value.shape).toEqual([]);
-      test_util.expectArraysClose(value, [-3 + -1 + 1 + 3]);
+      const gradients = math.vjp(() => math.subtract(a, b), {a, b}, dy);
 
       expect(gradients.a.shape).toEqual(a.shape);
       expect(gradients.a.dtype).toEqual('float32');
-      test_util.expectArraysClose(gradients.a, [1, 1, 1, 1]);
+      test_util.expectArraysClose(gradients.a, [1, 10, 100, 1000]);
 
       expect(gradients.b.shape).toEqual(b.shape);
       expect(gradients.b.dtype).toEqual('float32');
-      test_util.expectArraysClose(gradients.b, [-1, -1, -1, -1]);
+      test_util.expectArraysClose(gradients.b, [-1, -10, -100, -1000]);
     });
   };
 
-  test_util.describeMathCPU('subtract valueAndGradients', [tests]);
-  test_util.describeMathGPU('subtract valueAndGradients', [tests], [
+  test_util.describeMathCPU('subtract', [tests]);
+  test_util.describeMathGPU('subtract', [tests], [
     {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 1},
     {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2},
     {'WEBGL_FLOAT_TEXTURE_ENABLED': false, 'WEBGL_VERSION': 1}

--- a/src/math/math.ts
+++ b/src/math/math.ts
@@ -813,9 +813,8 @@ export class NDArrayMath implements NDArrayStorage, NDArrayManager {
         const keepDims = true;
         const lse = this.logSumExp(logits, [dim], keepDims);
         const logResult = this.subtract(logits, lse);
-        return {
-          value: this.exp(logResult) as T, gradients
-        }
+        const value = this.exp(logResult) as T;
+        return {value, gradients};
       }, {logits});
     });
   }
@@ -852,8 +851,9 @@ export class NDArrayMath implements NDArrayStorage, NDArrayManager {
     }
     if (dim !== logits.rank - 1) {
       throw Error(
-          'Softmax cross entropy along a non-last dimension is not yet supported. ' +
-          `Labels / logits was rank ${logits.rank} and dim was ${dim}`);
+          `Softmax cross entropy along a non-last dimension is not yet ` +
+          `supported. Labels / logits was rank ${logits.rank} ` +
+          `and dim was ${dim}`);
     }
 
     // Use a custom gradient for numerical stability.

--- a/src/math/math.ts
+++ b/src/math/math.ts
@@ -18,7 +18,6 @@
 import {BackendType, ENV} from '../environment';
 import * as util from '../util';
 import {NamedArrayMap} from '../util';
-
 import * as axis_util from './axis_util';
 // tslint:disable-next-line:max-line-length
 import {NDArrayStorage} from './backends/backend';
@@ -874,7 +873,7 @@ export class NDArrayMath implements NDArrayStorage, NDArrayManager {
 
           return {
             logits: () => this.multiply(
-                  dy.reshape(dyShape), this.subtract(softmaxLogits, labels)),
+                dy.reshape(dyShape), this.subtract(softmaxLogits, labels)),
             labels: () => this.multiply(
                 dy.reshape(dyShape), this.subtract(labels, softmaxLogits))
           };

--- a/src/math/math.ts
+++ b/src/math/math.ts
@@ -797,8 +797,10 @@ export class NDArrayMath implements NDArrayStorage, NDArrayManager {
 
     const gradient = (dy: T, y: T) => {
       return {
-        logits: () => this.elementWiseMul(
-            this.subtract(dy, this.sum(this.elementWiseMul(dy, y))), y)
+        logits: () => {
+          const dyTimesY = this.multiply(dy, y);
+          return this.subtract(dyTimesY, this.multiply(this.sum(dyTimesY), y));
+        }
       };
     };
 

--- a/src/math/math_test.ts
+++ b/src/math/math_test.ts
@@ -480,7 +480,7 @@ import {Array1D, Array2D, Array3D, Scalar} from './ndarray';
         const result = math.gradients(() => der, a);
 
         // New gradients shouldn't be disposed.
-        expect(math.getNumArrays()).toBeGreaterThan(numArrays);
+        expect(math.getNumArrays()).toBeGreaterThan(numArrays + 1);
         return result;
       });
 

--- a/src/math/math_test.ts
+++ b/src/math/math_test.ts
@@ -257,7 +257,7 @@ import {Array1D, Array2D, Array3D, Scalar} from './ndarray';
     it('matmul + relu', math => {
       const a = Array2D.new([2, 3], [-1, 2, -3, 10, -20, 30]);
       const b = Array2D.new([3, 2], [2, -3, 4, -1, 2, -3]);
-      const dy = Array2D.new([2, 2], [1, 10, 100, 1000]);
+      const dy = Array2D.new([2, 2], [1, 10, 20, 30]);
 
       const gradients = math.vjp(() => {
         // m = dot(a, b)

--- a/src/math/math_test.ts
+++ b/src/math/math_test.ts
@@ -287,7 +287,7 @@ import {Array1D, Array2D, Array3D, NDArray, Scalar} from './ndarray';
               MatrixOrientation.REGULAR));
     });
 
-    it('nikhil second order nested gradient vjp & gradients', math => {
+    it('second order nested gradient vjp & gradients', math => {
       const a = Scalar.new(2);
       const b = Scalar.new(3, 'int32');
 

--- a/src/math/math_test.ts
+++ b/src/math/math_test.ts
@@ -340,7 +340,7 @@ import {Array1D, Array2D, Array3D, Scalar} from './ndarray';
 
       expect(
           // tslint:disable-next-line:no-any
-          () => math.valueAndGradients(() => math.matMul(a, b) as any, {a, b}))
+          () => math.gradients(() => math.matMul(a, b) as any, {a, b}))
           .toThrowError();
     });
 
@@ -380,15 +380,15 @@ import {Array1D, Array2D, Array3D, Scalar} from './ndarray';
       test_util.expectArraysClose(
           gradients.a,
           math.matMul(
-              dedm, b, MatrixOrientation.REGULAR,
-              MatrixOrientation.TRANSPOSED));
+              dedm, b, MatrixOrientation.REGULAR, MatrixOrientation.TRANSPOSED),
+          1e-1);
 
       // de/db = dot(aT, de/dy)
       test_util.expectArraysClose(
           gradients.b,
           math.matMul(
-              a, dedm, MatrixOrientation.TRANSPOSED,
-              MatrixOrientation.REGULAR));
+              a, dedm, MatrixOrientation.TRANSPOSED, MatrixOrientation.REGULAR),
+          1e-1);
     });
 
     it('Throws is y is not a scalar', math => {
@@ -427,15 +427,15 @@ import {Array1D, Array2D, Array3D, Scalar} from './ndarray';
       test_util.expectArraysClose(
           gradients.a,
           math.matMul(
-              dedm, b, MatrixOrientation.REGULAR,
-              MatrixOrientation.TRANSPOSED));
+              dedm, b, MatrixOrientation.REGULAR, MatrixOrientation.TRANSPOSED),
+          1e-1);
 
       // de/db = dot(aT, de/dy)
       test_util.expectArraysClose(
           gradients.b,
           math.matMul(
-              a, dedm, MatrixOrientation.TRANSPOSED,
-              MatrixOrientation.REGULAR));
+              a, dedm, MatrixOrientation.TRANSPOSED, MatrixOrientation.REGULAR),
+          1e-1);
     });
 
     it('second order nested gradient', math => {
@@ -447,7 +447,7 @@ import {Array1D, Array2D, Array3D, Scalar} from './ndarray';
       }, a);
 
       expect(gradients.shape).toEqual(a.shape);
-      test_util.expectNumbersClose(gradients.get(), 6 * a.get());
+      test_util.expectNumbersClose(gradients.get(), 6 * a.get(), 1e-1);
     });
 
     it('second order with gradientsScope', math => {
@@ -465,7 +465,7 @@ import {Array1D, Array2D, Array3D, Scalar} from './ndarray';
       });
 
       expect(gradients.shape).toEqual(a.shape);
-      test_util.expectNumbersClose(gradients.get(), 6 * a.get());
+      test_util.expectNumbersClose(gradients.get(), 6 * a.get(), 1e-1);
     });
   };
 

--- a/src/math/matmul_test.ts
+++ b/src/math/matmul_test.ts
@@ -229,7 +229,7 @@ const commonTests: MathTests = it => {
   it('gradients: A * B', math => {
     const a = Array2D.new([2, 3], [1, 2, 3, 10, 20, 30]);
     const b = Array2D.new([3, 2], [2, 3, 4, 1, 2, 3]);
-    const dy = Array2D.new([2, 2], [1, 10, 100, 1000]);
+    const dy = Array2D.new([2, 2], [1, 10, 20, 30]);
 
     const gradients = math.vjp(
         () => math.matMul(

--- a/src/math/matmul_test.ts
+++ b/src/math/matmul_test.ts
@@ -226,6 +226,7 @@ const commonTests: MathTests = it => {
     test_util.expectArraysClose(result, expected);
   });
 
+  // TODO(nsthorat): fix the precision for backprop.
   it('gradients: A * B', math => {
     const a = Array2D.new([2, 3], [1, 2, 3, 10, 20, 30]);
     const b = Array2D.new([3, 2], [2, 3, 4, 1, 2, 3]);

--- a/src/math/matmul_test.ts
+++ b/src/math/matmul_test.ts
@@ -283,7 +283,7 @@ const gpuTests: MathTests = it => {
   });
 };
 
-test_util.describeMathCPU('nikhil matMul', [commonTests]);
+test_util.describeMathCPU('matMul', [commonTests]);
 test_util.describeMathGPU('matMul', [commonTests, gpuTests], [
   {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 1},
   {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2},

--- a/src/math/matmul_test.ts
+++ b/src/math/matmul_test.ts
@@ -225,6 +225,44 @@ const commonTests: MathTests = it => {
     expect(result.shape).toEqual([2, 2]);
     test_util.expectArraysClose(result, expected);
   });
+
+  it('gradients: A * B', math => {
+    const a = Array2D.new([2, 3], [1, 2, 3, 10, 20, 30]);
+    const b = Array2D.new([3, 2], [2, 3, 4, 1, 2, 3]);
+    const dy = Array2D.new([2, 2], [1, 10, 100, 1000]);
+
+    const gradients = math.vjp(
+        () => math.matMul(
+            a, b, MatrixOrientation.REGULAR, MatrixOrientation.REGULAR),
+        {a, b}, dy);
+
+    // da = dy * bT
+    test_util.expectArraysClose(
+        gradients.a,
+        [
+          dy.get(0, 0) * b.get(0, 0) + dy.get(0, 1) * b.get(0, 1),
+          dy.get(0, 0) * b.get(1, 0) + dy.get(0, 1) * b.get(1, 1),
+          dy.get(0, 0) * b.get(2, 0) + dy.get(0, 1) * b.get(2, 1),
+          dy.get(1, 0) * b.get(0, 0) + dy.get(1, 1) * b.get(0, 1),
+          dy.get(1, 0) * b.get(1, 0) + dy.get(1, 1) * b.get(1, 1),
+          dy.get(1, 0) * b.get(2, 0) + dy.get(1, 1) * b.get(2, 1)
+        ],
+        1e-1);
+
+    // db = aT * dy
+    expect(gradients.b.shape).toEqual(b.shape);
+    test_util.expectArraysClose(
+        gradients.b,
+        [
+          a.get(0, 0) * dy.get(0, 0) + a.get(1, 0) * dy.get(1, 0),
+          a.get(0, 0) * dy.get(0, 1) + a.get(1, 0) * dy.get(1, 1),
+          a.get(0, 1) * dy.get(0, 0) + a.get(1, 1) * dy.get(1, 0),
+          a.get(0, 1) * dy.get(0, 1) + a.get(1, 1) * dy.get(1, 1),
+          a.get(0, 2) * dy.get(0, 0) + a.get(1, 2) * dy.get(1, 0),
+          a.get(0, 2) * dy.get(0, 1) + a.get(1, 2) * dy.get(1, 1)
+        ],
+        1e-1);
+  });
 };
 
 const gpuTests: MathTests = it => {
@@ -245,54 +283,9 @@ const gpuTests: MathTests = it => {
   });
 };
 
-// TODO(nsthorat): fix the precision for backprop.
-const gradientTests: MathTests = it => {
-  it('nikhil MatMul gradient A * B', math => {
-    const a = Array2D.new([2, 3], [1, 2, 3, 10, 20, 30]);
-    const b = Array2D.new([3, 2], [2, 3, 4, 1, 2, 3]);
-    const dy = 1;
-
-    const {value, gradients} = math.valueAndGradients(() => {
-      return math.sum(math.matMul(
-          a, b, MatrixOrientation.REGULAR, MatrixOrientation.REGULAR));
-    }, {a, b});
-
-    test_util.expectNumbersClose(value.get(), 330, 1e-1);
-
-    test_util.expectNumbersClose(
-        gradients.a.get(0, 0), dy * b.get(0, 0) + dy * b.get(0, 1), 1e-1);
-    test_util.expectNumbersClose(
-        gradients.a.get(0, 1), dy * b.get(1, 0) + dy * b.get(1, 1), 1e-1);
-    test_util.expectNumbersClose(
-        gradients.a.get(0, 2), dy * b.get(2, 0) + dy * b.get(2, 1), 1e-1);
-    test_util.expectNumbersClose(
-        gradients.a.get(1, 0), dy * b.get(0, 0) + dy * b.get(0, 1), 1e-1);
-    test_util.expectNumbersClose(
-        gradients.a.get(1, 1), dy * b.get(1, 0) + dy * b.get(1, 1), 1e-1);
-    test_util.expectNumbersClose(
-        gradients.a.get(1, 2), dy * b.get(2, 0) + dy * b.get(2, 1), 1e-1);
-
-    // db = aT * dy
-    expect(gradients.b.shape).toEqual(b.shape);
-    test_util.expectNumbersClose(
-        gradients.b.get(0, 0), a.get(0, 0) * dy + a.get(1, 0) * dy, 1e-1);
-    test_util.expectNumbersClose(
-        gradients.b.get(0, 1), a.get(0, 0) * dy + a.get(1, 0) * dy, 1e-1);
-    test_util.expectNumbersClose(
-        gradients.b.get(1, 0), a.get(0, 1) * dy + a.get(1, 1) * dy, 1e-1);
-    test_util.expectNumbersClose(
-        gradients.b.get(1, 1), a.get(0, 1) * dy + a.get(1, 1) * dy, 1e-1);
-    test_util.expectNumbersClose(
-        gradients.b.get(2, 0), a.get(0, 2) * dy + a.get(1, 2) * dy, 1e-1);
-    test_util.expectNumbersClose(
-        gradients.b.get(2, 1), a.get(0, 2) * dy + a.get(1, 2) * dy, 1e-1);
-  });
-};
-
-test_util.describeMathCPU('gradients matMul', [commonTests, gradientTests]);
-test_util.describeMathGPU(
-    'gradients matMul', [commonTests, gpuTests, gradientTests], [
-      {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 1},
-      {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2},
-      {'WEBGL_FLOAT_TEXTURE_ENABLED': false, 'WEBGL_VERSION': 1}
-    ]);
+test_util.describeMathCPU('nikhil matMul', [commonTests]);
+test_util.describeMathGPU('matMul', [commonTests, gpuTests], [
+  {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 1},
+  {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2},
+  {'WEBGL_FLOAT_TEXTURE_ENABLED': false, 'WEBGL_VERSION': 1}
+]);

--- a/src/math/reduction_ops_test.ts
+++ b/src/math/reduction_ops_test.ts
@@ -479,61 +479,21 @@ import * as reduce_util from './reduce_util';
       expect(res.shape).toEqual([]);
       test_util.expectArraysClose(res, [7]);
     });
+
+    it('gradients: basic', math => {
+      const a = Array2D.new([3, 2], [1, 2, 3, 0, 0, 1]);
+      const dy = Scalar.new(10);
+
+      const gradients = math.vjp(() => math.sum(a), a, dy);
+
+      expect(gradients.shape).toEqual(a.shape);
+      expect(gradients.dtype).toEqual('float32');
+      test_util.expectArraysClose(gradients, [10, 10, 10, 10, 10, 10]);
+    });
   };
 
   test_util.describeMathCPU('sum', [tests]);
   test_util.describeMathGPU('sum', [tests], [
-    {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 1},
-    {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2},
-    {'WEBGL_FLOAT_TEXTURE_ENABLED': false, 'WEBGL_VERSION': 1}
-  ]);
-}
-
-// math.sum gradient
-{
-  const tests: MathTests = it => {
-    it('valueAndGradients basic', math => {
-      const a = Array2D.new([3, 2], [1, 2, 3, 0, 0, 1]);
-      const {value, gradients} = math.valueAndGradients(() => math.sum(a), a);
-
-      expect(value.shape).toEqual([]);
-      expect(value.dtype).toEqual('float32');
-      test_util.expectArraysClose(value, [7]);
-
-      expect(gradients.shape).toEqual(a.shape);
-      expect(gradients.dtype).toEqual('float32');
-      test_util.expectArraysClose(gradients, [1, 1, 1, 1, 1, 1]);
-    });
-
-    it('gradients basic', math => {
-      const a = Array2D.new([3, 2], [1, 2, 3, 0, 0, 1]);
-      const gradients = math.gradients(() => math.sum(a), a);
-
-      expect(gradients.shape).toEqual(a.shape);
-      expect(gradients.dtype).toEqual('float32');
-      test_util.expectArraysClose(gradients, [1, 1, 1, 1, 1, 1]);
-    });
-
-    it('valueAndGradients sums all values in 2D array with keep dim', math => {
-      const a = Array2D.new([3, 2], [1, 2, 3, 0, 0, 1]);
-
-      const {value, gradients} = math.valueAndGradients(() => {
-        const res = math.sum(a, null, true /* keepDims */);
-        return math.sum(res);
-      }, a);
-
-      expect(value.shape).toEqual([]);
-      expect(value.dtype).toEqual('float32');
-      test_util.expectArraysClose(value, [7]);
-
-      expect(gradients.shape).toEqual(a.shape);
-      expect(gradients.dtype).toEqual('float32');
-      test_util.expectArraysClose(gradients, [1, 1, 1, 1, 1, 1]);
-    });
-  };
-
-  test_util.describeMathCPU('gradients sum', [tests]);
-  test_util.describeMathGPU('gradients sum', [tests], [
     {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 1},
     {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2},
     {'WEBGL_FLOAT_TEXTURE_ENABLED': false, 'WEBGL_VERSION': 1}

--- a/src/math/reduction_ops_test.ts
+++ b/src/math/reduction_ops_test.ts
@@ -533,6 +533,17 @@ import * as reduce_util from './reduce_util';
       expect(res.shape).toEqual([]);
       test_util.expectArraysClose(res, [7]);
     });
+
+    it('gradients: basic', math => {
+      const a = Array2D.new([3, 2], [1, 2, 3, 0, 0, 1]);
+      const dy = Scalar.new(10);
+
+      const gradients = math.vjp(() => math.sum(a), a, dy);
+
+      expect(gradients.shape).toEqual(a.shape);
+      expect(gradients.dtype).toEqual('float32');
+      test_util.expectArraysClose(gradients, [10, 10, 10, 10, 10, 10]);
+    });
   };
 
   test_util.describeMathCPU('sum', [tests]);
@@ -541,27 +552,6 @@ import * as reduce_util from './reduce_util';
     {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2},
     {'WEBGL_FLOAT_TEXTURE_ENABLED': false, 'WEBGL_VERSION': 1}
   ]);
-}
-
-it('gradients: basic', math => {
-  const a = Array2D.new([3, 2], [1, 2, 3, 0, 0, 1]);
-  const dy = Scalar.new(10);
-
-  const gradients = math.vjp(() => math.sum(a), a, dy);
-
-  expect(gradients.shape).toEqual(a.shape);
-  expect(gradients.dtype).toEqual('float32');
-  test_util.expectArraysClose(gradients, [10, 10, 10, 10, 10, 10]);
-});
-}
-;
-
-test_util.describeMathCPU('sum', [tests]);
-test_util.describeMathGPU('sum', [tests], [
-  {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 1},
-  {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2},
-  {'WEBGL_FLOAT_TEXTURE_ENABLED': false, 'WEBGL_VERSION': 1}
-]);
 }
 
 // math.mean

--- a/src/math/softmax_test.ts
+++ b/src/math/softmax_test.ts
@@ -18,84 +18,247 @@
 import * as test_util from '../test_util';
 import {MathTests} from '../test_util';
 
-import {Array1D, Array2D} from './ndarray';
+import {Array1D, Array2D, Scalar} from './ndarray';
 
-const tests: MathTests = it => {
-  it('regular test', math => {
-    const y = math.softmax(Array1D.new([2, 1, 3]));
+// softmax
+{
+  const tests: MathTests = it => {
+    it('regular test', math => {
+      const y = math.softmax(Array1D.new([2, 1, 3]));
 
-    test_util.expectArraysClose(y, [0.24472847, 0.09003057, 0.66524095]);
-    test_util.expectNumbersClose(y.get(0) + y.get(1) + y.get(2), 1);
-  });
+      test_util.expectArraysClose(y, [0.24472847, 0.09003057, 0.66524095]);
+      test_util.expectNumbersClose(y.get(0) + y.get(1) + y.get(2), 1);
+    });
 
-  it('overflow', math => {
-    const y = math.softmax(Array1D.new([1000, 1000]));
+    it('overflow', math => {
+      const y = math.softmax(Array1D.new([1000, 1000]));
 
-    test_util.expectArraysClose(y, [0.5, 0.5]);
-  });
+      test_util.expectArraysClose(y, [0.5, 0.5]);
+    });
 
-  it('underflow', math => {
-    const y = math.softmax(Array1D.new([-1000, -1000]));
+    it('underflow', math => {
+      const y = math.softmax(Array1D.new([-1000, -1000]));
 
-    test_util.expectArraysClose(y, [0.5, 0.5]);
-  });
+      test_util.expectArraysClose(y, [0.5, 0.5]);
+    });
 
-  it('Huge difference between probabilities', math => {
-    const y = math.softmax(Array1D.new([-1000, +1000]));
+    it('Huge difference between probabilities', math => {
+      const y = math.softmax(Array1D.new([-1000, +1000]));
 
-    test_util.expectArraysClose(y, [0, 1]);
-  });
+      test_util.expectArraysClose(y, [0, 1]);
+    });
 
-  it('Propagates NaNs', math => {
-    const a = Array1D.new([2, 1, NaN]);
-    const y = math.softmax(a);
-    test_util.expectArraysClose(y, [NaN, NaN, NaN]);
-  });
+    it('Propagates NaNs', math => {
+      const a = Array1D.new([2, 1, NaN]);
+      const y = math.softmax(a);
+      test_util.expectArraysClose(y, [NaN, NaN, NaN]);
+    });
 
-  it('2D, dim=1', math => {
-    const y = math.softmax(Array2D.new([2, 3], [[2, 1, 3], [1, 3, 2]]), 1);
-    const expected = [
-      0.24472847, 0.09003057, 0.66524095, 0.09003057, 0.66524095, 0.24472847
-    ];
-    expect(y.rank).toBe(2);
-    test_util.expectArraysClose(y, expected);
-  });
+    it('2D, dim=1', math => {
+      const y = math.softmax(Array2D.new([2, 3], [[2, 1, 3], [1, 3, 2]]), 1);
+      const expected = [
+        0.24472847, 0.09003057, 0.66524095, 0.09003057, 0.66524095, 0.24472847
+      ];
+      expect(y.rank).toBe(2);
+      test_util.expectArraysClose(y, expected);
+    });
 
-  it('2D, implicit dim=1', math => {
-    const y = math.softmax(Array2D.new([2, 3], [[2, 1, 3], [1, 3, 2]]));
-    const expected = [
-      0.24472847, 0.09003057, 0.66524095, 0.09003057, 0.66524095, 0.24472847
-    ];
-    expect(y.rank).toBe(2);
-    test_util.expectArraysClose(y, expected);
-  });
+    it('2D, implicit dim=1', math => {
+      const y = math.softmax(Array2D.new([2, 3], [[2, 1, 3], [1, 3, 2]]));
+      const expected = [
+        0.24472847, 0.09003057, 0.66524095, 0.09003057, 0.66524095, 0.24472847
+      ];
+      expect(y.rank).toBe(2);
+      test_util.expectArraysClose(y, expected);
+    });
 
-  it('2D, dim=0 throws error', math => {
-    const f = () => {
-      math.softmax(Array2D.new([2, 3], [[2, 1, 3], [1, 3, 2]]), 0);
-    };
-    expect(f).toThrowError();
-  });
+    it('2D, dim=0 throws error', math => {
+      const f = () => {
+        math.softmax(Array2D.new([2, 3], [[2, 1, 3], [1, 3, 2]]), 0);
+      };
+      expect(f).toThrowError();
+    });
 
-  it('gradient', math => {
-    const x = Array1D.new([10, 0, -1]);
-    const y = math.softmax(x);
-    const dy = Array1D.new([1, 10, 20]);
-    const vjp = math.vjp(() => math.softmax(x), {x}, dy);
+    it('1D gradient', math => {
+      const x = Array1D.new([10, 0, -1]);
+      const y = math.softmax(x);
+      const dy = Array1D.new([1, 2, 3]);
+      const vjp = math.vjp(() => math.softmax(x), {x}, dy);
 
-    const totalSum = math.sum(math.elementWiseMul(dy, y));
+      const totalSum = math.sum(math.elementWiseMul(dy, y));
 
-    test_util.expectArraysClose(vjp.x, [
-      (dy.get(0) - totalSum.get()) * y.get(0),
-      (dy.get(1) - totalSum.get()) * y.get(1),
-      (dy.get(2) - totalSum.get()) * y.get(2)
-    ]);
-  });
-};
+      expect(vjp.x.shape).toEqual(x.shape);
+      test_util.expectArraysClose(vjp.x, [
+        (dy.get(0) - totalSum.get()) * y.get(0),
+        (dy.get(1) - totalSum.get()) * y.get(1),
+        (dy.get(2) - totalSum.get()) * y.get(2)
+      ]);
+    });
 
-test_util.describeMathCPU('softmax', [tests]);
-test_util.describeMathGPU('softmax', [tests], [
-  {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 1},
-  {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2},
-  {'WEBGL_FLOAT_TEXTURE_ENABLED': false, 'WEBGL_VERSION': 1}
-]);
+    it('2D gradient', math => {
+      const x = Array2D.new([2, 3], [10, 0, -1, 5, 4, 3]);
+      const y = math.softmax(x);
+      const dy = Array2D.new([2, 3], [3, 2, 1, 1, 2, 3]);
+      const vjp = math.vjp(() => math.softmax(x), {x}, dy);
+
+      const axis = -1;
+      const totalSum = math.sum(math.elementWiseMul(dy, y), axis);
+
+      expect(vjp.x.shape).toEqual(x.shape);
+      test_util.expectArraysClose(vjp.x, [
+        (dy.get(0, 0) - totalSum.get(0)) * y.get(0, 0),
+        (dy.get(0, 1) - totalSum.get(0)) * y.get(0, 1),
+        (dy.get(0, 2) - totalSum.get(0)) * y.get(0, 2),
+        (dy.get(1, 0) - totalSum.get(1)) * y.get(1, 0),
+        (dy.get(1, 1) - totalSum.get(1)) * y.get(1, 1),
+        (dy.get(1, 2) - totalSum.get(1)) * y.get(1, 2)
+      ]);
+    });
+  };
+
+  test_util.describeMathCPU('softmax', [tests]);
+  test_util.describeMathGPU('softmax', [tests], [
+    {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 1},
+    {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2},
+    {'WEBGL_FLOAT_TEXTURE_ENABLED': false, 'WEBGL_VERSION': 1}
+  ]);
+}
+{
+  const tests: MathTests = it => {
+    it('1D', math => {
+      const logits = Array1D.new([1, 2, 3]);
+      const label = Array1D.new([0.3, 0.6, 0.1]);
+      const softmaxLogits = math.softmax(logits);
+
+      const y = math.softmaxCrossEntropyWithLogits(label, logits);
+
+      expect(y.shape).toEqual([]);
+      test_util.expectNumbersClose(
+          y.get(),
+          -Math.log(softmaxLogits.get(0)) * label.get(0) +
+              -Math.log(softmaxLogits.get(1)) * label.get(1) +
+              -Math.log(softmaxLogits.get(2)) * label.get(2));
+    });
+
+    it('2D implicit dim', math => {
+      const logits = Array2D.new([2, 3], [1, 2, 3, 4, 5, 6]);
+      const label = Array2D.new([2, 3], [0.3, 0.6, 0.1, 0.2, 0.3, 0.5]);
+      const softmaxLogits = math.softmax(logits);
+
+      const y = math.softmaxCrossEntropyWithLogits(label, logits);
+
+      expect(y.shape).toEqual([2]);
+      test_util.expectArraysClose(y, [
+        -Math.log(softmaxLogits.get(0, 0)) * label.get(0, 0) +
+            -Math.log(softmaxLogits.get(0, 1)) * label.get(0, 1) +
+            -Math.log(softmaxLogits.get(0, 2)) * label.get(0, 2),
+        -Math.log(softmaxLogits.get(1, 0)) * label.get(1, 0) +
+            -Math.log(softmaxLogits.get(1, 1)) * label.get(1, 1) +
+            -Math.log(softmaxLogits.get(1, 2)) * label.get(1, 2)
+      ]);
+    });
+
+    it('2D, dim=1', math => {
+      const logits = Array2D.new([2, 3], [1, 2, 3, 4, 5, 6]);
+      const label = Array2D.new([2, 3], [0.3, 0.6, 0.1, 0.2, 0.3, 0.5]);
+      const dim = 1;
+      const softmaxLogits = math.softmax(logits, dim);
+
+      const y = math.softmaxCrossEntropyWithLogits(label, logits, dim);
+
+      expect(y.shape).toEqual([2]);
+      test_util.expectArraysClose(y, [
+        -Math.log(softmaxLogits.get(0, 0)) * label.get(0, 0) +
+            -Math.log(softmaxLogits.get(0, 1)) * label.get(0, 1) +
+            -Math.log(softmaxLogits.get(0, 2)) * label.get(0, 2),
+        -Math.log(softmaxLogits.get(1, 0)) * label.get(1, 0) +
+            -Math.log(softmaxLogits.get(1, 1)) * label.get(1, 1) +
+            -Math.log(softmaxLogits.get(1, 2)) * label.get(1, 2)
+      ]);
+    });
+
+    it('2D, dim=0', math => {
+      const logits = Array2D.new([2, 3], [1, 2, 3, 4, 5, 6]);
+      const label = Array2D.new([2, 3], [0.3, 0.6, 0.1, 0.2, 0.3, 0.5]);
+      const dim = 0;
+
+      expect(() => math.softmaxCrossEntropyWithLogits(label, logits, dim))
+          .toThrowError();
+    });
+
+    it('Propagates NaNs', math => {
+      const logits = Array1D.new([1, 2, NaN]);
+      const label = Array1D.new([0.3, 0.6, 0.1]);
+
+      const y = math.softmaxCrossEntropyWithLogits(label, logits);
+
+      expect(y.shape).toEqual([]);
+      test_util.expectArraysClose(y, [NaN]);
+    });
+
+    it('1D gradient', math => {
+      const logits = Array1D.new([1, 2, 3]);
+      const labels = Array1D.new([0.3, 0.6, 0.1]);
+      const softmaxLogits = math.softmax(logits);
+      const dy = Scalar.new(2);
+
+      const vjp = math.vjp(
+          () => math.softmaxCrossEntropyWithLogits(labels, logits),
+          {labels, logits}, dy);
+
+      expect(vjp.logits.shape).toEqual(logits.shape);
+      expect(vjp.labels.shape).toEqual(labels.shape);
+
+      test_util.expectArraysClose(vjp.logits, [
+        dy.get() * (softmaxLogits.get(0) - labels.get(0)),
+        dy.get() * (softmaxLogits.get(1) - labels.get(1)),
+        dy.get() * (softmaxLogits.get(2) - labels.get(2))
+      ]);
+
+      test_util.expectArraysClose(vjp.labels, [
+        dy.get() * (labels.get(0) - softmaxLogits.get(0)),
+        dy.get() * (labels.get(1) - softmaxLogits.get(1)),
+        dy.get() * (labels.get(2) - softmaxLogits.get(2))
+      ]);
+    });
+
+    it('2D gradient', math => {
+      const logits = Array2D.new([2, 3], [1, 2, 3, 4, 5, 6]);
+      const labels = Array2D.new([2, 3], [0.3, 0.6, 0.1, .2, .3, .5]);
+      const softmaxLogits = math.softmax(logits);
+      const dy = Array1D.new([2, 4]);
+
+      const vjp = math.vjp(
+          () => math.softmaxCrossEntropyWithLogits(labels, logits),
+          {labels, logits}, dy);
+
+      expect(vjp.logits.shape).toEqual(logits.shape);
+      expect(vjp.labels.shape).toEqual(labels.shape);
+
+      test_util.expectArraysClose(vjp.logits, [
+        dy.get(0) * (softmaxLogits.get(0, 0) - labels.get(0, 0)),
+        dy.get(0) * (softmaxLogits.get(0, 1) - labels.get(0, 1)),
+        dy.get(0) * (softmaxLogits.get(0, 2) - labels.get(0, 2)),
+        dy.get(1) * (softmaxLogits.get(1, 0) - labels.get(1, 0)),
+        dy.get(1) * (softmaxLogits.get(1, 1) - labels.get(1, 1)),
+        dy.get(1) * (softmaxLogits.get(1, 2) - labels.get(1, 2))
+      ]);
+
+      test_util.expectArraysClose(vjp.labels, [
+        dy.get(0) * (labels.get(0, 0) - softmaxLogits.get(0, 0)),
+        dy.get(0) * (labels.get(0, 1) - softmaxLogits.get(0, 1)),
+        dy.get(0) * (labels.get(0, 2) - softmaxLogits.get(0, 2)),
+        dy.get(1) * (labels.get(1, 0) - softmaxLogits.get(1, 0)),
+        dy.get(1) * (labels.get(1, 1) - softmaxLogits.get(1, 1)),
+        dy.get(1) * (labels.get(1, 2) - softmaxLogits.get(1, 2))
+      ]);
+    });
+  };
+
+  test_util.describeMathCPU('softmaxCrossEntropyWithLogits', [tests]);
+  test_util.describeMathGPU('softmaxCrossEntropyWithLogits', [tests], [
+    {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 1},
+    {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2},
+    {'WEBGL_FLOAT_TEXTURE_ENABLED': false, 'WEBGL_VERSION': 1}
+  ]);
+}

--- a/src/math/softmax_test.ts
+++ b/src/math/softmax_test.ts
@@ -80,14 +80,15 @@ const tests: MathTests = it => {
   it('gradient', math => {
     const x = Array1D.new([10, 0, -1]);
     const y = math.softmax(x);
-    const dy = Array1D.new([1, 10, 100]);
+    const dy = Array1D.new([1, 10, 20]);
     const vjp = math.vjp(() => math.softmax(x), {x}, dy);
 
-    const sum = 10 * 1 + 10 * 0 + -1 * 100;
+    const totalSum = math.sum(math.elementWiseMul(dy, y));
 
     test_util.expectArraysClose(vjp.x, [
-      (dy.get(0) - sum) * y.get(0), (dy.get(1) - sum) * y.get(1),
-      (dy.get(2) - sum) * y.get(2)
+      (dy.get(0) - totalSum.get()) * y.get(0),
+      (dy.get(1) - totalSum.get()) * y.get(1),
+      (dy.get(2) - totalSum.get()) * y.get(2)
     ]);
   });
 };

--- a/src/math/softmax_test.ts
+++ b/src/math/softmax_test.ts
@@ -85,7 +85,7 @@ import {Array1D, Array2D, Scalar} from './ndarray';
       const dy = Array1D.new([1, 2, 3]);
       const vjp = math.vjp(() => math.softmax(x), {x}, dy);
 
-      const totalSum = math.sum(math.elementWiseMul(dy, y));
+      const totalSum = math.sum(math.multiply(dy, y));
 
       expect(vjp.x.shape).toEqual(x.shape);
       test_util.expectArraysClose(vjp.x, [

--- a/src/math/softmax_test.ts
+++ b/src/math/softmax_test.ts
@@ -177,7 +177,7 @@ import {Array1D, Array2D, Scalar} from './ndarray';
       ]);
     });
 
-    it('2D, dim=0', math => {
+    it('2D, dim=0 throws error', math => {
       const logits = Array2D.new([2, 3], [1, 2, 3, 4, 5, 6]);
       const label = Array2D.new([2, 3], [0.3, 0.6, 0.1, 0.2, 0.3, 0.5]);
       const dim = 0;

--- a/src/math/softmax_test.ts
+++ b/src/math/softmax_test.ts
@@ -76,6 +76,20 @@ const tests: MathTests = it => {
     };
     expect(f).toThrowError();
   });
+
+  it('gradient', math => {
+    const x = Array1D.new([10, 0, -1]);
+    const y = math.softmax(x);
+    const dy = Array1D.new([1, 10, 100]);
+    const vjp = math.vjp(() => math.softmax(x), {x}, dy);
+
+    const sum = 10 * 1 + 10 * 0 + -1 * 100;
+
+    test_util.expectArraysClose(vjp.x, [
+      (dy.get(0) - sum) * y.get(0), (dy.get(1) - sum) * y.get(1),
+      (dy.get(2) - sum) * y.get(2)
+    ]);
+  });
 };
 
 test_util.describeMathCPU('softmax', [tests]);

--- a/src/math/unaryop_test.ts
+++ b/src/math/unaryop_test.ts
@@ -94,13 +94,13 @@ import {Array1D, Array2D, Scalar} from './ndarray';
     it('gradients: array', math => {
       // TODO(nsthorat): Use 0 instead of -.001 when we fix the precision
       const a = Array2D.new([2, 2], [1, -1, -.001, .1]);
-      const dy = Array2D.new([2, 2], [1, 10, 100, 1000]);
+      const dy = Array2D.new([2, 2], [1, 2, 3, 4]);
 
       const gradients = math.vjp(() => math.relu(a), a, dy);
 
       expect(gradients.shape).toEqual(a.shape);
       expect(gradients.dtype).toEqual('float32');
-      test_util.expectArraysClose(gradients, [1, 0, 0, 1000]);
+      test_util.expectArraysClose(gradients, [1, 0, 0, 4]);
     });
   };
 
@@ -278,30 +278,30 @@ import {Array1D, Array2D, Scalar} from './ndarray';
 
       expect(gradients.shape).toEqual(a.shape);
       expect(gradients.dtype).toEqual('float32');
-      test_util.expectArraysClose(gradients, [2 * 5 * 8]);
+      test_util.expectArraysClose(gradients, [2 * 5 * 8], 1e-1);
     });
 
     it('gradients: Array1D', math => {
       const a = Array1D.new([-1, 2, 3, -5]);
-      const dy = Array1D.new([1, 10, 100, 1000]);
+      const dy = Array1D.new([1, 2, 3, 4]);
 
       const gradients = math.vjp(() => math.square(a), a, dy);
 
       expect(gradients.shape).toEqual(a.shape);
       expect(gradients.dtype).toEqual('float32');
-      test_util.expectArraysClose(gradients, [-2, 4, 6, -10], 1e-1);
+      test_util.expectArraysClose(gradients, [-2, 4 * 2, 6 * 3, -10 * 4], 1e-1);
     });
 
     it('gradients: Array2D', math => {
       const a = Array2D.new([2, 2], [-3, 1, 2, 3]);
-      const dy = Array2D.new([2, 2], [1, 10, 100, 1000]);
+      const dy = Array2D.new([2, 2], [1, 2, 3, 4]);
 
       const gradients = math.vjp(() => math.square(a), a, dy);
 
       expect(gradients.shape).toEqual(a.shape);
       expect(gradients.dtype).toEqual('float32');
       test_util.expectArraysClose(
-          gradients, [-6 * 1, 2 * 10, 4 * 100, 6 * 1000], 1e-1);
+          gradients, [-6 * 1, 2 * 2, 4 * 3, 6 * 4], 1e-1);
     });
   };
 

--- a/src/math/unaryop_test.ts
+++ b/src/math/unaryop_test.ts
@@ -69,17 +69,7 @@ import {Array1D, Array2D, Scalar} from './ndarray';
       test_util.expectArraysClose(result, [1, 0, 0, 1, 0, util.NAN_BOOL]);
     });
 
-    it('gradients: positive scalar, dy = 1', math => {
-      const a = Scalar.new(3);
-
-      const gradients = math.gradients(() => math.relu(a), a);
-
-      expect(gradients.shape).toEqual(a.shape);
-      expect(gradients.dtype).toEqual('float32');
-      test_util.expectArraysClose(gradients, [1]);
-    });
-
-    it('gradients: positive scalar, dy != 1', math => {
+    it('gradients: positive scalar', math => {
       const a = Scalar.new(3);
       const dy = Scalar.new(5);
 
@@ -90,17 +80,7 @@ import {Array1D, Array2D, Scalar} from './ndarray';
       test_util.expectArraysClose(gradients, [5]);
     });
 
-    it('gradients: negative scalar, dy = 1', math => {
-      const a = Scalar.new(-3);
-
-      const gradients = math.gradients(() => math.relu(a), a);
-
-      expect(gradients.shape).toEqual(a.shape);
-      expect(gradients.dtype).toEqual('float32');
-      test_util.expectArraysClose(gradients, [0]);
-    });
-
-    it('gradients: negative scalar, dy != 1', math => {
+    it('gradients: negative scalar', math => {
       const a = Scalar.new(-3);
       const dy = Scalar.new(5);
 
@@ -111,18 +91,7 @@ import {Array1D, Array2D, Scalar} from './ndarray';
       test_util.expectArraysClose(gradients, [0]);
     });
 
-    it('gradients: array, dy = 1', math => {
-      // TODO(nsthorat): Use 0 instead of -.001 when we fix the precision
-      const a = Array2D.new([2, 2], [1, -1, -.001, .1]);
-
-      const gradients = math.gradients(() => math.sum(math.relu(a)), a);
-
-      expect(gradients.shape).toEqual(a.shape);
-      expect(gradients.dtype).toEqual('float32');
-      test_util.expectArraysClose(gradients, [1, 0, 0, 1]);
-    });
-
-    it('gradients: array, dy != 1', math => {
+    it('gradients: array', math => {
       // TODO(nsthorat): Use 0 instead of -.001 when we fix the precision
       const a = Array2D.new([2, 2], [1, -1, -.001, .1]);
       const dy = Array2D.new([2, 2], [1, 10, 100, 1000]);
@@ -135,7 +104,7 @@ import {Array1D, Array2D, Scalar} from './ndarray';
     });
   };
 
-  test_util.describeMathCPU('nikhil relu', [tests]);
+  test_util.describeMathCPU('relu', [tests]);
   test_util.describeMathGPU('relu', [tests], [
     {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 1},
     {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2},


### PR DESCRIPTION
This PR:
* Adds `math.vjp()`, which is like `gradients()`, but allows f() to return any NDArray, and takes a dy to backpropagate. Returns the vector-jacobian product as an NDArray.
* Adds `math.customGradient` which takes a function that is executed immediately, as well as a gradient function to be used on the tape.
* Add softmaxCrossEntropyWithLogits op.
* Add custom gradient for softmax and softmaxCrossEntropyWithLogits. softmaxCrossEntropyWithLogits calls softmax - the custom gradient for softmaxCrossEntropyWithLogits overrides the custom gradient for softmax.
* Converts unit tests to use vjp. This allows us to test functions with any dy.
* Fix gradients where we didn't multiply by dy, and add unit tests.
* Adds unit tests for gradientsScope to test memory cleanup.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/486)
<!-- Reviewable:end -->
