### PR TITLE
Use npm's clang-format formatter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,5 +21,6 @@
   "files.insertFinalNewline": true,
   "editor.detectIndentation": false,
   "editor.wrappingIndent": "none",
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "clang-format.executable": "${workspaceRoot}/node_modules/.bin/clang-format"
 }

--- a/README.md
+++ b/README.md
@@ -89,7 +89,12 @@ $ yarn prep # Installs dependencies.
 ```
 
 We recommend using [Visual Studio Code](https://code.visualstudio.com/) for
-development. Make sure to install [TSLint VSCode extension](https://marketplace.visualstudio.com/items?itemName=eg2.tslint) and the `clang-format` command line tool with the [Clang-Format VSCode extension](https://marketplace.visualstudio.com/items?itemName=xaver.clang-format) for auto-formatting. Be sure to install `clang-format` 6.0 or later, not the [npm one](https://github.com/angular/clang-format). You can download a [prebuilt package](http://releases.llvm.org/download.html), or use a package manager (e.g. `brew install clang-format` on Mac OS).
+development. Make sure to install
+[TSLint VSCode extension](https://marketplace.visualstudio.com/items?itemName=eg2.tslint)
+and the npm [clang-format](https://github.com/angular/clang-format) `1.2.2` or later
+with the
+[Clang-Format VSCode extension](https://marketplace.visualstudio.com/items?itemName=xaver.clang-format)
+for auto-formatting.
 
 
 To interactively develop any of the demos (e.g. `demos/nn-art/`):

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@types/jasmine": "~2.5.53",
     "@types/seedrandom": "~2.4.27",
     "browserify": "~14.4.0",
+    "clang-format": "~1.2.2",
     "cross-spawn": "~5.1.0",
     "http-server": "~0.10.0",
     "jasmine-core": "~2.6.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -696,6 +696,14 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
+clang-format@~1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/clang-format/-/clang-format-1.2.2.tgz#a7277a03fce9aa4e387ddaa83b60d99dab115737"
+  dependencies:
+    async "^1.5.2"
+    glob "^7.0.0"
+    resolve "^1.1.6"
+
 cliui@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-2.1.0.tgz#4b475760ff80264c762c3a1719032e91c7fea0d1"


### PR DESCRIPTION
This will align everyone to use the same clang-format formatter. 

https://www.npmjs.com/package/clang-format 1.2.2 got released yesterday which uses clang 6.0 which fixes formatting issues we had.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/530)
<!-- Reviewable:end -->

  