### PR TITLE
Fix a bug in webgl storage and fix demos

### DIFF
--- a/demos/complementary-color-prediction/complementary-color-prediction.ts
+++ b/demos/complementary-color-prediction/complementary-color-prediction.ts
@@ -16,7 +16,7 @@
  */
 
 // tslint:disable-next-line:max-line-length
-import {Array1D, CostReduction, ENV, FeedEntry, Graph, InCPUMemoryShuffledInputProviderBuilder, NDArrayMath, Session, SGDOptimizer, Tensor} from 'deeplearn';
+import {Array1D, CostReduction, ENV, FeedEntry, Graph, InCPUMemoryShuffledInputProviderBuilder, Session, SGDOptimizer, Tensor} from 'deeplearn';
 
 class ComplementaryColorModel {
   // Runs training.
@@ -126,7 +126,7 @@ class ComplementaryColorModel {
 
   predict(rgbColor: number[]): number[] {
     let complementColor: number[] = [];
-    this.math.scope((keep, track) => {
+    this.math.scope(() => {
       const mapping = [{
         tensor: this.inputTensor,
         data: Array1D.new(this.normalizeColor(rgbColor)),
@@ -156,10 +156,6 @@ class ComplementaryColorModel {
    */
   private generateTrainingData(exampleCount: number) {
     const rawInputs = new Array(exampleCount);
-    const oldMath = ENV.math;
-    const safeMode = false;
-    const math = new NDArrayMath('cpu', safeMode);
-    ENV.setMath(math);
 
     for (let i = 0; i < exampleCount; i++) {
       rawInputs[i] = [
@@ -187,7 +183,6 @@ class ComplementaryColorModel {
       {tensor: this.inputTensor, data: inputProvider},
       {tensor: this.targetTensor, data: targetProvider}
     ];
-    ENV.setMath(oldMath);
   }
 
   private generateRandomChannelValue() {

--- a/demos/complementary-color-prediction/complementary-color-prediction.ts
+++ b/demos/complementary-color-prediction/complementary-color-prediction.ts
@@ -25,12 +25,12 @@ class ComplementaryColorModel {
   // Encapsulates math operations on the CPU and GPU.
   math = ENV.math;
 
-  // An optimizer with a certain initial learning rate. Used for training.
-  initialLearningRate = 0.042;
+  // An optimizer with a certain learning rate. Used for training.
+  learningRate = 0.1;
   optimizer: SGDOptimizer;
 
   // Each training batch will be on this many examples.
-  batchSize = 300;
+  batchSize = 50;
 
   inputTensor: Tensor;
   targetTensor: Tensor;
@@ -41,7 +41,7 @@ class ComplementaryColorModel {
   feedEntries: FeedEntry[];
 
   constructor() {
-    this.optimizer = new SGDOptimizer(this.initialLearningRate);
+    this.optimizer = new SGDOptimizer(this.learningRate);
   }
 
   /**
@@ -94,7 +94,7 @@ class ComplementaryColorModel {
   train1Batch(shouldFetchCost: boolean): number {
     // Every 42 steps, lower the learning rate by 15%.
     const learningRate =
-        this.initialLearningRate * Math.pow(0.85, Math.floor(step / 42));
+        this.learningRate * Math.pow(0.85, Math.floor(step / 42));
     this.optimizer.setLearningRate(learningRate);
 
     // Train 1 batch.

--- a/demos/fast-style-transfer/net.ts
+++ b/demos/fast-style-transfer/net.ts
@@ -131,13 +131,13 @@ export class TransformNet implements Model {
   private instanceNorm(input: Array3D, varId: number): Array3D {
     const [height, width, inDepth]: [number, number, number] = input.shape;
     const moments = this.math.moments(input, [0, 1]);
-    const mu = moments.mean as Array3D;
+    const mu = moments.mean;
     const sigmaSq = moments.variance as Array3D;
     const shift = this.variables[this.varName(varId)] as Array1D;
     const scale = this.variables[this.varName(varId + 1)] as Array1D;
     const epsilon = this.epsilonScalar;
     const normalized = this.math.divide(
-        this.math.sub(input, mu),
+        this.math.sub(input.asType('float32'), mu),
         this.math.sqrt(this.math.add(sigmaSq, epsilon)));
     const shifted = this.math.add(this.math.multiply(scale, normalized), shift);
     return shifted.as3D(height, width, inDepth);

--- a/demos/game_of_life/game_of_life.ts
+++ b/demos/game_of_life/game_of_life.ts
@@ -29,7 +29,9 @@ export class GameOfLife {
     this.size = size;
   }
 
-  setSize(size: number) { this.size = size; }
+  setSize(size: number) {
+    this.size = size;
+  }
 
   generateGolExample(): [NDArray, NDArray] {
     let world: NDArray;
@@ -120,7 +122,7 @@ export class GameOfLife {
         }
       }
     }
-    return Array2D.new(shape as[number, number], values, 'int32');
+    return Array2D.new(shape as [number, number], values, 'int32');
   }
 }
 
@@ -148,7 +150,9 @@ export class GameOfLifeModel {
   // Maps tensors to InputProviders
   feedEntries: FeedEntry[];
 
-  constructor(math: NDArrayMath) { this.math = math; }
+  constructor(math: NDArrayMath) {
+    this.math = math;
+  }
 
   setupSession(
       boardSize: number, batchSize: number, initialLearningRate: number,
@@ -199,10 +203,8 @@ export class GameOfLifeModel {
   predict(world: NDArray): Array2D {
     let values = null;
     this.math.scope(() => {
-      const mapping = [{
-        tensor: this.inputTensor,
-        data: world.reshape([this.size * this.size])
-      }];
+      const mapping =
+          [{tensor: this.inputTensor, data: world.flatten().asType('float32')}];
 
       const evalOutput = this.session.eval(this.predictionTensor, mapping);
       values = evalOutput.dataSync();
@@ -215,8 +217,8 @@ export class GameOfLifeModel {
     const outputs = [];
     for (let i = 0; i < worlds.length; i++) {
       const example = worlds[i];
-      inputs.push(example[0].reshape([this.size * this.size]));
-      outputs.push(example[1].reshape([this.size * this.size]));
+      inputs.push(example[0].flatten().asType('float32'));
+      outputs.push(example[1].flatten().asType('float32'));
     }
 
     // TODO(kreeger): Don't really need to shuffle these.

--- a/demos/imagenet/imagenet.html
+++ b/demos/imagenet/imagenet.html
@@ -58,7 +58,9 @@ limitations under the License.
       </paper-listbox>
     </paper-dropdown-menu>
     <div id="imgContainer">
-      <video autoplay="true" id="webcamVideo" width="227" height="227"></video>
+      <video autoplay playsinline muted id="webcamVideo" width="227" height="227"></video>
+      <!-- Used for capturing frames from the video tag -->
+      <canvas id="video-canvas" style="display: none;"></canvas>
       <img id="staticImg" style="display: none"/>
     </div>
 

--- a/demos/imagenet/imagenet.html
+++ b/demos/imagenet/imagenet.html
@@ -59,8 +59,6 @@ limitations under the License.
     </paper-dropdown-menu>
     <div id="imgContainer">
       <video autoplay playsinline muted id="webcamVideo" width="227" height="227"></video>
-      <!-- Used for capturing frames from the video tag -->
-      <canvas id="video-canvas" style="display: none;"></canvas>
       <img id="staticImg" style="display: none"/>
     </div>
 

--- a/demos/imagenet/imagenet.ts
+++ b/demos/imagenet/imagenet.ts
@@ -64,6 +64,9 @@ export class ImagenetDemo extends ImagenetDemoPolymer {
   private webcamVideoElement: HTMLVideoElement;
   private staticImgElement: HTMLImageElement;
   private inferenceCanvas: HTMLCanvasElement;
+  /** Hidden. Used only for capturing frames from the video tag. */
+  private videoCanvas: HTMLCanvasElement;
+  private videoCtx: CanvasRenderingContext2D;
 
   private isMediaLoaded = false;
 
@@ -74,6 +77,10 @@ export class ImagenetDemo extends ImagenetDemoPolymer {
         this.querySelector('#staticImg') as HTMLImageElement;
     this.webcamVideoElement =
         this.querySelector('#webcamVideo') as HTMLVideoElement;
+    this.videoCanvas = this.querySelector('#video-canvas') as HTMLCanvasElement;
+    this.videoCanvas.height = this.webcamVideoElement.height;
+    this.videoCanvas.width = this.webcamVideoElement.width;
+    this.videoCtx = this.videoCanvas.getContext('2d');
 
     const gl = gpgpu_util.createWebGLContext(this.inferenceCanvas);
     this.gpgpu = new GPGPUContext(gl);
@@ -184,7 +191,8 @@ export class ImagenetDemo extends ImagenetDemoPolymer {
 
       const element =
           isWebcam ? this.webcamVideoElement : this.staticImgElement;
-      const image = Array3D.fromPixels(element, 3, this.math);
+      this.videoCtx.drawImage(element, 0, 0, element.width, element.height);
+      const image = Array3D.fromPixels(this.videoCanvas, 3, this.math);
 
       const inferenceResult =
           this.squeezeNet.predictWithActivation(image, this.selectedLayerName);

--- a/demos/imagenet/imagenet.ts
+++ b/demos/imagenet/imagenet.ts
@@ -64,9 +64,6 @@ export class ImagenetDemo extends ImagenetDemoPolymer {
   private webcamVideoElement: HTMLVideoElement;
   private staticImgElement: HTMLImageElement;
   private inferenceCanvas: HTMLCanvasElement;
-  /** Hidden. Used only for capturing frames from the video tag. */
-  private videoCanvas: HTMLCanvasElement;
-  private videoCtx: CanvasRenderingContext2D;
 
   private isMediaLoaded = false;
 
@@ -77,10 +74,6 @@ export class ImagenetDemo extends ImagenetDemoPolymer {
         this.querySelector('#staticImg') as HTMLImageElement;
     this.webcamVideoElement =
         this.querySelector('#webcamVideo') as HTMLVideoElement;
-    this.videoCanvas = this.querySelector('#video-canvas') as HTMLCanvasElement;
-    this.videoCanvas.height = this.webcamVideoElement.height;
-    this.videoCanvas.width = this.webcamVideoElement.width;
-    this.videoCtx = this.videoCanvas.getContext('2d');
 
     const gl = gpgpu_util.createWebGLContext(this.inferenceCanvas);
     this.gpgpu = new GPGPUContext(gl);
@@ -191,8 +184,7 @@ export class ImagenetDemo extends ImagenetDemoPolymer {
 
       const element =
           isWebcam ? this.webcamVideoElement : this.staticImgElement;
-      this.videoCtx.drawImage(element, 0, 0, element.width, element.height);
-      const image = Array3D.fromPixels(this.videoCanvas, 3, this.math);
+      const image = Array3D.fromPixels(element, 3, this.math);
 
       const inferenceResult =
           this.squeezeNet.predictWithActivation(image, this.selectedLayerName);

--- a/demos/nn-art/cppn.ts
+++ b/demos/nn-art/cppn.ts
@@ -34,8 +34,8 @@ const colorModeOutputDimensions: {[colorMode in ColorMode]: number} = {
 
 export type ActivationFunction = 'tanh'|'sin'|'relu'|'step';
 const activationFunctionMap: {
-  [activationFunction in ActivationFunction]:
-      (math: NDArrayMath, ndarray: Array2D) => Array2D
+  [activationFunction in ActivationFunction]: (
+      math: NDArrayMath, ndarray: Array2D) => Array2D
 } = {
   'tanh': (math: NDArrayMath, ndarray: Array2D) => math.tanh(ndarray),
   'sin': (math: NDArrayMath, ndarray: Array2D) => math.sin(ndarray),

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -50,6 +50,10 @@ module.exports = function(config) {
         os: 'OS X',
         os_version: 'Sierra'
       },
+      chrome_with_swift_shader: {
+        base: 'Chrome',
+        flags: ['--blacklist-accelerated-compositing', '--blacklist-webgl']
+      }
     },
     client: {
       args: ['--grep', config.grep || '']

--- a/models/squeezenet/squeezenet.ts
+++ b/models/squeezenet/squeezenet.ts
@@ -67,7 +67,8 @@ export class SqueezeNet implements Model {
       let activation: Array3D;
       // Preprocess the input.
       const preprocessedInput =
-          this.math.subtract(input, this.preprocessOffset) as Array3D;
+          this.math.subtract(input.asType('float32'), this.preprocessOffset) as
+          Array3D;
       const conv1 = this.math.conv2d(
           preprocessedInput, this.variables['conv1_W:0'] as Array4D,
           this.variables['conv1_b:0'] as Array1D, 2, 0);

--- a/src/graph_runner.ts
+++ b/src/graph_runner.ts
@@ -311,7 +311,7 @@ export class GraphRunner {
             this.session.eval(this.metricTensor, this.metricFeedEntries) as
             NDArray<'float32'>;
 
-        metric = this.math.add(metric, metricValue);
+        metric = this.math.add(metric, metricValue.asType('float32'));
       }
 
       if (this.metricReduction === MetricReduction.MEAN) {

--- a/src/math/backends/backend.ts
+++ b/src/math/backends/backend.ts
@@ -26,13 +26,13 @@ export interface NDArrayStorage {
   read<D extends DataType>(id: number): Promise<DataTypeMap[D]>;
   readSync<D extends DataType>(id: number): DataTypeMap[D];
   disposeData(id: number): void;
-  write<D extends DataType>(
-      id: number, values: DataTypeMap[D], dtype: D, shape: number[]): void;
+  write<D extends DataType>(id: number, values: DataTypeMap[D]): void;
   writePixels(
       id: number,
       pixels: ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement,
       numChannels: number): void;
   time(query: () => NDArray): Promise<number>;
+  register(id: number, shape: number[], dtype: DataType): void;
 }
 
 /**

--- a/src/math/backends/backend_cpu.ts
+++ b/src/math/backends/backend_cpu.ts
@@ -34,18 +34,24 @@ import {MatrixOrientation} from './types/matmul';
 
 export class MathBackendCPU implements MathBackend {
   private data: {[id: number]: DataTypeMap[DataType]} = {};
-
-  dispose() {}
-  write<D extends DataType>(
-      id: number, values: DataTypeMap[D], dtype: D, shape: number[]): void {
-    if (values != null) {
-      this.data[id] = values;
+  register(id: number, shape: number[], dtype: DataType): void {
+    this.data[id] = null;
+  }
+  write<D extends DataType>(id: number, values: DataTypeMap[D]): void {
+    if (values == null) {
+      throw new Error('MathBackendCPU.write(): values can not be null');
     }
+    this.throwIfNoData(id);
+    this.data[id] = values;
   }
   writePixels(
       id: number,
       pixels: ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement,
       numChannels: number): void {
+    if (pixels == null) {
+      throw new Error('MathBackendCPU.writePixels(): pixels can not be null');
+    }
+    this.throwIfNoData(id);
     let vals: Uint8ClampedArray;
     if (pixels instanceof ImageData) {
       vals = pixels.data;
@@ -1406,6 +1412,7 @@ export class MathBackendCPU implements MathBackend {
     }
     return result;
   }
+  dispose() {}
 }
 
 ENV.registerBackend('cpu', () => new MathBackendCPU());

--- a/src/math/backends/backend_cpu.ts
+++ b/src/math/backends/backend_cpu.ts
@@ -34,6 +34,14 @@ import {MatrixOrientation} from './types/matmul';
 
 export class MathBackendCPU implements MathBackend {
   private data: {[id: number]: DataTypeMap[DataType]} = {};
+  private canvas: HTMLCanvasElement;
+
+  constructor() {
+    if (typeof document !== 'undefined') {
+      this.canvas = document.createElement('canvas');
+    }
+  }
+
   register(id: number, shape: number[], dtype: DataType): void {
     this.data[id] = null;
   }
@@ -62,13 +70,17 @@ export class MathBackendCPU implements MathBackend {
     } else if (
         pixels instanceof HTMLImageElement ||
         pixels instanceof HTMLVideoElement) {
-      const canvas = document.createElement('canvas');
-      canvas.width = pixels.width;
-      canvas.height = pixels.height;
-      canvas.getContext('2d').drawImage(
-          pixels, 0, 0, canvas.width, canvas.height);
-      vals = canvas.getContext('2d')
-                 .getImageData(0, 0, canvas.width, canvas.height)
+      if (this.canvas == null) {
+        throw new Error(
+            'Can\'t read pixels from HTMLImageElement outside ' +
+            'the browser.');
+      }
+      this.canvas.width = pixels.width;
+      this.canvas.height = pixels.height;
+      this.canvas.getContext('2d').drawImage(
+          pixels, 0, 0, pixels.width, pixels.height);
+      vals = this.canvas.getContext('2d')
+                 .getImageData(0, 0, pixels.width, pixels.height)
                  .data;
     } else {
       throw new Error(

--- a/src/math/backends/backend_cpu.ts
+++ b/src/math/backends/backend_cpu.ts
@@ -38,7 +38,9 @@ export class MathBackendCPU implements MathBackend {
   dispose() {}
   write<D extends DataType>(
       id: number, values: DataTypeMap[D], dtype: D, shape: number[]): void {
-    this.data[id] = values;
+    if (values != null) {
+      this.data[id] = values;
+    }
   }
   writePixels(
       id: number,
@@ -1311,11 +1313,11 @@ export class MathBackendCPU implements MathBackend {
       x: Array4D, mean: Array4D|Array1D, variance: Array4D|Array1D,
       varianceEpsilon: number, scale?: Array4D|Array1D,
       offset?: Array4D|Array1D): Array4D {
-    const xValues = x.getValues();
-    const meanValues = mean.getValues();
-    const varianceValues = variance.getValues();
-    const scaleValues = scale ? scale.getValues() : new Float32Array([1]);
-    const offsetValues = offset ? offset.getValues() : new Float32Array([0]);
+    const xValues = x.dataSync();
+    const meanValues = mean.dataSync();
+    const varianceValues = variance.dataSync();
+    const scaleValues = scale ? scale.dataSync() : new Float32Array([1]);
+    const offsetValues = offset ? offset.dataSync() : new Float32Array([0]);
     const outValues = new Float32Array(xValues.length);
 
     for (let i = 0; i < xValues.length; i++) {

--- a/src/math/backends/backend_webgl.ts
+++ b/src/math/backends/backend_webgl.ts
@@ -84,10 +84,10 @@ export class MathBackendWebGL implements MathBackend {
   }
   write<D extends DataType>(
       id: number, values: DataTypeMap[D], dtype: D, shape: number[]): void {
-    if (values == null) {
-      throw new Error('MathBackendWebGL.write(): values can not be null');
-    }
     const {texture, texShape} = this.getOrMakeTexData(id, shape, dtype);
+    if (values == null) {
+      return;
+    }
     if (texture != null) {
       // Release the old texture.
       this.textureManager.releaseTexture(texture, texShape);

--- a/src/math/backends/backend_webgl.ts
+++ b/src/math/backends/backend_webgl.ts
@@ -26,7 +26,6 @@ import {Array1D, Array2D, Array3D, Array4D, DataType, DataTypeMap, NDArray} from
 import * as reduce_util from '../reduce_util';
 import * as types from '../types';
 import {SumTypes, SumTypesMap} from '../types';
-
 import {MathBackend} from './backend';
 import {MatrixOrientation} from './types/matmul';
 import {ArgMinMaxProgram} from './webgl/argminmax_gpu';
@@ -63,15 +62,34 @@ import * as webgl_util from './webgl/webgl_util';
 export class MathBackendWebGL implements MathBackend {
   private texData: {[id: number]: TextureData} = {};
 
+  register(id: number, shape: number[], dtype: DataType): void {
+    if (id in this.texData) {
+      throw new Error(`id ${id} already registered`);
+    }
+    this.texData[id] = {
+      shape,
+      dtype,
+      values: null,
+      texture: null,
+      texShape: null,
+      textureType: null
+    };
+  }
   writePixels(
       id: number,
       pixels: ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement,
       numChannels: number): void {
+    if (pixels == null) {
+      throw new Error('MathBackendWebGL.writePixels(): pixels can not be null');
+    }
+    this.throwIfNoData(id);
     const texShape: [number, number] = [pixels.height, pixels.width];
-    const texture = id in this.texData ?
-        this.texData[id].texture :
+    const texture = this.texData[id].texture ||
         this.textureManager.acquireTexture(texShape);
+    const {shape} = this.texData[id];
+
     this.texData[id] = {
+      shape,
       values: null,
       texture,
       textureType: TextureType.RGBA_COLOR,
@@ -82,34 +100,25 @@ export class MathBackendWebGL implements MathBackend {
     // Pixel data is immediate storage since it already lives on gpu.
     this.gpgpu.uploadPixelDataToTexture(texture, pixels);
   }
-  write<D extends DataType>(
-      id: number, values: DataTypeMap[D], dtype: D, shape: number[]): void {
-    const {texture, texShape} = this.getOrMakeTexData(id, shape, dtype);
+  write<D extends DataType>(id: number, values: DataTypeMap[D]): void {
     if (values == null) {
-      return;
+      throw new Error('MathBackendWebGL.write(): values can not be null');
     }
+    this.throwIfNoData(id);
+
+    const {texture, texShape} = this.texData[id];
     if (texture != null) {
       // Release the old texture.
       this.textureManager.releaseTexture(texture, texShape);
       this.texData[id].texture = null;
+      this.texData[id].texShape = null;
+      this.texData[id].textureType = null;
     }
-    // Point to the new values.
     this.texData[id].values = values;
+
     if (!this.delayedStorage) {
       this.uploadToGPU(id);
     }
-  }
-
-  private getOrMakeTexData(id: number, shape: number[], dtype: DataType):
-      TextureData {
-    if (!(id in this.texData)) {
-      const texShape =
-          webgl_util.getTextureShapeFromLogicalShape(this.gpgpu.gl, shape);
-      const textureType = TextureType.DEFAULT;
-      this.texData[id] =
-          {texture: null, values: null, textureType, texShape, dtype};
-    }
-    return this.texData[id];
   }
 
   readSync<D extends DataType>(id: number): DataTypeMap[D] {
@@ -208,6 +217,7 @@ export class MathBackendWebGL implements MathBackend {
 
   clone<D extends DataType, T extends NDArray<D>>(x: T): T {
     this.throwIfNoData(x.id);
+    this.uploadToGPU(x.id);
     const {texShape} = this.texData[x.id];
     // Pretend the source was in logical shape that matches the texture shape.
     const source = x.as2D(texShape[0], texShape[1]);
@@ -755,7 +765,6 @@ export class MathBackendWebGL implements MathBackend {
       this.uploadToGPU(input.id);
       return {array: input, texData: this.texData[input.id]};
     });
-    this.getOrMakeTexData(output.id, output.shape, output.dtype);
     this.uploadToGPU(output.id);
     const outputData = {array: output, texData: this.texData[output.id]};
     const key = gpgpu_math.makeShaderKey(program, inputsData, outputData);
@@ -802,11 +811,15 @@ export class MathBackendWebGL implements MathBackend {
 
   private uploadToGPU(id: number): void {
     this.throwIfNoData(id);
-    const {texShape, values, texture, dtype} = this.texData[id];
+    const {shape, values, texture, dtype} = this.texData[id];
     if (texture != null) {
       // Array is already on GPU. No-op.
       return;
     }
+    const texShape =
+        webgl_util.getTextureShapeFromLogicalShape(this.gpgpu.gl, shape);
+    this.texData[id].textureType = TextureType.DEFAULT;
+    this.texData[id].texShape = texShape;
     const newTexture = this.textureManager.acquireTexture(texShape);
     this.texData[id].texture = newTexture;
     if (values != null) {
@@ -826,6 +839,8 @@ export class MathBackendWebGL implements MathBackend {
     if (dontKeepCopyOnGPU && texture != null) {
       this.textureManager.releaseTexture(texture, texShape);
       this.texData[id].texture = null;
+      this.texData[id].texShape = null;
+      this.texData[id].textureType = null;
     }
     if (float32Values != null) {
       this.texData[id].values = float32ToTypedArray(float32Values, dtype);

--- a/src/math/backends/backend_webgl_test.ts
+++ b/src/math/backends/backend_webgl_test.ts
@@ -24,7 +24,8 @@ const tests: Tests = () => {
     const delayedStorage = true;
     const backend = new MathBackendWebGL(null, delayedStorage);
     const texManager = backend.getTextureManager();
-    backend.write(0, new Float32Array([1, 2, 3]), 'float32', [3]);
+    backend.register(0, [3], 'float32');
+    backend.write(0, new Float32Array([1, 2, 3]));
     expect(texManager.getNumUsedTextures()).toBe(0);
     backend.getTexture(0);
     expect(texManager.getNumUsedTextures()).toBe(1);
@@ -41,11 +42,12 @@ const tests: Tests = () => {
     const delayedStorage = true;
     const backend = new MathBackendWebGL(null, delayedStorage);
     const texManager = backend.getTextureManager();
-    backend.write(0, new Float32Array([1, 2, 3]), 'float32', [3]);
+    backend.register(0, [3], 'float32');
+    backend.write(0, new Float32Array([1, 2, 3]));
     backend.getTexture(0);
     expect(texManager.getNumUsedTextures()).toBe(1);
     // overwrite.
-    backend.write(0, new Float32Array([4, 5, 6]), 'float32', [3]);
+    backend.write(0, new Float32Array([4, 5, 6]));
     expect(texManager.getNumUsedTextures()).toBe(0);
     test_util.expectArraysClose(
         backend.readSync(0), new Float32Array([4, 5, 6]));
@@ -60,7 +62,8 @@ const tests: Tests = () => {
     const delayedStorage = false;
     const backend = new MathBackendWebGL(null, delayedStorage);
     const texManager = backend.getTextureManager();
-    backend.write(0, new Float32Array([1, 2, 3]), 'float32', [3]);
+    backend.register(0, [3], 'float32');
+    backend.write(0, new Float32Array([1, 2, 3]));
     expect(texManager.getNumUsedTextures()).toBe(1);
     test_util.expectArraysClose(
         backend.readSync(0), new Float32Array([1, 2, 3]));
@@ -73,9 +76,10 @@ const tests: Tests = () => {
     const delayedStorage = false;
     const backend = new MathBackendWebGL(null, delayedStorage);
     const texManager = backend.getTextureManager();
-    backend.write(0, new Float32Array([1, 2, 3]), 'float32', [3]);
+    backend.register(0, [3], 'float32');
+    backend.write(0, new Float32Array([1, 2, 3]));
     expect(texManager.getNumUsedTextures()).toBe(1);
-    backend.write(0, new Float32Array([4, 5, 6]), 'float32', [3]);
+    backend.write(0, new Float32Array([4, 5, 6]));
     expect(texManager.getNumUsedTextures()).toBe(1);
     test_util.expectArraysClose(
         backend.readSync(0), new Float32Array([4, 5, 6]));
@@ -88,8 +92,10 @@ const tests: Tests = () => {
     const delayedStorage = false;
     const backend = new MathBackendWebGL(null, delayedStorage);
     const texManager = backend.getTextureManager();
-    backend.write(0, new Float32Array([1, 2, 3]), 'float32', [3]);
-    backend.write(1, new Float32Array([4, 5, 6]), 'float32', [3]);
+    backend.register(0, [3], 'float32');
+    backend.write(0, new Float32Array([1, 2, 3]));
+    backend.register(1, [3], 'float32');
+    backend.write(1, new Float32Array([4, 5, 6]));
     expect(texManager.getNumUsedTextures()).toBe(2);
     backend.dispose();
     expect(texManager.getNumUsedTextures()).toBe(0);

--- a/src/math/backends/webgl/gpgpu_context.ts
+++ b/src/math/backends/webgl/gpgpu_context.ts
@@ -107,7 +107,7 @@ export class GPGPUContext {
 
   public uploadPixelDataToTexture(
       texture: WebGLTexture,
-      pixels: ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement) {
+      pixels: ImageData|HTMLImageElement|HTMLCanvasElement) {
     this.throwIfDisposed();
     gpgpu_util.uploadPixelDataToTexture(this.gl, texture, pixels);
   }

--- a/src/math/backends/webgl/gpgpu_math.ts
+++ b/src/math/backends/webgl/gpgpu_math.ts
@@ -168,7 +168,8 @@ export function makeShaderKey(
     output: ArrayData<NDArray>): string {
   let keyInputs = '';
   inputs.concat(output).forEach(x => {
-    keyInputs += `${x.array.shape}_${x.texData.texShape}`;
+    keyInputs +=
+        `${x.array.shape}_${x.texData.texShape}_${x.texData.textureType}`;
   });
   const keyUserCode = program.userCode;
   const keyBroadcast = (program.supportsBroadcasting === true).toString();

--- a/src/math/backends/webgl/tex_util.ts
+++ b/src/math/backends/webgl/tex_util.ts
@@ -25,6 +25,7 @@ export enum TextureType {
 
 export interface TextureData {
   texture: WebGLTexture;
+  shape: number[];
   /** [rows, columns] shape of the texture. */
   texShape: [number, number];
   textureType: TextureType;

--- a/src/math/math.ts
+++ b/src/math/math.ts
@@ -19,10 +19,7 @@ import {BackendType, ENV} from '../environment';
 import * as util from '../util';
 import {NamedArrayMap} from '../util';
 import * as axis_util from './axis_util';
-// tslint:disable-next-line:max-line-length
-import {NDArrayStorage} from './backends/backend';
 import {MathBackend} from './backends/backend';
-// tslint:disable-next-line:max-line-length
 import {BackendEngine} from './backends/backend_engine';
 import {TapeNodeInputGradientArrays} from './backends/tape_types';
 import {ScopeResult, ScopeResultImmediate} from './backends/tape_util';
@@ -46,7 +43,7 @@ export interface NDArrayManager {
   registerVariable(v: Variable): void;
 }
 
-export class NDArrayMath implements NDArrayStorage, NDArrayManager {
+export class NDArrayMath implements NDArrayManager {
   protected backendEngine: BackendEngine;
   private registeredArrays = new Set();
   private backend: MathBackend;
@@ -68,6 +65,7 @@ export class NDArrayMath implements NDArrayStorage, NDArrayManager {
       throw new Error(`NDArray with id ${a.id} was already registered`);
     }
     this.registeredArrays.add(a.id);
+    this.backend.register(a.id, a.shape, a.dtype);
     this.backendEngine.track(a);
   }
 
@@ -84,9 +82,8 @@ export class NDArrayMath implements NDArrayStorage, NDArrayManager {
       numChannels: number): void {
     this.backend.writePixels(id, pixels, numChannels);
   }
-  write<D extends DataType>(
-      id: number, values: DataTypeMap[D], dtype: D, shape: number[]): void {
-    this.backend.write(id, values, dtype, shape);
+  write<D extends DataType>(id: number, values: DataTypeMap[D]): void {
+    this.backend.write(id, values);
   }
   readSync<D extends DataType>(id: number): DataTypeMap[D] {
     return this.backend.readSync(id);

--- a/src/math/ndarray.ts
+++ b/src/math/ndarray.ts
@@ -116,7 +116,9 @@ export class NDArray<D extends DataType = DataType, R extends Rank = Rank> {
       this.id = NDArray.nextId++;
       this.math.register(this);
     }
-    this.math.write(this.id, values, this.dtype, this.shape);
+    if (values != null) {
+      this.math.write(this.id, values);
+    }
   }
 
   /** Creates a ndarray of ones with the specified shape. */
@@ -297,7 +299,7 @@ export class NDArray<D extends DataType = DataType, R extends Rank = Rank> {
     }
     const vals = this.dataSync();
     vals[index] = value;
-    this.math.write(this.id, vals, this.dtype, this.shape);
+    this.math.write(this.id, vals);
   }
 
   async val(...locs: number[]): Promise<number> {
@@ -330,7 +332,7 @@ export class NDArray<D extends DataType = DataType, R extends Rank = Rank> {
     this.throwIfDisposed();
     const vals = this.dataSync();
     vals.fill(value);
-    this.math.write(this.id, vals, this.dtype, this.shape);
+    this.math.write(this.id, vals);
   }
 
   /** @deprecated Use dataSync() instead. */

--- a/src/math/ndarray.ts
+++ b/src/math/ndarray.ts
@@ -116,9 +116,7 @@ export class NDArray<D extends DataType = DataType, R extends Rank = Rank> {
       this.id = NDArray.nextId++;
       this.math.register(this);
     }
-    if (values != null) {
-      this.math.write(this.id, values, this.dtype, this.shape);
-    }
+    this.math.write(this.id, values, this.dtype, this.shape);
   }
 
   /** Creates a ndarray of ones with the specified shape. */
@@ -151,7 +149,7 @@ export class NDArray<D extends DataType = DataType, R extends Rank = Rank> {
 
   /** Creates a ndarray with the same values/shape as the specified ndarray. */
   static like<T extends NDArray>(another: T): T {
-    const newValues = copyTypedArray(another.getValues(), another.dtype);
+    const newValues = copyTypedArray(another.dataSync(), another.dtype);
     return NDArray.make(
                another.shape, {values: newValues}, another.dtype,
                another.math) as T;


### PR DESCRIPTION
- Fix a bug in webgl where the user can't directly interact with the backend like in `imagenet` and `cppn` demos (e.g. calling `backend.getTexture(id)` right after calling `NDArray.make()`)
- Make the backend storage mehanism clearer (separate registration from writing).
- Small changes of hyper-params in the complementary colors demo, to converge faster
- To be more compatible with TF, `add/sub/multiply/divide` now require both inputs to be of the same dtype. Update outdated demos and squeezenet model.

After this PR is in, I will:
- release a new `deeplearn` package
- release a new `deeplearn-squeezenet` package
- update `demos/package.json` to depend on the newest libraries

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/505)
<!-- Reviewable:end -->

  
  