### PR TITLE
Comparison Operator: Adds math.lessEqual method

### DIFF
--- a/src/math/backends/backend.ts
+++ b/src/math/backends/backend.ts
@@ -79,6 +79,8 @@ export interface MathBackend extends NDArrayStorage {
   equal(a: NDArray, b: NDArray): NDArray<'bool'>;
   notEqual(a: NDArray, b: NDArray): NDArray<'bool'>;
 
+  lessEqual(a: NDArray, b: NDArray): NDArray<'bool'>;
+
   greater(a: NDArray, b: NDArray): NDArray<'bool'>;
   greaterEqual(a: NDArray, b: NDArray): NDArray<'bool'>;
 

--- a/src/math/backends/backend_cpu.ts
+++ b/src/math/backends/backend_cpu.ts
@@ -500,6 +500,16 @@ export class MathBackendCPU implements MathBackend {
     });
   }
 
+  lessEqual(a: NDArray, b: NDArray): NDArray<'bool'> {
+    return this.broadcastedBinaryOp(a, b, 'bool', (aVal, bVal) => {
+      if (util.isValNaN(aVal, a.dtype) || util.isValNaN(bVal, b.dtype)) {
+        return util.getNaN('bool');
+      } else {
+        return (aVal <= bVal) ? 1 : 0;
+      }
+    });
+  }
+
   greater(a: NDArray, b: NDArray): NDArray<'bool'> {
     return this.broadcastedBinaryOp(a, b, 'bool', (aVal, bVal) => {
       if (util.isValNaN(aVal, a.dtype) || util.isValNaN(bVal, b.dtype)) {

--- a/src/math/backends/backend_webgl.ts
+++ b/src/math/backends/backend_webgl.ts
@@ -523,6 +523,13 @@ export class MathBackendWebGL implements MathBackend {
     return this.compileAndRun(program, [a, b], output);
   }
 
+  lessEqual(a: NDArray, b: NDArray): NDArray<'bool'> {
+    const program =
+        new BinaryOpProgram(binaryop_gpu.LESS_EQUAL, a.shape, b.shape);
+    const output = this.makeOutputArray(program.outputShape, 'bool');
+    return this.compileAndRun(program, [a, b], output);
+  }
+
   greater(a: NDArray, b: NDArray): NDArray<'bool'> {
     const program = new BinaryOpProgram(binaryop_gpu.GREATER, a.shape, b.shape);
     const output = this.makeOutputArray(program.outputShape, 'bool');

--- a/src/math/backends/kernel_registry.ts
+++ b/src/math/backends/kernel_registry.ts
@@ -130,6 +130,9 @@ const KERNEL_METHODS: {
   NotEqual: (backend: MathBackend, config: EqualInputConfig) => {
     return backend.notEqual(config.inputs.a, config.inputs.b);
   },
+  LessEqual: (backend: MathBackend, config: EqualInputConfig) => {
+    return backend.lessEqual(config.inputs.a, config.inputs.b);
+  },
   Greater: (backend: MathBackend, config: EqualInputConfig) => {
     return backend.greater(config.inputs.a, config.inputs.b);
   },
@@ -377,6 +380,7 @@ export interface KernelConfigRegistry {
   ArgMin: ArgMinNode;
   Equal: EqualNode;
   NotEqual: EqualNode;
+  LessEqual: EqualNode;
   Greater: EqualNode;
   GreaterEqual: EqualNode;
   LogicalOr: LogicalOrNode;

--- a/src/math/backends/types/logical.ts
+++ b/src/math/backends/types/logical.ts
@@ -30,7 +30,7 @@ export interface DualGradientInputArrays extends TapeNodeInputGradientArrays {
   b: () => NDArray;
 }
 
-// Equal/NotEqual/Greater/GreaterEqual
+// Equal/NotEqual/LessEqual/Greater/GreaterEqual
 export interface EqualNode extends KernelNode {
   inputAndArgs: EqualInputConfig;
   output: NDArray<'bool'>;

--- a/src/math/backends/webgl/binaryop_gpu.ts
+++ b/src/math/backends/webgl/binaryop_gpu.ts
@@ -37,6 +37,9 @@ export const EQUAL = CHECK_NAN_SNIPPET + `
 export const NOT_EQUAL = CHECK_NAN_SNIPPET + `
   return float(a != b);
 `;
+export const LESS_EQUAL = CHECK_NAN_SNIPPET + `
+  return float(a <= b);
+`;
 export const GREATER = CHECK_NAN_SNIPPET + `
   return float(a > b);
 `;

--- a/src/math/compareop_test.ts
+++ b/src/math/compareop_test.ts
@@ -609,6 +609,335 @@ import {Array1D, Array2D, Array3D, Array4D, Scalar} from './ndarray';
   ]);
 }
 
+// LessEqual:
+{
+  const boolNaN = util.getNaN('bool');
+
+  const tests: MathTests = it => {
+    // Array1D:
+    it('Array1D - int32', math => {
+      let a = Array1D.new([1, 4, 5], 'int32');
+      let b = Array1D.new([2, 3, 5], 'int32');
+      let res = math.lessEqual(a, b);
+
+      expect(res.dtype).toBe('bool');
+      test_util.expectArraysClose(res, [1, 0, 1]);
+
+      a = Array1D.new([2, 2, 2], 'int32');
+      b = Array1D.new([2, 2, 2], 'int32');
+      res = math.lessEqual(a, b);
+
+      expect(res.dtype).toBe('bool');
+      test_util.expectArraysClose(res, [1, 1, 1]);
+
+      a = Array1D.new([0, 0], 'int32');
+      b = Array1D.new([3, 3], 'int32');
+      res = math.lessEqual(a, b);
+
+      expect(res.dtype).toBe('bool');
+      test_util.expectArraysClose(res, [1, 1]);
+    });
+    it('Array1D - float32', math => {
+      let a = Array1D.new([1.1, 4.1, 5.1], 'float32');
+      let b = Array1D.new([2.2, 3.2, 5.1], 'float32');
+      let res = math.lessEqual(a, b);
+
+      expect(res.dtype).toBe('bool');
+      test_util.expectArraysClose(res, [1, 0, 1]);
+
+      a = Array1D.new([2.31, 2.31, 2.31], 'float32');
+      b = Array1D.new([2.31, 2.31, 2.31], 'float32');
+      res = math.lessEqual(a, b);
+
+      expect(res.dtype).toBe('bool');
+      test_util.expectArraysClose(res, [1, 1, 1]);
+
+      a = Array1D.new([0.45, 0.123], 'float32');
+      b = Array1D.new([3.123, 3.321], 'float32');
+      res = math.lessEqual(a, b);
+
+      expect(res.dtype).toBe('bool');
+      test_util.expectArraysClose(res, [1, 1]);
+    });
+    it('mismatched Array1D shapes - int32', math => {
+      const a = Array1D.new([1, 2], 'int32');
+      const b = Array1D.new([1, 2, 3], 'int32');
+      const f = () => {
+        math.lessEqual(a, b);
+      };
+      expect(f).toThrowError();
+    });
+    it('mismatched Array1D shapes - float32', math => {
+      const a = Array1D.new([1.1, 2.1], 'float32');
+      const b = Array1D.new([1.1, 2.1, 3.1], 'float32');
+      const f = () => {
+        math.lessEqual(a, b);
+      };
+      expect(f).toThrowError();
+    });
+    it('NaNs in Array1D - int32', math => {
+      const a = Array1D.new([1, NaN, 0], 'int32');
+      const b = Array1D.new([0, 0, NaN], 'int32');
+      const res = math.lessEqual(a, b);
+
+      expect(res.dtype).toBe('bool');
+      test_util.expectArraysClose(res, [0, boolNaN, boolNaN]);
+    });
+    it('NaNs in Array1D - float32', math => {
+      const a = Array1D.new([1.1, NaN, 2.1], 'float32');
+      const b = Array1D.new([2.1, 3.1, NaN], 'float32');
+      const res = math.lessEqual(a, b);
+
+      expect(res.dtype).toBe('bool');
+      test_util.expectArraysClose(res, [1, boolNaN, boolNaN]);
+    });
+
+    // Array2D:
+    it('Array2D - int32', math => {
+      let a = Array2D.new([2, 3], [[1, 4, 5], [8, 9, 12]], 'int32');
+      let b = Array2D.new([2, 3], [[2, 3, 6], [7, 10, 11]], 'int32');
+      let res = math.lessEqual(a, b);
+
+      expect(res.dtype).toBe('bool');
+      test_util.expectArraysClose(res, [1, 0, 1, 0, 1, 0]);
+
+      a = Array2D.new([2, 2], [[0, 0], [1, 1]], 'int32');
+      b = Array2D.new([2, 2], [[0, 0], [1, 1]], 'int32');
+      res = math.lessEqual(a, b);
+
+      expect(res.dtype).toBe('bool');
+      test_util.expectArraysClose(res, [1, 1, 1, 1]);
+    });
+    it('Array2D - float32', math => {
+      let a =
+          Array2D.new([2, 3], [[1.1, 4.1, 5.1], [8.1, 9.1, 12.1]], 'float32');
+      let b =
+          Array2D.new([2, 3], [[2.1, 3.1, 6.1], [7.1, 10.1, 11.1]], 'float32');
+      let res = math.lessEqual(a, b);
+
+      expect(res.dtype).toBe('bool');
+      test_util.expectArraysClose(res, [1, 0, 1, 0, 1, 0]);
+
+      a = Array2D.new([2, 2], [[0.2, 0.2], [1.2, 1.2]], 'float32');
+      b = Array2D.new([2, 2], [[0.2, 0.2], [1.2, 1.2]], 'float32');
+      res = math.lessEqual(a, b);
+
+      expect(res.dtype).toBe('bool');
+      test_util.expectArraysClose(res, [1, 1, 1, 1]);
+    });
+    it('broadcasting Array2D shapes - int32', math => {
+      const a = Array2D.new([2, 1], [[3], [7]], 'int32');
+      const b = Array2D.new([2, 3], [[2, 3, 4], [7, 8, 9]], 'int32');
+      const res = math.lessEqual(a, b);
+
+      expect(res.dtype).toBe('bool');
+      test_util.expectArraysClose(res, [0, 1, 1, 1, 1, 1]);
+    });
+    it('broadcasting Array2D shapes - float32', math => {
+      const a = Array2D.new([2, 1], [[1.1], [7.1]], 'float32');
+      const b =
+          Array2D.new([2, 3], [[0.1, 1.1, 2.1], [7.1, 8.1, 9.1]], 'float32');
+      const res = math.lessEqual(a, b);
+
+      expect(res.dtype).toBe('bool');
+      test_util.expectArraysClose(res, [0, 1, 1, 1, 1, 1]);
+    });
+    it('NaNs in Array2D - int32', math => {
+      const a = Array2D.new([2, 3], [[1, NaN, 2], [0, NaN, NaN]], 'int32');
+      const b = Array2D.new([2, 3], [[0, NaN, NaN], [1, NaN, 3]], 'int32');
+      const res = math.lessEqual(a, b);
+
+      expect(res.dtype).toBe('bool');
+      test_util.expectArraysClose(
+          res, [0, boolNaN, boolNaN, 1, boolNaN, boolNaN]);
+    });
+    it('NaNs in Array2D - float32', math => {
+      const a = Array2D.new([2, 2], [[1.1, NaN], [0.1, NaN]], 'float32');
+      const b = Array2D.new([2, 2], [[0.1, NaN], [1.1, NaN]], 'float32');
+      const res = math.lessEqual(a, b);
+
+      expect(res.dtype).toBe('bool');
+      test_util.expectArraysClose(res, [0, boolNaN, 1, boolNaN]);
+    });
+
+    // Array3D:
+    it('Array3D - int32', math => {
+      let a =
+          Array3D.new([2, 3, 1], [[[1], [4], [5]], [[8], [9], [12]]], 'int32');
+      let b =
+          Array3D.new([2, 3, 1], [[[2], [3], [6]], [[7], [10], [11]]], 'int32');
+      let res = math.lessEqual(a, b);
+
+      expect(res.dtype).toBe('bool');
+      test_util.expectArraysClose(res, [1, 0, 1, 0, 1, 0]);
+
+      a = Array3D.new([2, 3, 1], [[[0], [0], [0]], [[1], [1], [1]]], 'int32');
+      b = Array3D.new([2, 3, 1], [[[0], [0], [0]], [[1], [1], [1]]], 'int32');
+      res = math.lessEqual(a, b);
+
+      expect(res.dtype).toBe('bool');
+      test_util.expectArraysClose(res, [1, 1, 1, 1, 1, 1]);
+    });
+    it('Array3D - float32', math => {
+      let a = Array3D.new(
+          [2, 3, 1], [[[1.1], [4.1], [5.1]], [[8.1], [9.1], [12.1]]],
+          'float32');
+      let b = Array3D.new(
+          [2, 3, 1], [[[2.1], [3.1], [6.1]], [[7.1], [10.1], [11.1]]],
+          'float32');
+      let res = math.lessEqual(a, b);
+
+      expect(res.dtype).toBe('bool');
+      test_util.expectArraysClose(res, [1, 0, 1, 0, 1, 0]);
+
+      a = Array3D.new(
+          [2, 3, 1], [[[0.1], [0.1], [0.1]], [[1.1], [1.1], [1.2]]], 'float32');
+      b = Array3D.new(
+          [2, 3, 1], [[[0.1], [0.1], [0.1]], [[1.1], [1.1], [1.1]]], 'float32');
+      res = math.lessEqual(a, b);
+
+      expect(res.dtype).toBe('bool');
+      test_util.expectArraysClose(res, [1, 1, 1, 1, 1, 0]);
+    });
+    it('broadcasting Array3D shapes - int32', math => {
+      const a = Array3D.new(
+          [2, 3, 2], [[[1, 0], [2, 3], [4, 5]], [[6, 7], [9, 8], [10, 11]]],
+          'int32');
+      const b =
+          Array3D.new([2, 3, 1], [[[1], [2], [3]], [[7], [10], [9]]], 'int32');
+      const res = math.lessEqual(a, b);
+
+      expect(res.dtype).toBe('bool');
+      test_util.expectArraysClose(res, [1, 1, 1, 0, 0, 0, 1, 1, 1, 1, 0, 0]);
+    });
+    it('broadcasting Array3D float32', math => {
+      const a = Array3D.new(
+          [2, 3, 2],
+          [
+            [[1.1, 0.1], [2.1, 3.1], [4.1, 5.1]],
+            [[6.1, 7.1], [9.1, 8.1], [10.1, 11.1]]
+          ],
+          'float32');
+      const b = Array3D.new(
+          [2, 3, 1], [[[1.1], [2.1], [3.1]], [[7.1], [10.1], [9.1]]],
+          'float32');
+      const res = math.lessEqual(a, b);
+
+      expect(res.dtype).toBe('bool');
+      test_util.expectArraysClose(res, [1, 1, 1, 0, 0, 0, 1, 1, 1, 1, 0, 0]);
+    });
+    it('NaNs in Array3D - int32', math => {
+      const a =
+          Array3D.new([2, 3, 1], [[[1], [NaN], [1]], [[0], [0], [0]]], 'int32');
+      const b =
+          Array3D.new([2, 3, 1], [[[0], [0], [1]], [[1], [0], [NaN]]], 'int32');
+      const res = math.lessEqual(a, b);
+
+      expect(res.dtype).toBe('bool');
+      test_util.expectArraysClose(res, [0, boolNaN, 1, 1, 1, boolNaN]);
+    });
+    it('NaNs in Array3D - float32', math => {
+      const a = Array3D.new(
+          [2, 3, 1], [[[1.1], [NaN], [1.1]], [[0.1], [0.1], [0.1]]], 'float32');
+      const b = Array3D.new(
+          [2, 3, 1], [[[0.1], [0.1], [1.1]], [[1.1], [0.1], [NaN]]], 'float32');
+      const res = math.lessEqual(a, b);
+
+      expect(res.dtype).toBe('bool');
+      test_util.expectArraysClose(res, [0, boolNaN, 1, 1, 1, boolNaN]);
+    });
+
+    // Array4D:
+    it('Array4D - int32', math => {
+      let a = Array4D.new([2, 2, 1, 1], [1, 4, 5, 8], 'int32');
+      let b = Array4D.new([2, 2, 1, 1], [2, 3, 6, 7], 'int32');
+      let res = math.lessEqual(a, b);
+
+      expect(res.dtype).toBe('bool');
+      test_util.expectArraysClose(res, [1, 0, 1, 0]);
+
+      a = Array4D.new([2, 2, 1, 1], [0, 1, 2, 3], 'int32');
+      b = Array4D.new([2, 2, 1, 1], [0, 1, 2, 3], 'int32');
+      res = math.lessEqual(a, b);
+
+      expect(res.dtype).toBe('bool');
+      test_util.expectArraysClose(res, [1, 1, 1, 1]);
+
+      a = Array4D.new([2, 2, 1, 1], [1, 1, 1, 1], 'int32');
+      b = Array4D.new([2, 2, 1, 1], [2, 2, 2, 2], 'int32');
+      res = math.lessEqual(a, b);
+
+      expect(res.dtype).toBe('bool');
+      test_util.expectArraysClose(res, [1, 1, 1, 1]);
+    });
+    it('Array4D - float32', math => {
+      let a = Array4D.new([2, 2, 1, 1], [1.1, 4.1, 5.1, 8.1], 'float32');
+      let b = Array4D.new([2, 2, 1, 1], [2.1, 3.1, 6.1, 7.1], 'float32');
+      let res = math.lessEqual(a, b);
+
+      expect(res.dtype).toBe('bool');
+      test_util.expectArraysClose(res, [1, 0, 1, 0]);
+
+      a = Array4D.new([2, 2, 1, 1], [0.1, 1.1, 2.2, 3.3], 'float32');
+      b = Array4D.new([2, 2, 1, 1], [0.1, 1.1, 2.2, 3.3], 'float32');
+      res = math.lessEqual(a, b);
+
+      expect(res.dtype).toBe('bool');
+      test_util.expectArraysClose(res, [1, 1, 1, 1]);
+
+      a = Array4D.new([2, 2, 1, 1], [0.1, 0.1, 0.1, 0.1], 'float32');
+      b = Array4D.new([2, 2, 1, 1], [1.1, 1.1, 1.1, 1.1], 'float32');
+      res = math.lessEqual(a, b);
+
+      expect(res.dtype).toBe('bool');
+      test_util.expectArraysClose(res, [1, 1, 1, 1]);
+    });
+    it('broadcasting Array4D shapes - int32', math => {
+      const a = Array4D.new([2, 2, 1, 1], [1, 2, 5, 9], 'int32');
+      const b = Array4D.new(
+          [2, 2, 1, 2], [[[[1, 2]], [[3, 4]]], [[[5, 6]], [[7, 8]]]], 'int32');
+      const res = math.lessEqual(a, b);
+
+      expect(res.dtype).toBe('bool');
+      test_util.expectArraysClose(res, [1, 1, 1, 1, 1, 1, 0, 0]);
+    });
+    it('broadcasting Array4D shapes - float32', math => {
+      const a = Array4D.new([2, 2, 1, 1], [1.1, 2.1, 5.1, 9.1], 'float32');
+      const b = Array4D.new(
+          [2, 2, 1, 2],
+          [[[[1.1, 2.1]], [[3.1, 4.1]]], [[[5.1, 6.1]], [[7.1, 8.1]]]],
+          'float32');
+      const res = math.lessEqual(a, b);
+
+      expect(res.dtype).toBe('bool');
+      test_util.expectArraysClose(res, [1, 1, 1, 1, 1, 1, 0, 0]);
+    });
+    it('NaNs in Array4D - int32', math => {
+      const a = Array4D.new([2, 2, 1, 1], [1, NaN, 0, 0], 'int32');
+      const b = Array4D.new([2, 2, 1, 1], [0, 1, 1, NaN], 'int32');
+      const res = math.lessEqual(a, b);
+
+      expect(res.dtype).toBe('bool');
+      test_util.expectArraysClose(res, [0, boolNaN, 1, boolNaN]);
+    });
+    it('NaNs in Array4D - float32', math => {
+      const a = Array4D.new([2, 2, 1, 1], [1.1, NaN, 0.1, 0.1], 'float32');
+      const b = Array4D.new([2, 2, 1, 1], [0.1, 1.1, 1.1, NaN], 'float32');
+      const res = math.lessEqual(a, b);
+
+      expect(res.dtype).toBe('bool');
+      test_util.expectArraysClose(res, [0, boolNaN, 1, boolNaN]);
+    });
+  };
+
+  test_util.describeMathCPU('lessEqual', [tests]);
+  test_util.describeMathGPU('lessEqual', [tests], [
+    {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 1},
+    {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2},
+    {'WEBGL_FLOAT_TEXTURE_ENABLED': false, 'WEBGL_VERSION': 1}
+  ]);
+}
+
 // Greater:
 {
   const boolNaN = util.getNaN('bool');
@@ -709,16 +1038,17 @@ import {Array1D, Array2D, Array3D, Array4D, Scalar} from './ndarray';
       test_util.expectArraysClose(res, [0, 0, 0, 0]);
     });
     it('Array2D - float32', math => {
-      let a = Array2D.new([2, 3], [[1.1, 4.1, 5.1], [8.1, 9.1, 11.1]], 'int32');
+      let a =
+          Array2D.new([2, 3], [[1.1, 4.1, 5.1], [8.1, 9.1, 11.1]], 'float32');
       let b =
-          Array2D.new([2, 3], [[2.1, 3.1, 6.1], [7.1, 10.1, 11.1]], 'int32');
+          Array2D.new([2, 3], [[2.1, 3.1, 6.1], [7.1, 10.1, 11.1]], 'float32');
       let res = math.greater(a, b);
 
       expect(res.dtype).toBe('bool');
       test_util.expectArraysClose(res, [0, 1, 0, 1, 0, 0]);
 
-      a = Array2D.new([2, 2], [[0.2, 0.2], [1.2, 1.2]], 'int32');
-      b = Array2D.new([2, 2], [[0.2, 0.2], [1.2, 1.2]], 'int32');
+      a = Array2D.new([2, 2], [[0.2, 0.2], [1.2, 1.2]], 'float32');
+      b = Array2D.new([2, 2], [[0.2, 0.2], [1.2, 1.2]], 'float32');
       res = math.greater(a, b);
 
       expect(res.dtype).toBe('bool');
@@ -1037,16 +1367,17 @@ import {Array1D, Array2D, Array3D, Array4D, Scalar} from './ndarray';
       test_util.expectArraysClose(res, [1, 1, 1, 1]);
     });
     it('Array2D - float32', math => {
-      let a = Array2D.new([2, 3], [[1.1, 4.1, 5.1], [8.1, 9.1, 12.1]], 'int32');
+      let a =
+          Array2D.new([2, 3], [[1.1, 4.1, 5.1], [8.1, 9.1, 12.1]], 'float32');
       let b =
-          Array2D.new([2, 3], [[2.1, 3.1, 6.1], [7.1, 10.1, 11.1]], 'int32');
+          Array2D.new([2, 3], [[2.1, 3.1, 6.1], [7.1, 10.1, 11.1]], 'float32');
       let res = math.greaterEqual(a, b);
 
       expect(res.dtype).toBe('bool');
       test_util.expectArraysClose(res, [0, 1, 0, 1, 0, 1]);
 
-      a = Array2D.new([2, 2], [[0.2, 0.2], [1.2, 1.2]], 'int32');
-      b = Array2D.new([2, 2], [[0.2, 0.2], [1.2, 1.2]], 'int32');
+      a = Array2D.new([2, 2], [[0.2, 0.2], [1.2, 1.2]], 'float32');
+      b = Array2D.new([2, 2], [[0.2, 0.2], [1.2, 1.2]], 'float32');
       res = math.greaterEqual(a, b);
 
       expect(res.dtype).toBe('bool');

--- a/src/math/math.ts
+++ b/src/math/math.ts
@@ -814,6 +814,19 @@ export class NDArrayMath implements NDArrayManager {
   }
 
   /**
+   * Returns the truth value of (a <= b) element-wise. Supports broadcasting.
+   *
+   * @param a The first input `NDArray`.
+   * @param b The second input `NDArray`. Must have the same dtype as `a`.
+   */
+  lessEqual<D1 extends DataType, D2 extends D1, T extends NDArray<'bool'>>(
+      a: NDArray<D1>, b: NDArray<D2>): T {
+    util.assertTypesMatch(a, b);
+    broadcast_util.assertAndGetBroadcastShape(a.shape, b.shape);
+    return this.backendEngine.executeKernel('LessEqual', {inputs: {a, b}}) as T;
+  }
+
+  /**
    * Returns the truth value of (a > b) element-wise. Supports broadcasting.
    *
    * @param a The first input `NDArray`.


### PR DESCRIPTION
This PR adds less equal operator for NDArrays which can be used as `math.lessEqual(a, b)`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/548)
<!-- Reviewable:end -->
