### PR TITLE
Logical Operators: Add math.logicalAnd method

### DIFF
--- a/src/math/backends/backend.ts
+++ b/src/math/backends/backend.ts
@@ -84,6 +84,7 @@ export interface MathBackend extends NDArrayStorage {
   greater(a: NDArray, b: NDArray): NDArray<'bool'>;
   greaterEqual(a: NDArray, b: NDArray): NDArray<'bool'>;
 
+  logicalAnd(a: NDArray, b: NDArray): NDArray<'bool'>;
   logicalOr(a: NDArray, b: NDArray): NDArray<'bool'>;
 
   topKValues<D extends DataType, T extends NDArray<D>>(x: T, k: number):

--- a/src/math/backends/backend_cpu.ts
+++ b/src/math/backends/backend_cpu.ts
@@ -530,6 +530,16 @@ export class MathBackendCPU implements MathBackend {
     });
   }
 
+  logicalAnd(a: NDArray, b: NDArray): NDArray<'bool'> {
+    return this.broadcastedBinaryOp(a, b, 'bool', (aVal, bVal) => {
+      if (util.isValNaN(aVal, a.dtype) || util.isValNaN(bVal, b.dtype)) {
+        return util.getNaN('bool');
+      } else {
+        return aVal && bVal;
+      }
+    });
+  }
+
   logicalOr(a: NDArray, b: NDArray): NDArray<'bool'> {
     return this.broadcastedBinaryOp(a, b, 'bool', (aVal, bVal) => {
       if (util.isValNaN(aVal, a.dtype) || util.isValNaN(bVal, b.dtype)) {

--- a/src/math/backends/backend_webgl.ts
+++ b/src/math/backends/backend_webgl.ts
@@ -543,6 +543,13 @@ export class MathBackendWebGL implements MathBackend {
     return this.compileAndRun(program, [a, b], output);
   }
 
+  logicalAnd(a: NDArray, b: NDArray): NDArray<'bool'> {
+    const program =
+        new BinaryOpProgram(binaryop_gpu.LOGICAL_AND, a.shape, b.shape);
+    const output = this.makeOutputArray(program.outputShape, 'bool');
+    return this.compileAndRun(program, [a, b], output);
+  }
+
   logicalOr(a: NDArray, b: NDArray): NDArray<'bool'> {
     const program =
         new BinaryOpProgram(binaryop_gpu.LOGICAL_OR, a.shape, b.shape);

--- a/src/math/backends/kernel_registry.ts
+++ b/src/math/backends/kernel_registry.ts
@@ -30,6 +30,7 @@ import {CastInputConfig, CastNode} from './types/cast';
 import {Concat1DInputConfig, Concat1DNode, Concat2DInputConfig, Concat2DNode, Concat3DInputConfig, Concat3DNode, Concat4DInputConfig, Concat4DNode} from './types/concat';
 // tslint:disable-next-line:max-line-length
 import {Conv2DDerBiasInputConfig, Conv2DDerBiasNode, Conv2DDerFilterInputConfig, Conv2DDerFilterNode, Conv2DDerInputInputConfig, Conv2DDerInputNode, Conv2DInputConfig, Conv2DNode, DepthwiseConv2DInputConfig} from './types/conv';
+import {GatherInputConfig, GatherNode} from './types/gather';
 // tslint:disable-next-line:max-line-length
 import {EqualInputConfig, EqualNode, LogicalInputConfig, LogicalNode} from './types/logical';
 import {LRN4DInputConfig, LRN4DNode} from './types/lrn';

--- a/src/math/backends/kernel_registry.ts
+++ b/src/math/backends/kernel_registry.ts
@@ -31,7 +31,7 @@ import {Concat1DInputConfig, Concat1DNode, Concat2DInputConfig, Concat2DNode, Co
 // tslint:disable-next-line:max-line-length
 import {Conv2DDerBiasInputConfig, Conv2DDerBiasNode, Conv2DDerFilterInputConfig, Conv2DDerFilterNode, Conv2DDerInputInputConfig, Conv2DDerInputNode, Conv2DInputConfig, Conv2DNode, DepthwiseConv2DInputConfig} from './types/conv';
 // tslint:disable-next-line:max-line-length
-import {EqualInputConfig, EqualNode, LogicalOrInputConfig, LogicalOrNode} from './types/logical';
+import {EqualInputConfig, EqualNode, LogicalInputConfig, LogicalNode} from './types/logical';
 import {LRN4DInputConfig, LRN4DNode} from './types/lrn';
 import {MatMulInputConfig, MatMulNode} from './types/matmul';
 // tslint:disable-next-line:max-line-length
@@ -139,7 +139,10 @@ const KERNEL_METHODS: {
   GreaterEqual: (backend: MathBackend, config: EqualInputConfig) => {
     return backend.greaterEqual(config.inputs.a, config.inputs.b);
   },
-  LogicalOr: (backend: MathBackend, config: LogicalOrInputConfig) => {
+  LogicalAnd: (backend: MathBackend, config: LogicalInputConfig) => {
+    return backend.logicalAnd(config.inputs.a, config.inputs.b);
+  },
+  LogicalOr: (backend: MathBackend, config: LogicalInputConfig) => {
     return backend.logicalOr(config.inputs.a, config.inputs.b);
   },
   TopKValues:
@@ -383,7 +386,8 @@ export interface KernelConfigRegistry {
   LessEqual: EqualNode;
   Greater: EqualNode;
   GreaterEqual: EqualNode;
-  LogicalOr: LogicalOrNode;
+  LogicalAnd: LogicalNode;
+  LogicalOr: LogicalNode;
   TopKValues: TopKValuesNode<DataType, NDArray>;
   TopKIndices: TopKIndicesNode;
   Min: MinNode<DataType>;

--- a/src/math/backends/types/logical.ts
+++ b/src/math/backends/types/logical.ts
@@ -42,7 +42,7 @@ export interface EqualInputConfig extends KernelInputConfig {
   inputs: DualInputArrays;
 }
 
-// LogicalOr
+// LogicalAnd/LogicalOr
 export interface LogicalNode extends KernelNode {
   inputAndArgs: LogicalInputConfig;
   output: NDArray<'bool'>;

--- a/src/math/backends/types/logical.ts
+++ b/src/math/backends/types/logical.ts
@@ -43,13 +43,13 @@ export interface EqualInputConfig extends KernelInputConfig {
 }
 
 // LogicalOr
-export interface LogicalOrNode extends KernelNode {
-  inputAndArgs: LogicalOrInputConfig;
+export interface LogicalNode extends KernelNode {
+  inputAndArgs: LogicalInputConfig;
   output: NDArray<'bool'>;
   gradient:
       (dy: NDArray<'bool'>, y: NDArray<'bool'>) => DualGradientInputArrays;
 }
 
-export interface LogicalOrInputConfig extends KernelInputConfig {
+export interface LogicalInputConfig extends KernelInputConfig {
   inputs: DualInputArrays;
 }

--- a/src/math/backends/webgl/binaryop_gpu.ts
+++ b/src/math/backends/webgl/binaryop_gpu.ts
@@ -46,6 +46,9 @@ export const GREATER = CHECK_NAN_SNIPPET + `
 export const GREATER_EQUAL = CHECK_NAN_SNIPPET + `
   return float(a >= b);
 `;
+export const LOGICAL_AND = CHECK_NAN_SNIPPET + `
+  return float(a >= 1.0 && b >= 1.0);
+`;
 export const LOGICAL_OR = CHECK_NAN_SNIPPET + `
   return float(a >= 1.0 || b >= 1.0);
 `;

--- a/src/math/logicalop_test.ts
+++ b/src/math/logicalop_test.ts
@@ -21,6 +21,128 @@ import * as util from '../util';
 
 import {Array1D, Array2D, Array3D, Array4D} from './ndarray';
 
+// LogicalAnd:
+{
+  const boolNaN = util.getNaN('bool');
+
+  const tests: MathTests = it => {
+    // Array1D:
+    it('Array1D.', math => {
+      let a = Array1D.new([1, 0, 0], 'bool');
+      let b = Array1D.new([0, 1, 0], 'bool');
+      test_util.expectArraysClose(math.logicalAnd(a, b), [0, 0, 0]);
+
+      a = Array1D.new([0, 0, 0], 'bool');
+      b = Array1D.new([0, 0, 0], 'bool');
+      test_util.expectArraysClose(math.logicalAnd(a, b), [0, 0, 0]);
+
+      a = Array1D.new([1, 1], 'bool');
+      b = Array1D.new([1, 1], 'bool');
+      test_util.expectArraysClose(math.logicalAnd(a, b), [1, 1]);
+    });
+    it('mismatched Array1D shapes', math => {
+      const a = Array1D.new([1, 0], 'bool');
+      const b = Array1D.new([0, 1, 0], 'bool');
+      const f = () => {
+        math.logicalAnd(a, b);
+      };
+      expect(f).toThrowError();
+    });
+    it('NaNs in Array1D', math => {
+      const a = Array1D.new([1, NaN, 0], 'bool');
+      const b = Array1D.new([0, 0, NaN], 'bool');
+      test_util.expectArraysClose(math.logicalAnd(a, b), [0, boolNaN, boolNaN]);
+    });
+
+    // Array2D:
+    it('Array2D', math => {
+      let a = Array2D.new([2, 3], [[1, 0, 1], [0, 0, 0]], 'bool');
+      let b = Array2D.new([2, 3], [[0, 0, 0], [0, 1, 0]], 'bool');
+      test_util.expectArraysClose(math.logicalAnd(a, b), [0, 0, 0, 0, 0, 0]);
+
+      a = Array2D.new([2, 3], [[0, 0, 0], [1, 1, 1]], 'bool');
+      b = Array2D.new([2, 3], [[0, 0, 0], [1, 1, 1]], 'bool');
+      test_util.expectArraysClose(math.logicalAnd(a, b), [0, 0, 0, 1, 1, 1]);
+    });
+    it('broadcasting Array2D shapes', math => {
+      const a = Array2D.new([2, 1], [[1], [0]], 'bool');
+      const b = Array2D.new([2, 3], [[0, 1, 0], [0, 1, 0]], 'bool');
+      test_util.expectArraysClose(math.logicalAnd(a, b), [0, 1, 0, 0, 0, 0]);
+    });
+    it('NaNs in Array2D', math => {
+      const a = Array2D.new([2, 2], [[1, NaN], [0, NaN]], 'bool');
+      const b = Array2D.new([2, 2], [[0, NaN], [1, NaN]], 'bool');
+      test_util.expectArraysClose(
+          math.logicalAnd(a, b), [0, boolNaN, 0, boolNaN]);
+    });
+
+    // Array3D:
+    it('Array3D', math => {
+      let a =
+          Array3D.new([2, 3, 1], [[[1], [0], [1]], [[0], [0], [1]]], 'bool');
+      let b =
+          Array3D.new([2, 3, 1], [[[0], [0], [1]], [[1], [0], [0]]], 'bool');
+      test_util.expectArraysClose(math.logicalAnd(a, b), [0, 0, 1, 0, 0, 0]);
+
+      a = Array3D.new([2, 3, 1], [[[0], [0], [0]], [[1], [1], [1]]], 'bool');
+      b = Array3D.new([2, 3, 1], [[[0], [0], [0]], [[1], [1], [1]]], 'bool');
+      test_util.expectArraysClose(math.logicalAnd(a, b), [0, 0, 0, 1, 1, 1]);
+    });
+    it('broadcasting Array3D shapes', math => {
+      const a = Array3D.new(
+          [2, 3, 2], [[[1, 0], [0, 0], [1, 1]], [[0, 0], [0, 1], [0, 0]]],
+          'bool');
+      const b =
+          Array3D.new([2, 3, 1], [[[0], [0], [1]], [[1], [0], [0]]], 'bool');
+      test_util.expectArraysClose(
+          math.logicalAnd(a, b), [0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0]);
+    });
+    it('NaNs in Array3D', math => {
+      const a =
+          Array3D.new([2, 3, 1], [[[1], [NaN], [1]], [[0], [0], [0]]], 'bool');
+      const b =
+          Array3D.new([2, 3, 1], [[[0], [0], [1]], [[1], [0], [NaN]]], 'bool');
+      test_util.expectArraysClose(
+          math.logicalAnd(a, b), [0, boolNaN, 1, 0, 0, boolNaN]);
+    });
+
+    // Array4D:
+    it('Array4D', math => {
+      let a = Array4D.new([2, 2, 1, 1], [1, 0, 1, 0], 'bool');
+      let b = Array4D.new([2, 2, 1, 1], [0, 1, 1, 0], 'bool');
+      test_util.expectArraysClose(math.logicalAnd(a, b), [0, 0, 1, 0]);
+
+      a = Array4D.new([2, 2, 1, 1], [0, 0, 0, 0], 'bool');
+      b = Array4D.new([2, 2, 1, 1], [0, 0, 0, 0], 'bool');
+      test_util.expectArraysClose(math.logicalAnd(a, b), [0, 0, 0, 0]);
+
+      a = Array4D.new([2, 2, 1, 1], [1, 1, 1, 1], 'bool');
+      b = Array4D.new([2, 2, 1, 1], [1, 1, 1, 1], 'bool');
+      test_util.expectArraysClose(math.logicalAnd(a, b), [1, 1, 1, 1]);
+    });
+    it('broadcasting Array4D shapes', math => {
+      const a = Array4D.new([2, 2, 1, 1], [1, 0, 1, 0], 'bool');
+      const b = Array4D.new(
+          [2, 2, 1, 2], [[[[1, 0]], [[0, 0]]], [[[0, 0]], [[1, 1]]]], 'bool');
+      test_util.expectArraysClose(
+          math.logicalAnd(a, b), [1, 0, 0, 0, 0, 0, 0, 0]);
+    });
+    it('NaNs in Array4D', math => {
+      const a = Array4D.new([2, 2, 1, 1], [1, NaN, 1, 0], 'bool');
+      const b = Array4D.new([2, 2, 1, 1], [0, 1, 0, NaN], 'bool');
+      test_util.expectArraysClose(
+          math.logicalAnd(a, b), [0, boolNaN, 0, boolNaN]);
+    });
+  };
+
+  test_util.describeMathCPU('logicalAnd', [tests]);
+  test_util.describeMathGPU('logicalAnd', [tests], [
+    {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 1},
+    {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2},
+    {'WEBGL_FLOAT_TEXTURE_ENABLED': false, 'WEBGL_VERSION': 1}
+  ]);
+}
+
 // LogicalOr:
 {
   const boolNaN = util.getNaN('bool');

--- a/src/math/math.ts
+++ b/src/math/math.ts
@@ -879,7 +879,7 @@ export class NDArrayMath implements NDArrayManager {
    */
   logicalAnd(a: NDArray<'bool'>, b: NDArray<'bool'>): NDArray<'bool'> {
     util.assert(
-        a.dtype === 'bool' || b.dtype === 'bool',
+        a.dtype === 'bool' && b.dtype === 'bool',
         'Error Array must be of type bool.');
     broadcast_util.assertAndGetBroadcastShape(a.shape, b.shape);
     return this.backendEngine.executeKernel('LogicalAnd', {inputs: {a, b}});
@@ -893,7 +893,7 @@ export class NDArrayMath implements NDArrayManager {
    */
   logicalOr(a: NDArray<'bool'>, b: NDArray<'bool'>): NDArray<'bool'> {
     util.assert(
-        a.dtype === 'bool' || b.dtype === 'bool',
+        a.dtype === 'bool' && b.dtype === 'bool',
         'Error Array must be of type bool.');
     broadcast_util.assertAndGetBroadcastShape(a.shape, b.shape);
     return this.backendEngine.executeKernel('LogicalOr', {inputs: {a, b}});
@@ -1230,17 +1230,17 @@ export class NDArrayMath implements NDArrayManager {
                'Transpose', {inputs: {x}, args: {perm}}, der) as T;
   }
 
-/**
- * Gather slices from array `x`'s axis `axis` according to `indices`
- *
- * @param x The array to transpose.
- * @param indices The indices of the values to extract.
- * @param axis Optional. The axis over which to select values. Defaults to 0.
- */
+  /**
+   * Gather slices from array `x`'s axis `axis` according to `indices`
+   *
+   * @param x The array to transpose.
+   * @param indices The indices of the values to extract.
+   * @param axis Optional. The axis over which to select values. Defaults to 0.
+   */
   gather<D extends DataType, T extends NDArray<D>>(
       x: T, indices: Array1D<'int32'>, axis = 0): T {
     return this.backendEngine.executeKernel(
-               'Gather', {inputs:{x, indices}, args: {axis}}) as T;
+               'Gather', {inputs: {x, indices}, args: {axis}}) as T;
   }
 
   /** @deprecated Use math.add(c, A) instead. */

--- a/src/math/math.ts
+++ b/src/math/math.ts
@@ -854,6 +854,20 @@ export class NDArrayMath implements NDArrayManager {
   }
 
   /**
+   * Returns the truth value of a AND b element-wise. Supports broadcasting.
+   *
+   * @param a The first input `NDArray<'bool'>`.
+   * @param b The second input `NDArray<'bool'>`.
+   */
+  logicalAnd(a: NDArray<'bool'>, b: NDArray<'bool'>): NDArray<'bool'> {
+    util.assert(
+        a.dtype === 'bool' || b.dtype === 'bool',
+        'Error Array must be of type bool.');
+    broadcast_util.assertAndGetBroadcastShape(a.shape, b.shape);
+    return this.backendEngine.executeKernel('LogicalAnd', {inputs: {a, b}});
+  }
+
+  /**
    * Returns the truth value of a OR b element-wise. Supports broadcasting.
    *
    * @param a The first input `NDArray<'bool'>`.


### PR DESCRIPTION
This PR adds logicalAnd operator for NDArrays which can be used as `math.logicalAnd(a, b)`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/557)
<!-- Reviewable:end -->
