### PR TITLE
Changes poi version from ~9.5.4 to ~9.6.8

### DIFF
--- a/demos/package.json
+++ b/demos/package.json
@@ -69,7 +69,7 @@
     "d3-scale": "~1.0.7",
     "minimist": "~1.2.0",
     "mkdirp": "~0.5.1",
-    "poi": "~9.5.4",
+    "poi": "~9.6.8",
     "poi-preset-typescript": "~9.0.2",
     "polymer-bundler": "~3.0.1",
     "tone-piano": "0.0.5",

--- a/demos/yarn.lock
+++ b/demos/yarn.lock
@@ -1585,6 +1585,10 @@ chownr@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.0.1.tgz#e2a75042a9551908bebd25b8523d5f9769d79181"
 
+ci-info@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.2.tgz#03561259db48d0474c8bdc90f5b47b068b6bbfb4"
+
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
@@ -3373,6 +3377,12 @@ is-callable@^1.1.1, is-callable@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
 
+is-ci@^1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.0.10.tgz#f739336b2632365061a9d48270cd56ae3369318e"
+  dependencies:
+    ci-info "^1.0.0"
+
 is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
@@ -4469,7 +4479,7 @@ poi-dev-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/poi-dev-utils/-/poi-dev-utils-1.0.1.tgz#c3089d1db60e9d2c56343decc6a3b9647d577c14"
 
-poi-load-config@^1.1.3:
+poi-load-config@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/poi-load-config/-/poi-load-config-1.1.4.tgz#7975f2c5753fa53294acd7ca0dd4f583907cadbc"
   dependencies:
@@ -4488,9 +4498,9 @@ poi-webpack-node-externals@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/poi-webpack-node-externals/-/poi-webpack-node-externals-2.0.0.tgz#3e23ae0673705f5f44b23ecd194b85c724de91fa"
 
-poi@~9.5.4:
-  version "9.5.11"
-  resolved "https://registry.yarnpkg.com/poi/-/poi-9.5.11.tgz#fee8e4e61b79c727bccecff0621cfa8988f25ed7"
+poi@~9.6.8:
+  version "9.6.9"
+  resolved "https://registry.yarnpkg.com/poi/-/poi-9.6.9.tgz#9f6516db26f33240ad85fa35c1c0464021e0eeb4"
   dependencies:
     address "^1.0.1"
     autoprefixer "^7.1.2"
@@ -4510,6 +4520,7 @@ poi@~9.5.4:
     highlight-es "^1.0.1"
     html-webpack-plugin "^2.28.0"
     import-local-file "^0.2.0"
+    is-ci "^1.0.10"
     lodash "^4.17.4"
     loud-rejection "^1.6.0"
     memory-fs "^0.4.1"
@@ -4518,7 +4529,7 @@ poi@~9.5.4:
     opn "^5.0.0"
     parse-json-config "^0.2.0"
     poi-dev-utils "^1.0.1"
-    poi-load-config "^1.1.3"
+    poi-load-config "^1.1.4"
     poi-webpack-node-externals "^2.0.0"
     post-compile-webpack-plugin "^0.1.1"
     postcss-loader "^2.0.6"


### PR DESCRIPTION
There are some issues with latest patches of `poi`, particularly `9.5.11`, which is throwing an error about userConfig. Using latest version seems to resolve that.

Error fixed:
```
TypeError: Cannot destructure property `useConfig` of 'undefined' or 'null'.
    at /Users/manrajsingh/Github/deeplearnjs/demos/node_modules/poi/lib/handle-options.js:97:1
    at Generator.next (<anonymous>)
    at onFulfilled (/Users/manrajsingh/Github/deeplearnjs/demos/node_modules/co/index.js:65:19)
    at <anonymous>

 FAIL  Failed to start!
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/497)
<!-- Reviewable:end -->
