### PR TITLE
Make NDArray's id unique. Move reshape() and asType() to Math.

### DIFF
--- a/src/math/backends/backend.ts
+++ b/src/math/backends/backend.ts
@@ -18,7 +18,7 @@
 
 import {Conv2DInfo} from '../conv_util';
 // tslint:disable-next-line:max-line-length
-import {Array1D, Array2D, Array3D, Array4D, DataType, DataTypeMap, NDArray} from '../ndarray';
+import {Array1D, Array2D, Array3D, Array4D, DataType, DataTypeMap, NDArray, Rank} from '../ndarray';
 import {SumTypes} from '../types';
 import {MatrixOrientation} from './types/matmul';
 
@@ -75,7 +75,7 @@ export interface MathBackend extends NDArrayStorage {
   argMax(x: NDArray, axes: number[]): NDArray<'int32'>;
 
   equal(a: NDArray, b: NDArray): NDArray<'bool'>;
-
+  notEqual(a: NDArray, b: NDArray): NDArray<'bool'>;
   topKValues<D extends DataType, T extends NDArray<D>>(x: T, k: number):
       Array1D<D>;
   topKIndices(x: NDArray, k: number): Array1D<'int32'>;
@@ -103,6 +103,7 @@ export interface MathBackend extends NDArrayStorage {
   leakyRelu<T extends NDArray>(x: T, alpha: number): T;
   prelu<T extends NDArray>(x: T, alpha: T): T;
   preluDer<T extends NDArray>(x: T, alpha: T): T;
+  int<R extends Rank>(x: NDArray<DataType, R>): NDArray<'int32', R>;
 
   clip<T extends NDArray>(x: T, min: number, max: number): T;
 

--- a/src/math/backends/backend.ts
+++ b/src/math/backends/backend.ts
@@ -23,13 +23,13 @@ import {SumTypes} from '../types';
 import {MatrixOrientation} from './types/matmul';
 
 export interface NDArrayStorage {
-  read<D extends DataType>(id: number): Promise<DataTypeMap[D]>;
-  readSync<D extends DataType>(id: number): DataTypeMap[D];
-  disposeData(id: number): void;
+  read<D extends DataType>(dataId: number): Promise<DataTypeMap[D]>;
+  readSync<D extends DataType>(dataId: number): DataTypeMap[D];
+  disposeData(dataId: number): void;
   write<D extends DataType>(
-      id: number, values: DataTypeMap[D], dtype: D, shape: number[]): void;
+      dataId: number, values: DataTypeMap[D], dtype: D, shape: number[]): void;
   writePixels(
-      id: number,
+      dataId: number,
       pixels: ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement,
       numChannels: number): void;
   time(query: () => NDArray): Promise<number>;

--- a/src/math/backends/backend_cpu.ts
+++ b/src/math/backends/backend_cpu.ts
@@ -33,15 +33,15 @@ import {MathBackend} from './backend';
 import {MatrixOrientation} from './types/matmul';
 
 export class MathBackendCPU implements MathBackend {
-  private data: {[id: number]: DataTypeMap[DataType]} = {};
+  private data: {[dataId: number]: DataTypeMap[DataType]} = {};
 
   dispose() {}
   write<D extends DataType>(
-      id: number, values: DataTypeMap[D], dtype: D, shape: number[]): void {
-    this.data[id] = values;
+      dataId: number, values: DataTypeMap[D], dtype: D, shape: number[]): void {
+    this.data[dataId] = values;
   }
   writePixels(
-      id: number,
+      dataId: number,
       pixels: ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement,
       numChannels: number): void {
     let vals: Uint8ClampedArray;
@@ -78,28 +78,28 @@ export class MathBackendCPU implements MathBackend {
         }
       }
     }
-    this.data[id] = values;
+    this.data[dataId] = values;
   }
-  async read<D extends DataType>(id: number): Promise<DataTypeMap[D]> {
-    this.throwIfNoData(id);
-    return this.data[id];
+  async read<D extends DataType>(dataId: number): Promise<DataTypeMap[D]> {
+    this.throwIfNoData(dataId);
+    return this.data[dataId];
   }
-  readSync<D extends DataType>(id: number): DataTypeMap[D] {
-    this.throwIfNoData(id);
-    return this.data[id];
+  readSync<D extends DataType>(dataId: number): DataTypeMap[D] {
+    this.throwIfNoData(dataId);
+    return this.data[dataId];
   }
-  disposeData(id: number): void {
-    delete this.data[id];
+  disposeData(dataId: number): void {
+    delete this.data[dataId];
   }
   async time(query: () => NDArray): Promise<number> {
     const start = performance.now();
     query();
     return performance.now() - start;
   }
-  private throwIfNoData(id: number) {
-    if (!(id in this.data)) {
+  private throwIfNoData(dataId: number) {
+    if (!(dataId in this.data)) {
       throw new Error(
-          `No data found for NDArray with id ${id}. ` +
+          `No data found for NDArray with data id ${dataId}. ` +
           `Use dl.ENV.math instead of constructing your own NDArrayMath. ` +
           `If you need to construct your own math, make sure this array is ` +
           `allocated after the math construction`);

--- a/src/math/backends/backend_engine.ts
+++ b/src/math/backends/backend_engine.ts
@@ -190,10 +190,12 @@ export class BackendEngine {
     // Backprop gradients through the filtered nodes.
     tape_util.backpropagateGradients(arrayAccumulatedGradientMap, filteredTape);
 
-    const gradients: NDArray[] = [];
-    for (let i = 0; i < xs.length; i++) {
-      gradients.push(arrayAccumulatedGradientMap[xs[i].id]);
-    }
+    const gradients = xs.map(x => arrayAccumulatedGradientMap[x.id]);
+    gradients.forEach((grad, i) => {
+      if (grad == null) {
+        throw new Error(`Gradient error: y was not a function of xs[${i}]`);
+      }
+    });
     return gradients;
   }
 

--- a/src/math/backends/backend_webgl.ts
+++ b/src/math/backends/backend_webgl.ts
@@ -65,7 +65,7 @@ export class MathBackendWebGL implements MathBackend {
 
   register(dataId: number, shape: number[], dtype: DataType): void {
     if (dataId in this.texData) {
-      throw new Error(`id ${dataId} already registered`);
+      throw new Error(`data id ${dataId} already registered`);
     }
     this.texData[dataId] = {
       shape,

--- a/src/math/backends/backend_webgl.ts
+++ b/src/math/backends/backend_webgl.ts
@@ -530,7 +530,10 @@ export class MathBackendWebGL implements MathBackend {
 
   pow<T extends NDArray>(a: T, b: NDArray<'int32'>): T {
     const program = new BinaryOpProgram(binaryop_gpu.POW, a.shape, b.shape);
-    return this.compileAndRun<NDArray, T>(program, [a, b]);
+    const output =
+        this.makeOutputArray(
+            program.outputShape, types.upcastType(a.dtype, b.dtype)) as T;
+    return this.compileAndRun<NDArray, T>(program, [a, b], output);
   }
 
   ceil<T extends NDArray>(x: T): T {
@@ -601,7 +604,7 @@ export class MathBackendWebGL implements MathBackend {
 
   int<R extends Rank>(x: NDArray<DataType, R>): NDArray<'int32', R> {
     const program = new UnaryOpProgram(x.shape, unary_op.TO_INT);
-    const output = this.makeOutputArray(x.shape, 'int32');
+    const output = this.makeOutputArray(program.outputShape, 'int32');
     return this.compileAndRun(program, [x], output) as NDArray<'int32', R>;
   }
 

--- a/src/math/backends/backend_webgl.ts
+++ b/src/math/backends/backend_webgl.ts
@@ -22,7 +22,7 @@ import * as axis_util from '../axis_util';
 import {Conv2DInfo} from '../conv_util';
 import {NDArrayMath} from '../math';
 // tslint:disable-next-line:max-line-length
-import {Array1D, Array2D, Array3D, Array4D, DataType, DataTypeMap, NDArray} from '../ndarray';
+import {Array1D, Array2D, Array3D, Array4D, DataType, DataTypeMap, NDArray, Rank} from '../ndarray';
 import * as reduce_util from '../reduce_util';
 import * as types from '../types';
 import {SumTypes, SumTypesMap} from '../types';
@@ -461,6 +461,13 @@ export class MathBackendWebGL implements MathBackend {
     return this.compileAndRun(program, [a, b], output);
   }
 
+  notEqual(a: NDArray, b: NDArray): NDArray<'bool'> {
+    const program =
+        new BinaryOpProgram(binaryop_gpu.NOT_EQUAL, a.shape, b.shape);
+    const output = this.makeOutputArray(program.outputShape, 'bool');
+    return this.compileAndRun(program, [a, b], output);
+  }
+
   topKValues<D extends DataType, T extends NDArray<D>>(x: T, k: number):
       Array1D<D> {
     throw new Error('topKValues GPU not yet implemented!');
@@ -590,6 +597,12 @@ export class MathBackendWebGL implements MathBackend {
     const program =
         new BinaryOpProgram(binaryop_gpu.PRELU_DER, a.shape, b.shape);
     return this.compileAndRun(program, [a, b]) as T;
+  }
+
+  int<R extends Rank>(x: NDArray<DataType, R>): NDArray<'int32', R> {
+    const program = new UnaryOpProgram(x.shape, unary_op.TO_INT);
+    const output = this.makeOutputArray(x.shape, 'int32');
+    return this.compileAndRun(program, [x], output) as NDArray<'int32', R>;
   }
 
   clip<T extends NDArray>(x: T, min: number, max: number): T {

--- a/src/math/backends/kernel_registry.ts
+++ b/src/math/backends/kernel_registry.ts
@@ -1,5 +1,22 @@
-import {DataType, NDArray, NDArrayData} from '../ndarray';
+/**
+ * @license
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
 
+import * as util from '../../util';
+import {DataType, NDArray, Scalar} from '../ndarray';
 import {MathBackend} from './backend';
 import {KernelInputConfig} from './tape_types';
 // tslint:disable-next-line:max-line-length
@@ -7,6 +24,7 @@ import {ArgMaxInputConfig, ArgMaxNode, ArgMinInputConfig, ArgMinNode} from './ty
 // tslint:disable-next-line:max-line-length
 import {BatchNorm2DInputConfig, BatchNorm2DNode, BatchNorm3DInputConfig, BatchNorm3DNode, BatchNorm4DInputConfig, BatchNorm4DNode} from './types/batchnorm';
 import {BinaryInputConfig, BinaryNode} from './types/binary';
+import {CastInputConfig, CastNode} from './types/cast';
 // tslint:disable-next-line:max-line-length
 import {Concat1DInputConfig, Concat1DNode, Concat2DInputConfig, Concat2DNode, Concat3DInputConfig, Concat3DNode, Concat4DInputConfig, Concat4DNode} from './types/concat';
 // tslint:disable-next-line:max-line-length
@@ -100,6 +118,9 @@ const KERNEL_METHODS: {
   Equal: (backend: MathBackend, config: EqualInputConfig) => {
     return backend.equal(config.inputs.a, config.inputs.b);
   },
+  NotEqual: (backend: MathBackend, config: EqualInputConfig) => {
+    return backend.notEqual(config.inputs.a, config.inputs.b);
+  },
   TopKValues:
       (backend: MathBackend, config: TopKValuesInputConfig<NDArray>) => {
         return backend.topKValues(config.inputs.x, config.args.k);
@@ -146,8 +167,23 @@ const KERNEL_METHODS: {
   Reshape: (backend: MathBackend, config: UnaryInputConfig<NDArray>) => {
     const x = config.inputs.x;
     const newShape = config.args.newShape;
-    const data: NDArrayData<DataType> = {dataId: x.dataId};
-    return NDArray.make(newShape, data, x.dtype);
+    return NDArray.make(newShape, {dataId: x.dataId}, x.dtype);
+  },
+  Cast: (backend: MathBackend, config: CastInputConfig) => {
+    const x = config.inputs.x;
+    const newDType = config.args.newDType;
+
+    if (!util.hasEncodingLoss(x.dtype, newDType)) {
+      // We don't change the underlying data, since we cast to higher precision.
+      return NDArray.make(x.shape, {dataId: x.dataId}, newDType);
+    }
+    if (newDType === 'int32') {
+      return backend.int(x);
+    } else if (newDType === 'bool') {
+      return backend.notEqual(x, Scalar.new(0, x.dtype));
+    } else {
+      throw new Error(`Error in Cast: unknown dtype argument (${newDType})`);
+    }
   },
   LeakyRelu: (backend: MathBackend, config: LeakyReluInputConfig<NDArray>) => {
     return backend.leakyRelu(config.inputs.x, config.args.alpha);
@@ -304,6 +340,7 @@ export interface KernelConfigRegistry {
   ArgMax: ArgMaxNode;
   ArgMin: ArgMinNode;
   Equal: EqualNode;
+  NotEqual: EqualNode;
   TopKValues: TopKValuesNode<DataType, NDArray>;
   TopKIndices: TopKIndicesNode;
   Min: MinNode<DataType>;
@@ -322,6 +359,7 @@ export interface KernelConfigRegistry {
   PReLU: PReLUNode<NDArray>;
   PReLUDer: PReLUNode<NDArray>;
   Reshape: ReshapeNode;
+  Cast: CastNode;
   Elu: UnaryNode<NDArray>;
   EluDer: UnaryNode<NDArray>;
   Selu: UnaryNode<NDArray>;

--- a/src/math/backends/kernel_registry.ts
+++ b/src/math/backends/kernel_registry.ts
@@ -1,4 +1,4 @@
-import {DataType, NDArray} from '../ndarray';
+import {DataType, NDArray, NDArrayData} from '../ndarray';
 
 import {MathBackend} from './backend';
 import {KernelInputConfig} from './tape_types';
@@ -21,6 +21,7 @@ import {OneHotInputConfig, OneHotNode} from './types/onehot';
 import {PoolBackpropInputConfig, PoolBackpropNode, PoolInputConfig, PoolNode} from './types/pool';
 import {PowInputConfig, PowNode} from './types/pow';
 import {PReLUInputConfig, PReLUNode} from './types/prelu';
+import {ReshapeNode} from './types/reshape';
 // tslint:disable-next-line:max-line-length
 import {ResizeBilinear3DInputConfig, ResizeBilinear3DNode} from './types/resize_bilinear';
 // tslint:disable-next-line:max-line-length
@@ -141,6 +142,12 @@ const KERNEL_METHODS: {
   },
   Relu: (backend: MathBackend, config: UnaryInputConfig<NDArray>) => {
     return backend.relu(config.inputs.x);
+  },
+  Reshape: (backend: MathBackend, config: UnaryInputConfig<NDArray>) => {
+    const x = config.inputs.x;
+    const newShape = config.args.newShape;
+    const data: NDArrayData<DataType> = {dataId: x.dataId};
+    return NDArray.make(newShape, data, x.dtype);
   },
   LeakyRelu: (backend: MathBackend, config: LeakyReluInputConfig<NDArray>) => {
     return backend.leakyRelu(config.inputs.x, config.args.alpha);
@@ -314,6 +321,7 @@ export interface KernelConfigRegistry {
   LeakyRelu: LeakyReluNode<NDArray>;
   PReLU: PReLUNode<NDArray>;
   PReLUDer: PReLUNode<NDArray>;
+  Reshape: ReshapeNode;
   Elu: UnaryNode<NDArray>;
   EluDer: UnaryNode<NDArray>;
   Selu: UnaryNode<NDArray>;

--- a/src/math/backends/tape_util.ts
+++ b/src/math/backends/tape_util.ts
@@ -167,8 +167,9 @@ export function backpropagateGradients(
     }
 
     if (node.gradient == null) {
-      throw new Error(`Cannot compute gradient: gradient function not found for
-              ${node.name}.`);
+      throw new Error(
+          `Cannot compute gradient: gradient function not found ` +
+          `for ${node.name}.`);
     }
 
     // Backprop dy through this node and accumulate gradients over the inputs.

--- a/src/math/backends/types/cast.ts
+++ b/src/math/backends/types/cast.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {DataType, NDArray} from '../../ndarray';
+import {KernelInputConfig, KernelNode} from '../tape_types';
+
+export interface CastNode extends KernelNode {
+  inputAndArgs: CastInputConfig;
+  output: NDArray;
+  gradient: (dy: NDArray, y: NDArray) => {
+    x: () => NDArray
+  };
+}
+
+export interface CastInputConfig extends KernelInputConfig {
+  inputs: {x: NDArray};
+  args: {newDType: DataType};
+}

--- a/src/math/backends/types/reshape.ts
+++ b/src/math/backends/types/reshape.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {NDArray} from '../../ndarray';
+import {KernelInputConfig, KernelNode} from '../tape_types';
+
+export interface ReshapeNode extends KernelNode {
+  inputAndArgs: ReshapeInputConfig;
+  output: NDArray;
+  gradient: (dy: NDArray, y: NDArray) => {
+    x: () => NDArray
+  };
+}
+
+export interface ReshapeInputConfig extends KernelInputConfig {
+  inputs: {x: NDArray};
+  args: {newShape: number[]};
+}

--- a/src/math/backends/webgl/binaryop_gpu.ts
+++ b/src/math/backends/webgl/binaryop_gpu.ts
@@ -34,6 +34,9 @@ export const POW = `
 export const EQUAL = CHECK_NAN_SNIPPET + `
   return float(a == b);
 `;
+export const NOT_EQUAL = CHECK_NAN_SNIPPET + `
+  return float(a != b);
+`;
 export const PRELU = `
   return (a >= 0.0) ? a : b * a;
 `;

--- a/src/math/backends/webgl/unaryop_gpu.ts
+++ b/src/math/backends/webgl/unaryop_gpu.ts
@@ -149,3 +149,7 @@ export const TANH = `
 export const SQUARE = `
   return x * x;
 `;
+
+export const TO_INT = `
+  return float(int(x));
+`;

--- a/src/math/element_wise_arithmetic_test.ts
+++ b/src/math/element_wise_arithmetic_test.ts
@@ -297,6 +297,17 @@ import {Array1D, Array2D, Array3D, Scalar} from './ndarray';
       test_util.expectArraysClose(result, expected, 0.01);
     });
 
+    it('int32^int32 returns int32', math => {
+      const a = Array1D.new([1, 2, 3], 'int32');
+      const exp = Scalar.new(2, 'int32');
+
+      const result = math.pow(a, exp);
+
+      expect(result.shape).toEqual([3]);
+      expect(result.dtype).toBe('int32');
+      test_util.expectArraysEqual(result, [1, 4, 9]);
+    });
+
     it('different-shaped ndarrays', math => {
       const a = Array2D.new([2, 3], [1, -2, -3, 0, 7, 1]);
       const b = Scalar.new(2, 'int32');

--- a/src/math/element_wise_arithmetic_test.ts
+++ b/src/math/element_wise_arithmetic_test.ts
@@ -830,3 +830,68 @@ import {Array1D, Array2D, Array3D, Scalar} from './ndarray';
     {'WEBGL_FLOAT_TEXTURE_ENABLED': false, 'WEBGL_VERSION': 1}
   ]);
 }
+
+// element-wise not equal
+{
+  const tests: MathTests = it => {
+    it('propagates NaNs', math => {
+      const a = Array1D.new([2, 5, NaN]);
+      const b = Array1D.new([4, 5, -1]);
+
+      const res = math.notEqual(a, b);
+      expect(res.dtype).toBe('bool');
+      test_util.expectArraysEqual(res, [1, 0, util.NAN_BOOL]);
+    });
+
+    it('strict version throws when x and y are different shape', math => {
+      const a = Array1D.new([2]);
+      const b = Array1D.new([4, 2, -1]);
+
+      expect(() => math.notEqualStrict(a, b)).toThrowError();
+      expect(() => math.notEqualStrict(b, a)).toThrowError();
+    });
+
+    it('2D and scalar broadcast', math => {
+      const a = Array2D.new([2, 3], [1, 2, 3, 2, 5, 6]);
+      const b = Scalar.new(2);
+      const res = math.notEqual(a, b);
+      expect(res.dtype).toBe('bool');
+      expect(res.shape).toEqual([2, 3]);
+      test_util.expectArraysEqual(res, [1, 0, 1, 0, 1, 1]);
+    });
+
+    it('scalar and 1D broadcast', math => {
+      const a = Scalar.new(2);
+      const b = Array1D.new([1, 2, 3, 4, 5, 2]);
+      const res = math.notEqual(a, b);
+      expect(res.dtype).toBe('bool');
+      expect(res.shape).toEqual([6]);
+      test_util.expectArraysEqual(res, [1, 0, 1, 1, 1, 0]);
+    });
+
+    it('2D and 2D broadcast each with 1 dim', math => {
+      const a = Array2D.new([1, 3], [1, 2, 5]);
+      const b = Array2D.new([2, 1], [5, 1]);
+      const res = math.notEqual(a, b);
+      expect(res.dtype).toBe('bool');
+      expect(res.shape).toEqual([2, 3]);
+      test_util.expectArraysEqual(res, [1, 1, 0, 0, 1, 1]);
+    });
+
+    it('3D and scalar', math => {
+      const a = Array3D.new([2, 3, 1], [1, 2, 3, 4, 5, -1]);
+      const b = Scalar.new(-1);
+      const res = math.notEqual(a, b);
+      expect(res.dtype).toBe('bool');
+      expect(res.shape).toEqual([2, 3, 1]);
+      test_util.expectArraysEqual(res, [1, 1, 1, 1, 1, 0]);
+    });
+  };
+
+  test_util.describeMathCPU('notEqual', [tests]);
+  test_util.describeMathGPU('notEqual', [tests], [
+    {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 1},
+    {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2},
+    {'WEBGL_FLOAT_TEXTURE_ENABLED': false, 'WEBGL_VERSION': 1}
+  ]);
+}

--- a/src/math/math.ts
+++ b/src/math/math.ts
@@ -336,10 +336,6 @@ export class NDArrayMath implements NDArrayManager {
   reshape<D extends DataType, R extends Rank, T extends RankMap<D>[R]>(
       x: NDArray<D>, newShape: number[]): T {
     newShape = util.inferFromImplicitShape(newShape, x.size);
-    if (util.arraysEqual(x.shape, newShape)) {
-      // No-op.
-      return x as T;
-    }
     util.assert(
         x.size === util.sizeFromShape(newShape),
         'new shape and old shape must have the same number of elements.');
@@ -357,12 +353,8 @@ export class NDArrayMath implements NDArrayManager {
    */
   cast<D extends DataType, R extends Rank>(
       x: NDArray<DataType, R>, newDType: D): RankMap<D>[R] {
-    if (x.dtype === newDType) {
-      // No-op.
-      return x as NDArray as RankMap<D>[R];
-    }
     const grad = (dy: NDArray, y: NDArray) => {
-      return {x: () => dy};
+      return {x: () => dy.reshape(dy.shape)};
     };
     return this.backendEngine.executeKernel(
                'Cast', {inputs: {x}, args: {newDType}}, grad) as RankMap<D>[R];

--- a/src/math/math.ts
+++ b/src/math/math.ts
@@ -360,8 +360,11 @@ export class NDArrayMath implements NDArrayStorage, NDArrayManager {
       // No-op.
       return x as NDArray as RankMap<D>[R];
     }
+    const grad = (dy: NDArray, y: NDArray) => {
+      return {x: () => dy};
+    };
     return this.backendEngine.executeKernel(
-               'Cast', {inputs: {x}, args: {newDType}}) as RankMap<D>[R];
+               'Cast', {inputs: {x}, args: {newDType}}, grad) as RankMap<D>[R];
   }
 
   /**
@@ -1128,7 +1131,7 @@ export class NDArrayMath implements NDArrayStorage, NDArrayManager {
           return this.multiply(
               dy,
               this.multiply(
-                  b.asType('float32'),
+                  b.asType(a.dtype),
                   this.pow(a, this.subtract(b, Scalar.new(1, 'int32')))));
         });
       };

--- a/src/math/math_test.ts
+++ b/src/math/math_test.ts
@@ -406,7 +406,7 @@ import {Array1D, Array2D, Array3D, NDArray, Scalar} from './ndarray';
       test_util.expectArraysClose(gradients.a, [2, 4, 6, 8]);
     });
 
-    it('reshape outside the gradients throws error', math => {
+    it('reshape outside math.gradients() throws error', math => {
       const a = Array2D.new([2, 2], [1, 2, 3, 4]);
       const b = a.flatten();
       const exponent = Array1D.new([2, 2, 2, 2], 'int32');
@@ -416,6 +416,35 @@ import {Array1D, Array2D, Array3D, NDArray, Scalar} from './ndarray';
           const m = math.pow(b, exponent);
           return math.sum(m);
         }, {a, b});
+      };
+      expect(f).toThrowError();
+    });
+
+    it('works with asType', math => {
+      const a = Array2D.new([2, 2], [1, 2, 3, 4], 'int32');
+      const exponent = Array2D.new([2, 2], [2, 2, 2, 2], 'int32');
+
+      const gradients = math.gradients(() => {
+        const b = a.asType('float32');
+        const m = math.pow(b, exponent);
+        return math.sum(m);
+      }, {a});
+
+      expect(gradients.a.shape).toEqual([2, 2]);
+      expect(gradients.a.dtype).toEqual('float32');
+      test_util.expectArraysClose(gradients.a, [2, 4, 6, 8]);
+    });
+
+    it('asType outside of math.gradients() throws error', math => {
+      const a = Array2D.new([2, 2], [1, 2, 3, 4], 'int32');
+      const b = a.asType('float32');
+      const exponent = Array2D.new([2, 2], [2, 2, 2, 2], 'int32');
+
+      const f = () => {
+        return math.gradients(() => {
+          const m = math.pow(b, exponent);
+          return math.sum(m);
+        }, {a});
       };
       expect(f).toThrowError();
     });

--- a/src/math/math_test.ts
+++ b/src/math/math_test.ts
@@ -394,17 +394,30 @@ import {Array1D, Array2D, Array3D, NDArray, Scalar} from './ndarray';
 
     it('works with reshape', math => {
       const a = Array2D.new([2, 2], [1, 2, 3, 4]);
-      const b = a.flatten();
       const exponent = Array1D.new([2, 2, 2, 2], 'int32');
 
       const gradients = math.gradients(() => {
+        const b = a.flatten();
         const m = math.pow(b, exponent);
         return math.sum(m);
-      }, {a, b});
+      }, {a});
 
       expect(gradients.a.shape).toEqual([2, 2]);
-      expect(gradients.b.shape).toEqual([4]);
-      test_util.expectArraysEqual(gradients.a, gradients.b);
+      test_util.expectArraysClose(gradients.a, [2, 4, 6, 8]);
+    });
+
+    it('reshape outside the gradients throws error', math => {
+      const a = Array2D.new([2, 2], [1, 2, 3, 4]);
+      const b = a.flatten();
+      const exponent = Array1D.new([2, 2, 2, 2], 'int32');
+
+      const f = () => {
+        return math.gradients(() => {
+          const m = math.pow(b, exponent);
+          return math.sum(m);
+        }, {a, b});
+      };
+      expect(f).toThrowError();
     });
   };
 

--- a/src/math/math_test.ts
+++ b/src/math/math_test.ts
@@ -391,6 +391,21 @@ import {Array1D, Array2D, Array3D, NDArray, Scalar} from './ndarray';
           () => math.gradients(() => math.matMul(a, b) as any, {a, b}))
           .toThrowError();
     });
+
+    it('works with reshape', math => {
+      const a = Array2D.new([2, 2], [1, 2, 3, 4]);
+      const b = a.flatten();
+      const exponent = Array1D.new([2, 2, 2, 2], 'int32');
+
+      const gradients = math.gradients(() => {
+        const m = math.pow(b, exponent);
+        return math.sum(m);
+      }, {a, b});
+
+      expect(gradients.a.shape).toEqual([2, 2]);
+      expect(gradients.b.shape).toEqual([4]);
+      test_util.expectArraysEqual(gradients.a, gradients.b);
+    });
   };
 
   test_util.describeMathCPU('gradients', [tests]);

--- a/src/math/ndarray.ts
+++ b/src/math/ndarray.ts
@@ -252,16 +252,7 @@ export class NDArray<D extends DataType = DataType, R extends Rank = Rank> {
 
   asType<D2 extends DataType>(dtype: D2): NDArray<D2, R> {
     this.throwIfDisposed();
-    if (this.dtype === dtype as string) {
-      // No-op.
-      return this as NDArray as NDArray<D2, R>;
-    }
-    // TODO(dsmilkov): Migrate casting to the backend.
-    const vals = this.dataSync();
-    const newVals = toTypedArray(vals, dtype);
-    return NDArray.make<D2, R>(
-               this.shape, {values: newVals}, dtype, this.math) as
-        NDArray<D2, R>;
+    return this.math.asType(this, dtype) as NDArray<D2, R>;
   }
 
   get rank(): number {

--- a/src/math/ndarray.ts
+++ b/src/math/ndarray.ts
@@ -252,7 +252,7 @@ export class NDArray<D extends DataType = DataType, R extends Rank = Rank> {
 
   asType<D2 extends DataType>(dtype: D2): NDArray<D2, R> {
     this.throwIfDisposed();
-    return this.math.asType(this, dtype) as NDArray<D2, R>;
+    return this.math.cast(this, dtype) as NDArray<D2, R>;
   }
 
   get rank(): number {

--- a/src/math/ndarray.ts
+++ b/src/math/ndarray.ts
@@ -49,14 +49,21 @@ export type Rank = keyof RankMap<DataType>;
 
 /** @hidden */
 export interface NDArrayData<D extends DataType> {
-  id?: number;
+  dataId?: number;
   values?: DataTypeMap[D];
 }
 
 export class NDArray<D extends DataType = DataType, R extends Rank = Rank> {
   private static nextId = 0;
+  private static nextDataId = 0;
 
+  /** Unique id of this ndarray. */
   id: number;
+  /**
+   * Id of the bucket holding the data for this ndarray. Multiple arrays can
+   * point to the same bucket (e.g. when calling array.reshape()).
+   */
+  dataId: number;
   /** The shape of the ndarray. */
   shape: number[];
   /** Number of elements in the ndarray. */
@@ -76,7 +83,7 @@ export class NDArray<D extends DataType = DataType, R extends Rank = Rank> {
   protected math: NDArrayMath;
 
   protected constructor(
-      shape: number[], dtype: D, values?: DataTypeMap[D], id?: number,
+      shape: number[], dtype: D, values?: DataTypeMap[D], dataId?: number,
       math?: NDArrayMath) {
     this.math = math || ENV.math;
     this.size = util.sizeFromShape(shape);
@@ -101,14 +108,12 @@ export class NDArray<D extends DataType = DataType, R extends Rank = Rank> {
         this.strides[i] = this.strides[i + 1] * this.shape[i + 1];
       }
     }
-    this.id = id;
+    this.dataId = dataId != null ? dataId : NDArray.nextDataId++;
+    this.id = NDArray.nextId++;
     this.rankType = (this.rank < 5 ? this.rank.toString() : 'higher') as R;
-    if (this.id == null) {
-      this.id = NDArray.nextId++;
-      this.math.register(this);
-    }
+    this.math.register(this);
     if (values != null) {
-      this.math.write(this.id, values, this.dtype, this.shape);
+      this.math.write(this.dataId, values, this.dtype, this.shape);
     }
   }
 
@@ -157,22 +162,22 @@ export class NDArray<D extends DataType = DataType, R extends Rank = Rank> {
       math?: NDArrayMath): RankMap<D>[R] {
     switch (shape.length) {
       case 0:
-        return new Scalar(shape, dtype, data.values, data.id, math);
+        return new Scalar(shape, dtype, data.values, data.dataId, math);
       case 1:
-        return new Array1D(shape, dtype, data.values, data.id, math);
+        return new Array1D(shape, dtype, data.values, data.dataId, math);
       case 2:
         return new Array2D(
-            shape as [number, number], dtype, data.values, data.id, math);
+            shape as [number, number], dtype, data.values, data.dataId, math);
       case 3:
         return new Array3D(
-            shape as [number, number, number], dtype, data.values, data.id,
+            shape as [number, number, number], dtype, data.values, data.dataId,
             math);
       case 4:
         return new Array4D(
             shape as [number, number, number, number], dtype, data.values,
-            data.id, math);
+            data.dataId, math);
       default:
-        return new NDArray(shape, dtype, data.values, data.id, math) as
+        return new NDArray(shape, dtype, data.values, data.dataId, math) as
             RankMap<D>[R];
     }
   }
@@ -190,26 +195,14 @@ export class NDArray<D extends DataType = DataType, R extends Rank = Rank> {
     math = math || ENV.math;
     const res =
         NDArray.make(shape, ndarrayData, 'int32', math) as Array3D<'int32'>;
-    math.writePixels(res.id, pixels, numChannels);
+    math.writePixels(res.dataId, pixels, numChannels);
     return res;
   }
 
   /** Reshapes the current ndarray into the provided shape. */
   reshape<R2 extends Rank>(newShape: number[]): RankMap<D>[R2] {
     this.throwIfDisposed();
-    newShape = util.inferFromImplicitShape(newShape, this.size);
-    if (util.arraysEqual(this.shape, newShape)) {
-      // No-op.
-      return this as RankMap<D>[R2];
-    }
-
-    const data: NDArrayData<D> = {id: this.id};
-
-    util.assert(
-        this.size === util.sizeFromShape(newShape),
-        'new shape and old shape must have the same number of elements.');
-
-    return NDArray.make<D, R2>(newShape, data, this.dtype, this.math);
+    return this.math.reshape(this, newShape);
   }
 
   /** Flatten a NDArray to a 1D array. */
@@ -290,7 +283,7 @@ export class NDArray<D extends DataType = DataType, R extends Rank = Rank> {
     }
     const vals = this.dataSync();
     vals[index] = value;
-    this.math.write(this.id, vals, this.dtype, this.shape);
+    this.math.write(this.dataId, vals, this.dtype, this.shape);
   }
 
   async val(...locs: number[]): Promise<number> {
@@ -323,7 +316,7 @@ export class NDArray<D extends DataType = DataType, R extends Rank = Rank> {
     this.throwIfDisposed();
     const vals = this.dataSync();
     vals.fill(value);
-    this.math.write(this.id, vals, this.dtype, this.shape);
+    this.math.write(this.dataId, vals, this.dtype, this.shape);
   }
 
   /** @deprecated Use dataSync() instead. */
@@ -342,7 +335,7 @@ export class NDArray<D extends DataType = DataType, R extends Rank = Rank> {
    */
   async data(): Promise<DataTypeMap[D]> {
     this.throwIfDisposed();
-    return this.math.read(this.id);
+    return this.math.read(this.dataId);
   }
 
   /**
@@ -351,12 +344,15 @@ export class NDArray<D extends DataType = DataType, R extends Rank = Rank> {
    */
   dataSync(): DataTypeMap[D] {
     this.throwIfDisposed();
-    return this.math.readSync(this.id);
+    return this.math.readSync(this.dataId);
   }
 
   dispose(): void {
+    if (this.isDisposed) {
+      return;
+    }
     this.isDisposed = true;
-    this.math.disposeData(this.id);
+    this.math.disposeData(this.dataId);
   }
 
   equals(t: NDArray<D, R>): boolean {
@@ -542,10 +538,10 @@ export class Array2D<D extends DataType = DataType> extends NDArray<D, '2'> {
   private stride0: number;
 
   constructor(
-      shape: [number, number], dtype: D, values?: DataTypeMap[D], id?: number,
-      math?: NDArrayMath) {
+      shape: [number, number], dtype: D, values?: DataTypeMap[D],
+      dataId?: number, math?: NDArrayMath) {
     util.assert(shape.length === 2, 'Shape should be of length 2');
-    super(shape, dtype, values, id, math);
+    super(shape, dtype, values, dataId, math);
     this.stride0 = this.strides[0];
   }
 
@@ -639,9 +635,9 @@ export class Array3D<D extends DataType = DataType> extends NDArray<D, '3'> {
 
   constructor(
       shape: [number, number, number], dtype: D, values?: DataTypeMap[D],
-      id?: number, math?: NDArrayMath) {
+      dataId?: number, math?: NDArrayMath) {
     util.assert(shape.length === 3, 'Shape should be of length 3');
-    super(shape, dtype, values, id, math);
+    super(shape, dtype, values, dataId, math);
     this.stride0 = this.strides[0];
     this.stride1 = this.strides[1];
   }
@@ -739,9 +735,9 @@ export class Array4D<D extends DataType = DataType> extends NDArray<D, '4'> {
 
   constructor(
       shape: [number, number, number, number], dtype: D,
-      values?: DataTypeMap[D], id?: number, math?: NDArrayMath) {
+      values?: DataTypeMap[D], dataId?: number, math?: NDArrayMath) {
     util.assert(shape.length === 4, 'Shape should be of length 4');
-    super(shape, dtype, values, id, math);
+    super(shape, dtype, values, dataId, math);
     this.stride0 = this.strides[0];
     this.stride1 = this.strides[1];
     this.stride2 = this.strides[2];

--- a/src/math/ndarray_test.ts
+++ b/src/math/ndarray_test.ts
@@ -48,8 +48,7 @@ const tests: MathTests = it => {
     expect(t.rank).toBe(2);
     expect(t.size).toBe(6);
 
-    test_util.expectArraysClose(
-        t, [1, 2, 3, 4, 5, 6]);
+    test_util.expectArraysClose(t, [1, 2, 3, 4, 5, 6]);
 
     // Out of bounds indexing.
     expect(t.get(5, 3)).toBeUndefined();
@@ -210,8 +209,7 @@ const testsNew: MathTests = it => {
 
   it('Array2D.new() from number[][]', () => {
     const a = Array2D.new([2, 3], [[1, 2, 3], [4, 5, 6]]);
-    test_util.expectArraysClose(
-        a, [1, 2, 3, 4, 5, 6]);
+    test_util.expectArraysClose(a, [1, 2, 3, 4, 5, 6]);
   });
 
   it('Array2D.new() from number[][], but shape does not match', () => {
@@ -221,8 +219,7 @@ const testsNew: MathTests = it => {
 
   it('Array3D.new() from number[][][]', () => {
     const a = Array3D.new([2, 3, 1], [[[1], [2], [3]], [[4], [5], [6]]]);
-    test_util.expectArraysClose(
-        a, [1, 2, 3, 4, 5, 6]);
+    test_util.expectArraysClose(a, [1, 2, 3, 4, 5, 6]);
   });
 
   it('Array3D.new() from number[][][], but shape does not match', () => {
@@ -277,16 +274,14 @@ const testsZeros: MathTests = it => {
     const a = Array2D.zeros([3, 2]);
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([3, 2]);
-    test_util.expectArraysClose(
-        a, [0, 0, 0, 0, 0, 0]);
+    test_util.expectArraysClose(a, [0, 0, 0, 0, 0, 0]);
   });
 
   it('2D float32 dtype', () => {
     const a = Array2D.zeros([3, 2], 'float32');
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([3, 2]);
-    test_util.expectArraysClose(
-        a, [0, 0, 0, 0, 0, 0]);
+    test_util.expectArraysClose(a, [0, 0, 0, 0, 0, 0]);
   });
 
   it('2D int32 dtype', () => {
@@ -307,16 +302,14 @@ const testsZeros: MathTests = it => {
     const a = Array3D.zeros([2, 2, 2]);
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([2, 2, 2]);
-    test_util.expectArraysClose(
-        a, [0, 0, 0, 0, 0, 0, 0, 0]);
+    test_util.expectArraysClose(a, [0, 0, 0, 0, 0, 0, 0, 0]);
   });
 
   it('3D float32 dtype', () => {
     const a = Array3D.zeros([2, 2, 2], 'float32');
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([2, 2, 2]);
-    test_util.expectArraysClose(
-        a, [0, 0, 0, 0, 0, 0, 0, 0]);
+    test_util.expectArraysClose(a, [0, 0, 0, 0, 0, 0, 0, 0]);
   });
 
   it('3D int32 dtype', () => {
@@ -337,16 +330,14 @@ const testsZeros: MathTests = it => {
     const a = Array4D.zeros([3, 2, 1, 1]);
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([3, 2, 1, 1]);
-    test_util.expectArraysClose(
-        a, [0, 0, 0, 0, 0, 0]);
+    test_util.expectArraysClose(a, [0, 0, 0, 0, 0, 0]);
   });
 
   it('4D float32 dtype', () => {
     const a = Array4D.zeros([3, 2, 1, 1], 'float32');
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([3, 2, 1, 1]);
-    test_util.expectArraysClose(
-        a, [0, 0, 0, 0, 0, 0]);
+    test_util.expectArraysClose(a, [0, 0, 0, 0, 0, 0]);
   });
 
   it('4D int32 dtype', () => {
@@ -396,16 +387,14 @@ const testsOnes: MathTests = it => {
     const a = Array2D.ones([3, 2]);
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([3, 2]);
-    test_util.expectArraysClose(
-        a, [1, 1, 1, 1, 1, 1]);
+    test_util.expectArraysClose(a, [1, 1, 1, 1, 1, 1]);
   });
 
   it('2D float32 dtype', () => {
     const a = Array2D.ones([3, 2], 'float32');
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([3, 2]);
-    test_util.expectArraysClose(
-        a, [1, 1, 1, 1, 1, 1]);
+    test_util.expectArraysClose(a, [1, 1, 1, 1, 1, 1]);
   });
 
   it('2D int32 dtype', () => {
@@ -426,16 +415,14 @@ const testsOnes: MathTests = it => {
     const a = Array3D.ones([2, 2, 2]);
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([2, 2, 2]);
-    test_util.expectArraysClose(
-        a, [1, 1, 1, 1, 1, 1, 1, 1]);
+    test_util.expectArraysClose(a, [1, 1, 1, 1, 1, 1, 1, 1]);
   });
 
   it('3D float32 dtype', () => {
     const a = Array3D.ones([2, 2, 2], 'float32');
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([2, 2, 2]);
-    test_util.expectArraysClose(
-        a, [1, 1, 1, 1, 1, 1, 1, 1]);
+    test_util.expectArraysClose(a, [1, 1, 1, 1, 1, 1, 1, 1]);
   });
 
   it('3D int32 dtype', () => {
@@ -456,16 +443,14 @@ const testsOnes: MathTests = it => {
     const a = Array4D.ones([3, 2, 1, 1]);
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([3, 2, 1, 1]);
-    test_util.expectArraysClose(
-        a, [1, 1, 1, 1, 1, 1]);
+    test_util.expectArraysClose(a, [1, 1, 1, 1, 1, 1]);
   });
 
   it('4D float32 dtype', () => {
     const a = Array4D.ones([3, 2, 1, 1], 'float32');
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([3, 2, 1, 1]);
-    test_util.expectArraysClose(
-        a, [1, 1, 1, 1, 1, 1]);
+    test_util.expectArraysClose(a, [1, 1, 1, 1, 1, 1]);
   });
 
   it('4D int32 dtype', () => {
@@ -757,8 +742,7 @@ const testsFill: MathTests = it => {
 
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([3, 2]);
-    test_util.expectArraysClose(
-        a, [2, 2, 2, 2, 2, 2]);
+    test_util.expectArraysClose(a, [2, 2, 2, 2, 2, 2]);
   });
 
   it('3D fill', () => {
@@ -767,8 +751,7 @@ const testsFill: MathTests = it => {
 
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([3, 2, 1]);
-    test_util.expectArraysClose(
-        a, [2, 2, 2, 2, 2, 2]);
+    test_util.expectArraysClose(a, [2, 2, 2, 2, 2, 2]);
   });
 
   it('4D fill', () => {
@@ -777,8 +760,7 @@ const testsFill: MathTests = it => {
 
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([3, 2, 1, 2]);
-    test_util.expectArraysClose(
-        a, [2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]);
+    test_util.expectArraysClose(a, [2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]);
   });
 };
 
@@ -1337,6 +1319,15 @@ const testsAsType: MathTests = it => {
     expect(a.get(1, 1)).toBe(0);
   });
 
+  it('array2d int32 -> bool', () => {
+    const a = Array2D.new([2, 2], [1, 3, 0, -1], 'int32').asType('bool');
+    expect(a.dtype).toBe('bool');
+    expect(a.get(0, 0)).toBe(1);
+    expect(a.get(0, 1)).toBe(1);
+    expect(a.get(1, 0)).toBe(0);
+    expect(a.get(1, 1)).toBe(1);
+  });
+
   it('array3d bool -> float32', () => {
     const a = Array3D.new([2, 2, 1], [true, false, false, true], 'bool')
                   .asType('float32');
@@ -1842,8 +1833,7 @@ const testsFromPixels: MathTests = it => {
 
     const array = Array3D.fromPixels(pixels, 3);
 
-    test_util.expectArraysEqual(
-        array, [0, 80, 160]);
+    test_util.expectArraysEqual(array, [0, 80, 160]);
   });
 
   it('ImageData 1x1x4', () => {
@@ -1855,8 +1845,7 @@ const testsFromPixels: MathTests = it => {
 
     const array = Array3D.fromPixels(pixels, 4);
 
-    test_util.expectArraysEqual(
-        array, [0, 80, 160, 240]);
+    test_util.expectArraysEqual(array, [0, 80, 160, 240]);
   });
 
   it('ImageData 2x2x3', () => {
@@ -1872,8 +1861,7 @@ const testsFromPixels: MathTests = it => {
     const array = Array3D.fromPixels(pixels, 3);
 
     test_util.expectArraysEqual(
-        array,
-        [0, 2, 4, 8, 10, 12, 16, 18, 20, 24, 26, 28]);
+        array, [0, 2, 4, 8, 10, 12, 16, 18, 20, 24, 26, 28]);
   });
 
   it('ImageData 2x2x4', () => {

--- a/src/math/ndarray_test.ts
+++ b/src/math/ndarray_test.ts
@@ -1296,6 +1296,14 @@ const testsReshape: MathTests = it => {
     expect(b.dtype).toBe('int32');
     expect(b.shape).toEqual([3, 2]);
   });
+
+  it('reshape is functional', math => {
+    const a = Scalar.new(2.4);
+    const b = a.reshape([]);
+    expect(a.id).not.toBe(b.id);
+    b.dispose();
+    test_util.expectArraysClose(a, [2.4]);
+  });
 };
 const testsAsType: MathTests = it => {
   it('scalar bool -> int32', () => {
@@ -1343,6 +1351,14 @@ const testsAsType: MathTests = it => {
   it('int32 CPU -> GPU -> CPU', () => {
     const a = Array1D.new([1, 2, 0, 0, 5], 'int32');
     test_util.expectArraysEqual(a, [1, 2, 0, 0, 5]);
+  });
+
+  it('asType is functional', math => {
+    const a = Scalar.new(2.4, 'float32');
+    const b = a.asType('float32');
+    expect(a.id).not.toBe(b.id);
+    b.dispose();
+    test_util.expectArraysClose(a, [2.4]);
   });
 };
 const testsAsXD: MathTests = it => {

--- a/src/math/variable.ts
+++ b/src/math/variable.ts
@@ -33,14 +33,13 @@ export class Variable<D extends DataType = DataType, R extends Rank = Rank>
       initialValue: NDArray<D, R>, public trainable = true, name?: string) {
     super(
         initialValue.shape, initialValue.dtype, null /* values */,
-        initialValue.id);
+        initialValue.dataId);
     this.name = name;
     if (this.name == null) {
       this.name = Variable.nextVarId.toString();
       Variable.nextVarId++;
     }
     ENV.math.registerVariable(this);
-    ENV.math.keep(this);
   }
 
   /**
@@ -72,9 +71,9 @@ export class Variable<D extends DataType = DataType, R extends Rank = Rank>
           `shape of the new value (${newValue.shape}) and ` +
           `previous value (${this.shape}) must match`);
     }
-    this.math.disposeData(this.id);
-    this.id = newValue.id;
-    ENV.math.keep(this);
+    this.math.disposeData(this.dataId);
+    this.dataId = newValue.dataId;
+    ENV.math.register(this);
   }
 }
 

--- a/src/math/variable_test.ts
+++ b/src/math/variable_test.ts
@@ -21,7 +21,7 @@ import {Array1D, Array2D} from './ndarray';
 import {variable, Variable} from './variable';
 
 const tests: MathTests = it => {
-  it('simple update', math => {
+  it('simple assign', math => {
     const v = variable(Array1D.new([1, 2, 3]));
     test_util.expectArraysClose(v, [1, 2, 3]);
 
@@ -75,25 +75,30 @@ const tests: MathTests = it => {
     expect(math.getNumArrays()).toBe(0);
   });
 
-  it('update will dispose old data', math => {
+  it('assign will dispose old data', math => {
     let v: Variable<'float32', '1'>;
-    const firstValue = Array1D.new([1, 2, 3]);
+    math.scope(() => {
+      math.scope(() => {
+        const firstArray = Array1D.new([1, 2, 3]);
+        v = variable(firstArray);
+      });
+      expect(math.getNumArrays()).toBe(1);
+      test_util.expectArraysClose(v, [1, 2, 3]);
 
-    v = variable(firstValue);
-    expect(math.getNumArrays()).toBe(1);
+      const secondArray = Array1D.new([4, 5, 6]);
+      expect(math.getNumArrays()).toBe(2);
 
-    const secondValue = Array1D.new([4, 5, 6]);
-    expect(math.getNumArrays()).toBe(2);
+      v.assign(secondArray);
+      test_util.expectArraysClose(v, [4, 5, 6]);
+      // The first array was disposed since there is no reference to it.
+      expect(math.getNumArrays()).toBe(1);
 
-    v.assign(secondValue);
-    expect(math.getNumArrays()).toBe(1);
-    // The first value was disposed.
-    expect(() => firstValue.dataSync()).toThrowError();
-
-    v.dispose();
+      v.dispose();
+      // The second array is not disposed since there is one reference to it.
+      expect(math.getNumArrays()).toBe(1);
+    });
+    // The outer scope ended, second array has 0 references and is disposed.
     expect(math.getNumArrays()).toBe(0);
-    // The second value was disposed.
-    expect(() => secondValue.dataSync()).toThrowError();
   });
 
   it('shape must match', math => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -376,3 +376,20 @@ export function unflattenToNameArrayMap(
   }
   return result;
 }
+
+/**
+ * Returns true if the new type can't encode the old type without loss of
+ * precision.
+ */
+export function hasEncodingLoss(oldType: DataType, newType: DataType): boolean {
+  if (newType === 'float32') {
+    return false;
+  }
+  if (newType === 'int32' && oldType !== 'float32') {
+    return false;
+  }
+  if (newType === 'bool' && oldType === 'bool') {
+    return false;
+  }
+  return true;
+}

--- a/src/util_test.ts
+++ b/src/util_test.ts
@@ -354,3 +354,30 @@ describe('util.checkForNaN', () => {
 
   test_util.describeMathCPU('util.unflattenToNameArrayMap', [tests]);
 }
+
+describe('util.hasEncodingLoss', () => {
+  it('any to float32', () => {
+    expect(util.hasEncodingLoss('bool', 'float32')).toBe(false);
+    expect(util.hasEncodingLoss('int32', 'float32')).toBe(false);
+    expect(util.hasEncodingLoss('float32', 'float32')).toBe(false);
+  });
+
+  it('float32 to any', () => {
+    expect(util.hasEncodingLoss('float32', 'float32')).toBe(false);
+    expect(util.hasEncodingLoss('float32', 'int32')).toBe(true);
+    expect(util.hasEncodingLoss('float32', 'bool')).toBe(true);
+  });
+
+  it('int32 to lower', () => {
+    expect(util.hasEncodingLoss('int32', 'int32')).toBe(false);
+    expect(util.hasEncodingLoss('int32', 'bool')).toBe(true);
+  });
+
+  it('lower to int32', () => {
+    expect(util.hasEncodingLoss('bool', 'int32')).toBe(false);
+  });
+
+  it('bool to bool', () => {
+    expect(util.hasEncodingLoss('bool', 'bool')).toBe(false);
+  });
+});


### PR DESCRIPTION
Now each `NDArray` has a unique `id`, but can share its `dataId` with other arrays.

- `const b = a.reshape(newShape)`
  - `b` has a different `id`, but the same `dataId` as `a`.
- `const b = a.asType(newType)`
   - `b` has a different `id`, and
   - same `dataId` if casting to a wider type (no loss of precision)
   - different `dataId` if casting to a narrower type, in which case we need to trim the data (e.g. flooring when doing to `int32`)

Also added:
 - `math.notEqual()`, analogous to `tf.not_equal()`.
 - `math.cast()` analogous to `tf.cast()`
 - `backend.int()` since it's a non-trivial operation: positive numbers are floored, negative numbers are ceiled. This is not exposed to the user. `math.cast()` uses it internally.

Fixes #484 
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/499)
<!-- Reviewable:end -->

  