### PR TITLE
Fix demos: Use `dataId` instead of `id` when calling `getTexture()`

### DIFF
--- a/demos/imagenet/imagenet.ts
+++ b/demos/imagenet/imagenet.ts
@@ -229,10 +229,10 @@ export class ImagenetDemo extends ImagenetDemoPolymer {
 
       imagenet_util.renderGrayscaleChannelsCollage(
           this.gpgpu, this.renderGrayscaleChannelsCollageShader,
-          this.backend.getTexture(activationNDArray.id),
-          this.backend.getTexture(minValues.id),
-          this.backend.getTexture(maxValues.id),
-          this.backend.getTextureData(activationNDArray.id).texShape,
+          this.backend.getTexture(activationNDArray.dataId),
+          this.backend.getTexture(minValues.dataId),
+          this.backend.getTexture(maxValues.dataId),
+          this.backend.getTextureData(activationNDArray.dataId).texShape,
           activationNDArray.shape[0], activationNDArray.shape[2],
           this.inferenceCanvas.width, numRows);
       // Unclear why, but unless we wait for the gpu to fully end, we get a

--- a/demos/nn-art/cppn.ts
+++ b/demos/nn-art/cppn.ts
@@ -152,8 +152,8 @@ export class CPPN {
         NDArray.make(this.inputAtlas.shape, {}) as Array2D;
     nn_art_util.addLatentVariables(
         this.gpgpu, this.addLatentVariablesShader,
-        this.backend.getTexture(this.inputAtlas.id),
-        this.backend.getTexture(inputAtlasWithLatentVariables.id),
+        this.backend.getTexture(this.inputAtlas.dataId),
+        this.backend.getTexture(inputAtlasWithLatentVariables.dataId),
         this.inputAtlas.shape, z1, z2);
 
     let lastOutput = inputAtlasWithLatentVariables;
@@ -168,8 +168,9 @@ export class CPPN {
                 this.math, matmulResult);
       }
       nn_art_util.render(
-          this.gpgpu, this.renderShader, this.backend.getTexture(lastOutput.id),
-          outputDimensions, colorModeIndex);
+          this.gpgpu, this.renderShader,
+          this.backend.getTexture(lastOutput.dataId), outputDimensions,
+          colorModeIndex);
     });
 
     inputAtlasWithLatentVariables.dispose();


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/511)
<!-- Reviewable:end -->
