### PR TITLE
squeezenet image resize to [227, 227]

### DIFF
--- a/models/squeezenet/demo.html
+++ b/models/squeezenet/demo.html
@@ -21,7 +21,8 @@
 
     resultElement.innerText = 'Predicting...';
 
-    const pixels = dl.Array3D.fromPixels(cat);
+    //make a 3D array from the image and resize it to standart dimentions
+    const pixels = math.resizeBilinear3D(dl.Array3D.fromPixels(cat),[227, 227]);
 
     const result = squeezeNet.predict(pixels);
 


### PR DESCRIPTION
The squeezenet model needed the following dimensions of the image [227, 227]. As discussed in https://github.com/PAIR-code/deeplearnjs/issues/469#issuecomment-354444559, I used resizeBilinear3D to resize the image 3D array.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/489)
<!-- Reviewable:end -->
