### PR TITLE
Add varList to optimizer.minimize, don't train non-trainable variables, and update dy typings to be typed as float32.

### DIFF
--- a/src/graph/ops/convolution.ts
+++ b/src/graph/ops/convolution.ts
@@ -78,7 +78,7 @@ export class Convolution2D extends Operation {
       gradientArrays: SummedTensorArrayMap) {
     const filter = inferenceArrays.get(this.wTensor) as Array4D;
     const x = inferenceArrays.get(this.xTensor) as Array3D;
-    const dy = gradientArrays.get(this.yTensor) as Array3D;
+    const dy = gradientArrays.get(this.yTensor) as Array3D<'float32'>;
 
     math.scope(() => {
       const dw =

--- a/src/graph/ops/max_pool.ts
+++ b/src/graph/ops/max_pool.ts
@@ -62,7 +62,7 @@ export class MaxPool extends Operation {
       math: NDArrayMath, inferenceArrays: TensorArrayMap,
       gradientArrays: SummedTensorArrayMap) {
     const x = inferenceArrays.get(this.xTensor) as Array3D;
-    const dy = gradientArrays.get(this.yTensor) as Array3D;
+    const dy = gradientArrays.get(this.yTensor) as Array3D<'float32'>;
 
     math.scope(() => {
       gradientArrays.add(

--- a/src/math/backends/backend.ts
+++ b/src/math/backends/backend.ts
@@ -48,14 +48,17 @@ export interface MathBackend extends NDArrayStorage {
 
   clone<T extends NDArray>(ndarray: T): T;
 
-  slice1D(x: Array1D, begin: number, size: number): Array1D;
-  slice2D(x: Array2D, begin: [number, number], size: [number, number]): Array2D;
-  slice3D(x: Array3D, begin: [number, number, number], size: [
-    number, number, number
-  ]): Array3D;
-  slice4D(x: Array4D, begin: [number, number, number, number], size: [
-    number, number, number, number
-  ]): Array4D;
+  slice1D<D extends DataType>(x: Array1D<D>, begin: number, size: number):
+      Array1D<D>;
+  slice2D<D extends DataType>(x: Array2D<D>, begin: [number, number], size: [
+    number, number
+  ]): Array2D<D>;
+  slice3D<D extends DataType>(
+      x: Array3D<D>, begin: [number, number, number],
+      size: [number, number, number]): Array3D<D>;
+  slice4D<D extends DataType>(
+      x: Array4D<D>, begin: [number, number, number, number],
+      size: [number, number, number, number]): Array4D<D>;
 
   reverse4D(a: Array4D, axis: number[]): Array4D;
 

--- a/src/math/backends/backend_cpu.ts
+++ b/src/math/backends/backend_cpu.ts
@@ -130,14 +130,16 @@ export class MathBackendCPU implements MathBackend {
     return NDArray.make(x.shape, {values: new Float32Array(x.dataSync())}) as T;
   }
 
-  slice1D(x: Array1D, begin: number, size: number): Array1D {
+  slice1D<D extends DataType>(x: Array1D<D>, begin: number, size: number):
+      Array1D<D> {
     const newVals = x.dataSync().slice(begin, begin + size);
     return Array1D.new(newVals);
   }
 
-  slice2D(x: Array2D, begin: [number, number], size: [number, number]):
-      Array2D {
-    const result = Array2D.zeros(size);
+  slice2D<D extends DataType>(x: Array2D<D>, begin: [number, number], size: [
+    number, number
+  ]): Array2D<D> {
+    const result = Array2D.zeros(size, x.dtype);
     const [startI, startJ] = begin;
 
     for (let i = 0; i < size[0]; ++i) {
@@ -149,10 +151,10 @@ export class MathBackendCPU implements MathBackend {
     return result;
   }
 
-  slice3D(x: Array3D, begin: [number, number, number], size: [
-    number, number, number
-  ]): Array3D {
-    const result = Array3D.zeros(size);
+  slice3D<D extends DataType>(
+      x: Array3D<D>, begin: [number, number, number],
+      size: [number, number, number]): Array3D<D> {
+    const result = Array3D.zeros(size, x.dtype);
     const [startI, startJ, startK] = begin;
 
     for (let i = 0; i < size[0]; ++i) {
@@ -165,10 +167,10 @@ export class MathBackendCPU implements MathBackend {
     }
     return result;
   }
-  slice4D(x: Array4D, begin: [number, number, number, number], size: [
-    number, number, number, number
-  ]): Array4D {
-    const result = Array4D.zeros(size);
+  slice4D<D extends DataType>(
+      x: Array4D<D>, begin: [number, number, number, number],
+      size: [number, number, number, number]): Array4D<D> {
+    const result = Array4D.zeros(size, x.dtype);
     const [startI, startJ, startK, startL] = begin;
 
     for (let i = 0; i < size[0]; ++i) {

--- a/src/math/backends/backend_engine.ts
+++ b/src/math/backends/backend_engine.ts
@@ -17,7 +17,7 @@
 
 import * as util from '../../util';
 import {NamedArrayMap} from '../../util';
-import {DataType, NDArray, Rank, Scalar} from '../ndarray';
+import {DataType, NDArray, Rank, Scalar, Variable} from '../ndarray';
 import {MathBackend} from './backend';
 import * as kernel_registry from './kernel_registry';
 import {KernelConfigRegistry} from './kernel_registry';
@@ -55,10 +55,12 @@ export class BackendEngine {
     this.debugMode = true;
   }
 
-  executeKernel<K extends keyof KernelConfigRegistry,
-                          C extends KernelConfigRegistry[K]['inputAndArgs']>(
-      kernelName: K, config: C, grad?: KernelConfigRegistry[K]['gradient']):
-      KernelConfigRegistry[K]['output'] {
+  executeKernel<D extends DataType, R extends Rank, K extends
+                    keyof KernelConfigRegistry<D, R>,
+                    C extends KernelConfigRegistry<D, R>[K]['inputAndArgs']>(
+      kernelName: K, config: C,
+      grad?: KernelConfigRegistry<D, R>[K]['gradient']):
+      KernelConfigRegistry<D, R>[K]['output'] {
     const kernelFn = () =>
         kernel_registry.executeKernel(this.backend, kernelName, config);
 
@@ -159,7 +161,8 @@ export class BackendEngine {
     }
   }
 
-  vjp<T extends NDArray>(f: () => T, xs: NDArray[], dy: T): NDArray[] {
+  vjp<D extends DataType, R extends Rank, T extends NDArray<D, R>>(
+      f: () => T, xs: NDArray[], dy: NDArray<'float32', R>): NDArray[] {
     const gradientsMode = true;
     return this.scope('vjp', () => {
       const y = f();
@@ -172,8 +175,38 @@ export class BackendEngine {
     }, gradientsMode);
   }
 
-  private gradientWrt<T extends NDArray>(y: T, xs: NDArray[], dy?: T):
-      NDArray[] {
+  variableGradientsAndValue<D extends DataType>(
+      f: () => Scalar<D>,
+      varList?: Variable[]): {value: Scalar<D>, gradients: NamedArrayMap} {
+    const gradientsMode = true;
+    let trainableVariableNames: string[];
+    const result = this.scope('gradients', () => {
+      const y = f();
+      if (y.rank !== 0) {
+        throw new Error(
+            `Cannot compute gradient of non-scalar y output. ` +
+            `Got y with rank ${y.rank}`);
+      }
+      const trainableVariables =
+          tape_util.computeTrainableVariableInputs(this.activeTape, varList);
+      trainableVariableNames =
+          trainableVariables.map(variable => variable.name);
+
+      const gradients = this.gradientWrt(y, trainableVariables);
+      return [y, ...gradients];
+    }, gradientsMode);
+
+    const gradients: NamedArrayMap = {};
+    for (let i = 0; i < trainableVariableNames.length; i++) {
+      gradients[trainableVariableNames[i]] = result[i + 1];
+    }
+
+    return {value: result[0] as Scalar<D>, gradients};
+  }
+
+  private gradientWrt<D extends DataType, R extends Rank,
+                                                    T extends NDArray<D, R>>(
+      y: T, xs: NDArray[], dy?: NDArray<'float32', R>): NDArray[] {
     // Filter out the nodes that don't connect x => y.
     const filteredTape = tape_util.getFilteredNodesXToY(this.activeTape, xs, y);
     if (filteredTape.length === 0) {
@@ -183,8 +216,10 @@ export class BackendEngine {
           `to are used inside the gradient function.`);
     }
 
-    const arrayAccumulatedGradientMap: {[ndarrayId: number]: NDArray} = {};
-    arrayAccumulatedGradientMap[y.id] = dy == null ? Scalar.new(1) : dy;
+    const arrayAccumulatedGradientMap:
+        {[ndarrayId: number]: NDArray<'float32'>} = {};
+    arrayAccumulatedGradientMap[y.id] =
+        dy == null ? Scalar.new(1, 'float32') : dy;
 
     // Backprop gradients through the filtered nodes.
     tape_util.backpropagateGradients(arrayAccumulatedGradientMap, filteredTape);

--- a/src/math/backends/backend_engine.ts
+++ b/src/math/backends/backend_engine.ts
@@ -192,7 +192,9 @@ export class BackendEngine {
       trainableVariableNames =
           trainableVariables.map(variable => variable.name);
 
-      const gradients = this.gradientWrt(y, trainableVariables);
+      const gradients = trainableVariables.length === 0 ?
+          [] :
+          this.gradientWrt(y, trainableVariables);
       return [y, ...gradients];
     }, gradientsMode);
 

--- a/src/math/backends/backend_webgl.ts
+++ b/src/math/backends/backend_webgl.ts
@@ -247,30 +247,32 @@ export class MathBackendWebGL implements MathBackend {
     return output.reshape(x.shape) as T;
   }
 
-  slice1D(x: Array1D, begin: number, size: number): Array1D {
+  slice1D<D extends DataType>(x: Array1D<D>, begin: number, size: number):
+      Array1D<D> {
     const program = new SliceProgram([size]);
     const customSetup = program.getCustomSetupFunc([begin]);
     return this.compileAndRun(program, [x], null, customSetup);
   }
 
-  slice2D(x: Array2D, begin: [number, number], size: [number, number]):
-      Array2D {
+  slice2D<D extends DataType>(x: Array2D<D>, begin: [number, number], size: [
+    number, number
+  ]): Array2D<D> {
     const program = new SliceProgram(size);
     const customSetup = program.getCustomSetupFunc(begin);
     return this.compileAndRun(program, [x], null, customSetup);
   }
 
-  slice3D(x: Array3D, begin: [number, number, number], size: [
-    number, number, number
-  ]): Array3D {
+  slice3D<D extends DataType>(
+      x: Array3D<D>, begin: [number, number, number],
+      size: [number, number, number]): Array3D<D> {
     const program = new SliceProgram(size);
     const customSetup = program.getCustomSetupFunc(begin);
     return this.compileAndRun(program, [x], null, customSetup);
   }
 
-  slice4D(x: Array4D, begin: [number, number, number, number], size: [
-    number, number, number, number
-  ]): Array4D {
+  slice4D<D extends DataType>(
+      x: Array4D<D>, begin: [number, number, number, number],
+      size: [number, number, number, number]): Array4D<D> {
     const program = new SliceProgram(size);
     const customSetup = program.getCustomSetupFunc(begin);
     return this.compileAndRun(program, [x], null, customSetup);

--- a/src/math/backends/kernel_registry.ts
+++ b/src/math/backends/kernel_registry.ts
@@ -221,13 +221,11 @@ const KERNEL_METHODS: {
        config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
         return backend.relu(config.inputs.x);
       },
-  Reshape:
-      (backend: MathBackend,
-       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
-        const x = config.inputs.x;
-        const newShape = config.args.newShape;
-        return NDArray.make(newShape, {dataId: x.dataId}, x.dtype);
-      },
+  Reshape: (backend: MathBackend, config: ReshapeNode['inputAndArgs']) => {
+    const x = config.inputs.x;
+    const newShape = config.args.newShape;
+    return NDArray.make(newShape, {dataId: x.dataId}, x.dtype);
+  },
   Cast: (backend: MathBackend, config: CastNode['inputAndArgs']) => {
     const x = config.inputs.x;
     const newDType = config.args.newDType;

--- a/src/math/backends/kernel_registry.ts
+++ b/src/math/backends/kernel_registry.ts
@@ -20,193 +20,215 @@ import {DataType, NDArray, Rank, Scalar} from '../ndarray';
 
 import {MathBackend} from './backend';
 import {KernelInputConfig} from './tape_types';
+import {ArgMaxNode, ArgMinNode} from './types/argminmax';
 // tslint:disable-next-line:max-line-length
-import {ArgMaxInputConfig, ArgMaxNode, ArgMinInputConfig, ArgMinNode} from './types/argminmax';
+import {BatchNorm2DNode, BatchNorm3DNode, BatchNorm4DNode} from './types/batchnorm';
+import {BinaryNode} from './types/binary';
+import {CastNode} from './types/cast';
 // tslint:disable-next-line:max-line-length
-import {BatchNorm2DInputConfig, BatchNorm2DNode, BatchNorm3DInputConfig, BatchNorm3DNode, BatchNorm4DInputConfig, BatchNorm4DNode} from './types/batchnorm';
-import {BinaryInputConfig, BinaryNode} from './types/binary';
-import {CastInputConfig, CastNode} from './types/cast';
+import {Concat1DNode, Concat2DNode, Concat3DNode, Concat4DNode} from './types/concat';
 // tslint:disable-next-line:max-line-length
-import {Concat1DInputConfig, Concat1DNode, Concat2DInputConfig, Concat2DNode, Concat3DInputConfig, Concat3DNode, Concat4DInputConfig, Concat4DNode} from './types/concat';
+import {Conv2DDerBiasNode, Conv2DDerFilterNode, Conv2DDerInputNode, Conv2DNode, DepthwiseConv2DNode} from './types/conv';
+import {GatherNode} from './types/gather';
+import {EqualNode, LogicalNode, WhereNode} from './types/logical';
+import {LRN4DNode} from './types/lrn';
+import {MatMulNode} from './types/matmul';
+import {MaximumNode, MaxNode, MinimumNode, MinNode} from './types/minmax';
+import {MultinomialNode} from './types/multinomial';
+import {OneHotNode} from './types/onehot';
+import {Pad1DNode, Pad2DNode} from './types/pad';
 // tslint:disable-next-line:max-line-length
-import {Conv2DDerBiasInputConfig, Conv2DDerBiasNode, Conv2DDerFilterInputConfig, Conv2DDerFilterNode, Conv2DDerInputInputConfig, Conv2DDerInputNode, Conv2DInputConfig, Conv2DNode, DepthwiseConv2DInputConfig} from './types/conv';
-import {GatherInputConfig, GatherNode} from './types/gather';
-// tslint:disable-next-line:max-line-length
-import {EqualInputConfig, EqualNode, LogicalInputConfig, LogicalNode, WhereInputConfig, WhereNode} from './types/logical';
-import {LRN4DInputConfig, LRN4DNode} from './types/lrn';
-import {MatMulInputConfig, MatMulNode} from './types/matmul';
-// tslint:disable-next-line:max-line-length
-import {MaximumInputConfig, MaximumNode, MaxInputConfig, MaxNode, MinimumInputConfig, MinimumNode, MinInputConfig, MinNode} from './types/minmax';
-import {MultinomialInputConfig, MultinomialNode} from './types/multinomial';
-import {OneHotInputConfig, OneHotNode} from './types/onehot';
-// tslint:disable-next-line:max-line-length
-import {Pad1DInputConfig, Pad1DNode, Pad2DInputConfig, Pad2DNode} from './types/pad';
-// tslint:disable-next-line:max-line-length
-import {PoolBackpropInputConfig, PoolBackpropNode, PoolInputConfig, PoolNode} from './types/pool';
-import {PowInputConfig, PowNode} from './types/pow';
-import {PReLUInputConfig, PReLUNode} from './types/prelu';
+import {PoolBackpropNode, PoolNode} from './types/pool';
+import {PowNode} from './types/pow';
+import {PReLUNode} from './types/prelu';
 import {ReshapeNode} from './types/reshape';
+import {ResizeBilinear3DNode} from './types/resize_bilinear';
+import {Reverse4DNode} from './types/reverse';
 // tslint:disable-next-line:max-line-length
-import {ResizeBilinear3DInputConfig, ResizeBilinear3DNode} from './types/resize_bilinear';
-import {Reverse4DInputConfig, Reverse4DNode} from './types/reverse';
+import {Slice1DNode, Slice2DNode, Slice3DNode, Slice4DNode} from './types/slice';
+import {SumNode} from './types/sum';
+import {TopKIndicesNode, TopKValuesNode} from './types/topk';
 // tslint:disable-next-line:max-line-length
-import {Slice1DInputConfig, Slice1DNode, Slice2DInputConfig, Slice2DNode, Slice3DInputConfig, Slice3DNode, Slice4DInputConfig, Slice4DNode} from './types/slice';
-import {SumInputConfig, SumNode} from './types/sum';
-// tslint:disable-next-line:max-line-length
-import {TopKIndicesInputConfig, TopKIndicesNode, TopKValuesInputConfig, TopKValuesNode} from './types/topk';
-// tslint:disable-next-line:max-line-length
-import {ClipInputConfig, ClipNode, LeakyReluInputConfig, LeakyReluNode, StepInputConfig, StepNode, TileInputConfig, TileNode, TransposeInputConfig, TransposeNode, UnaryInputConfig, UnaryNode} from './types/unary';
+import {ClipNode, LeakyReluNode, StepNode, TileNode, TransposeNode, UnaryNode} from './types/unary';
 
 const KERNEL_METHODS: {
   [kernel in keyof KernelConfigRegistry<DataType, Rank>]: (
       backend: MathBackend, config: KernelInputConfig) => NDArray
 } = {
   // NOTE: Using {} and "return" makes VSCode run much faster.
-  MatMul: (backend: MathBackend, config: MatMulInputConfig) => {
+  MatMul: (backend: MathBackend, config: MatMulNode['inputAndArgs']) => {
     return backend.matMul(
         config.inputs.a, config.inputs.b, config.args.aOrientation,
         config.args.bOrientation);
   },
-  Clone: (backend: MathBackend, config: UnaryInputConfig<NDArray>) => {
-    return backend.clone(config.inputs.x);
-  },
-  Slice1D: <D extends DataType>(
-      backend: MathBackend, config: Slice1DInputConfig<D>) => {
-    return backend.slice1D(
-        config.inputs.x, config.args.begin, config.args.size);
-  },
-  Slice2D: <D extends DataType>(
-      backend: MathBackend, config: Slice2DInputConfig<D>) => {
-    return backend.slice2D(
-        config.inputs.x, config.args.begin, config.args.size);
-  },
-  Slice3D: <D extends DataType>(
-      backend: MathBackend, config: Slice3DInputConfig<D>) => {
-    return backend.slice3D(
-        config.inputs.x, config.args.begin, config.args.size);
-  },
-  Slice4D: <D extends DataType>(
-      backend: MathBackend, config: Slice4DInputConfig<D>) => {
-    return backend.slice4D(
-        config.inputs.x, config.args.begin, config.args.size);
-  },
-  Reverse4D: (backend: MathBackend, config: Reverse4DInputConfig) => {
+  Clone:
+      (backend: MathBackend,
+       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
+        return backend.clone(config.inputs.x);
+      },
+  Slice1D:
+      (backend: MathBackend, config: Slice1DNode<DataType>['inputAndArgs']) => {
+        return backend.slice1D(
+            config.inputs.x, config.args.begin, config.args.size);
+      },
+  Slice2D:
+      (backend: MathBackend, config: Slice2DNode<DataType>['inputAndArgs']) => {
+        return backend.slice2D(
+            config.inputs.x, config.args.begin, config.args.size);
+      },
+  Slice3D:
+      (backend: MathBackend, config: Slice3DNode<DataType>['inputAndArgs']) => {
+        return backend.slice3D(
+            config.inputs.x, config.args.begin, config.args.size);
+      },
+  Slice4D:
+      (backend: MathBackend, config: Slice4DNode<DataType>['inputAndArgs']) => {
+        return backend.slice4D(
+            config.inputs.x, config.args.begin, config.args.size);
+      },
+  Reverse4D: (backend: MathBackend, config: Reverse4DNode['inputAndArgs']) => {
     return backend.reverse4D(config.inputs.x, config.args.axis);
   },
-  Concat1D: (backend: MathBackend, config: Concat1DInputConfig) => {
+  Concat1D: (backend: MathBackend, config: Concat1DNode['inputAndArgs']) => {
     return backend.concat1D(config.inputs.a, config.inputs.b);
   },
-  Concat2D: (backend: MathBackend, config: Concat2DInputConfig) => {
+  Concat2D: (backend: MathBackend, config: Concat2DNode['inputAndArgs']) => {
     return backend.concat2D(config.inputs.a, config.inputs.b, config.args.axis);
   },
-  Concat3D: (backend: MathBackend, config: Concat3DInputConfig) => {
+  Concat3D: (backend: MathBackend, config: Concat3DNode['inputAndArgs']) => {
     return backend.concat3D(config.inputs.a, config.inputs.b, config.args.axis);
   },
-  Concat4D: (backend: MathBackend, config: Concat4DInputConfig) => {
+  Concat4D: (backend: MathBackend, config: Concat4DNode['inputAndArgs']) => {
     return backend.concat4D(config.inputs.a, config.inputs.b, config.args.axis);
   },
-  Neg: (backend: MathBackend, config: UnaryInputConfig<NDArray>) => {
-    return backend.neg(config.inputs.x);
-  },
-  Add: (backend: MathBackend, config: BinaryInputConfig) => {
+  Neg:
+      (backend: MathBackend,
+       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
+        return backend.neg(config.inputs.x);
+      },
+  Add: (backend: MathBackend, config: BinaryNode['inputAndArgs']) => {
     return backend.add(config.inputs.a, config.inputs.b);
   },
-  Sub: (backend: MathBackend, config: BinaryInputConfig) => {
+  Sub: (backend: MathBackend, config: BinaryNode['inputAndArgs']) => {
     return backend.subtract(config.inputs.a, config.inputs.b);
   },
-  Mul: (backend: MathBackend, config: BinaryInputConfig) => {
+  Mul: (backend: MathBackend, config: BinaryNode['inputAndArgs']) => {
     return backend.multiply(config.inputs.a, config.inputs.b);
   },
-  Div: (backend: MathBackend, config: BinaryInputConfig) => {
+  Div: (backend: MathBackend, config: BinaryNode['inputAndArgs']) => {
     return backend.divide(config.inputs.a, config.inputs.b);
   },
-  Sum: (backend: MathBackend, config: SumInputConfig<'float32'|'int32'>) => {
-    return backend.sum(config.inputs.x, config.args.axes);
-  },
-  ArgMax: (backend: MathBackend, config: ArgMaxInputConfig) => {
+  Sum:
+      (backend: MathBackend,
+       config: SumNode<'float32'|'int32'>['inputAndArgs']) => {
+        return backend.sum(config.inputs.x, config.args.axes);
+      },
+  ArgMax: (backend: MathBackend, config: ArgMaxNode['inputAndArgs']) => {
     return backend.argMax(config.inputs.x, config.args.axes);
   },
-  ArgMin: (backend: MathBackend, config: ArgMinInputConfig) => {
+  ArgMin: (backend: MathBackend, config: ArgMinNode['inputAndArgs']) => {
     return backend.argMin(config.inputs.x, config.args.axes);
   },
-  Equal: (backend: MathBackend, config: EqualInputConfig) => {
+  Equal: (backend: MathBackend, config: EqualNode['inputAndArgs']) => {
     return backend.equal(config.inputs.a, config.inputs.b);
   },
-  NotEqual: (backend: MathBackend, config: EqualInputConfig) => {
+  NotEqual: (backend: MathBackend, config: EqualNode['inputAndArgs']) => {
     return backend.notEqual(config.inputs.a, config.inputs.b);
   },
-  Less: (backend: MathBackend, config: EqualInputConfig) => {
+  Less: (backend: MathBackend, config: EqualNode['inputAndArgs']) => {
     return backend.less(config.inputs.a, config.inputs.b);
   },
-  LessEqual: (backend: MathBackend, config: EqualInputConfig) => {
+  LessEqual: (backend: MathBackend, config: EqualNode['inputAndArgs']) => {
     return backend.lessEqual(config.inputs.a, config.inputs.b);
   },
-  Greater: (backend: MathBackend, config: EqualInputConfig) => {
+  Greater: (backend: MathBackend, config: EqualNode['inputAndArgs']) => {
     return backend.greater(config.inputs.a, config.inputs.b);
   },
-  GreaterEqual: (backend: MathBackend, config: EqualInputConfig) => {
+  GreaterEqual: (backend: MathBackend, config: EqualNode['inputAndArgs']) => {
     return backend.greaterEqual(config.inputs.a, config.inputs.b);
   },
-  LogicalAnd: (backend: MathBackend, config: LogicalInputConfig) => {
+  LogicalAnd: (backend: MathBackend, config: LogicalNode['inputAndArgs']) => {
     return backend.logicalAnd(config.inputs.a, config.inputs.b);
   },
-  LogicalOr: (backend: MathBackend, config: LogicalInputConfig) => {
+  LogicalOr: (backend: MathBackend, config: LogicalNode['inputAndArgs']) => {
     return backend.logicalOr(config.inputs.a, config.inputs.b);
   },
-  Where: (backend: MathBackend, config: WhereInputConfig) => {
+  Where: (backend: MathBackend, config: WhereNode['inputAndArgs']) => {
     return backend.where(
         config.inputs.condition, config.inputs.a, config.inputs.b,
         config.args.dtype);
   },
   TopKValues:
-      (backend: MathBackend, config: TopKValuesInputConfig<NDArray>) => {
+      (backend: MathBackend,
+       config: TopKValuesNode<DataType, Rank>['inputAndArgs']) => {
         return backend.topKValues(config.inputs.x, config.args.k);
       },
-  TopKIndices: (backend: MathBackend, config: TopKIndicesInputConfig) => {
-    return backend.topKIndices(config.inputs.x, config.args.k);
-  },
-  Min: (backend: MathBackend, config: MinInputConfig<DataType>) => {
+  TopKIndices:
+      (backend: MathBackend, config: TopKIndicesNode['inputAndArgs']) => {
+        return backend.topKIndices(config.inputs.x, config.args.k);
+      },
+  Min: (backend: MathBackend, config: MinNode<DataType>['inputAndArgs']) => {
     return backend.min(config.inputs.x, config.args.axes);
   },
-  Minimum: (backend: MathBackend, config: MinimumInputConfig<DataType>) => {
-    return backend.minimum(config.inputs.a, config.inputs.b);
-  },
-  Max: (backend: MathBackend, config: MaxInputConfig<DataType>) => {
+  Minimum:
+      (backend: MathBackend, config: MinimumNode<DataType>['inputAndArgs']) => {
+        return backend.minimum(config.inputs.a, config.inputs.b);
+      },
+  Max: (backend: MathBackend, config: MaxNode<DataType>['inputAndArgs']) => {
     return backend.max(config.inputs.x, config.args.axes);
   },
-  Maximum: (backend: MathBackend, config: MaximumInputConfig<DataType>) => {
-    return backend.maximum(config.inputs.a, config.inputs.b);
-  },
-  Ceil: (backend: MathBackend, config: UnaryInputConfig<NDArray>) => {
-    return backend.ceil(config.inputs.x);
-  },
-  Floor: (backend: MathBackend, config: UnaryInputConfig<NDArray>) => {
-    return backend.floor(config.inputs.x);
-  },
-  Pow: (backend: MathBackend, config: PowInputConfig<NDArray>) => {
-    return backend.pow(config.inputs.a, config.inputs.b);
-  },
-  Exp: (backend: MathBackend, config: UnaryInputConfig<NDArray>) => {
-    return backend.exp(config.inputs.x);
-  },
-  Log: (backend: MathBackend, config: UnaryInputConfig<NDArray>) => {
-    return backend.log(config.inputs.x);
-  },
-  Sqrt: (backend: MathBackend, config: UnaryInputConfig<NDArray>) => {
-    return backend.sqrt(config.inputs.x);
-  },
-  Square: (backend: MathBackend, config: UnaryInputConfig<NDArray>) => {
-    return backend.square(config.inputs.x);
-  },
-  Relu: (backend: MathBackend, config: UnaryInputConfig<NDArray>) => {
-    return backend.relu(config.inputs.x);
-  },
-  Reshape: (backend: MathBackend, config: UnaryInputConfig<NDArray>) => {
-    const x = config.inputs.x;
-    const newShape = config.args.newShape;
-    return NDArray.make(newShape, {dataId: x.dataId}, x.dtype);
-  },
-  Cast: (backend: MathBackend, config: CastInputConfig) => {
+  Maximum:
+      (backend: MathBackend, config: MaximumNode<DataType>['inputAndArgs']) => {
+        return backend.maximum(config.inputs.a, config.inputs.b);
+      },
+  Ceil:
+      (backend: MathBackend,
+       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
+        return backend.ceil(config.inputs.x);
+      },
+  Floor:
+      (backend: MathBackend,
+       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
+        return backend.floor(config.inputs.x);
+      },
+  Pow:
+      (backend: MathBackend,
+       config: PowNode<DataType, Rank>['inputAndArgs']) => {
+        return backend.pow(config.inputs.a, config.inputs.b);
+      },
+  Exp:
+      (backend: MathBackend,
+       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
+        return backend.exp(config.inputs.x);
+      },
+  Log:
+      (backend: MathBackend,
+       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
+        return backend.log(config.inputs.x);
+      },
+  Sqrt:
+      (backend: MathBackend,
+       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
+        return backend.sqrt(config.inputs.x);
+      },
+  Square:
+      (backend: MathBackend,
+       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
+        return backend.square(config.inputs.x);
+      },
+  Relu:
+      (backend: MathBackend,
+       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
+        return backend.relu(config.inputs.x);
+      },
+  Reshape:
+      (backend: MathBackend,
+       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
+        const x = config.inputs.x;
+        const newShape = config.args.newShape;
+        return NDArray.make(newShape, {dataId: x.dataId}, x.dtype);
+      },
+  Cast: (backend: MathBackend, config: CastNode['inputAndArgs']) => {
     const x = config.inputs.x;
     const newDType = config.args.newDType;
 
@@ -222,150 +244,202 @@ const KERNEL_METHODS: {
       throw new Error(`Error in Cast: unknown dtype argument (${newDType})`);
     }
   },
-  LeakyRelu: (backend: MathBackend, config: LeakyReluInputConfig<NDArray>) => {
-    return backend.leakyRelu(config.inputs.x, config.args.alpha);
-  },
-  PReLU: (backend: MathBackend, config: PReLUInputConfig<NDArray>) => {
-    return backend.prelu(config.inputs.x, config.inputs.alpha);
-  },
-  PReLUDer: (backend: MathBackend, config: PReLUInputConfig<NDArray>) => {
-    return backend.preluDer(config.inputs.x, config.inputs.alpha);
-  },
-  Elu: (backend: MathBackend, config: UnaryInputConfig<NDArray>) => {
-    return backend.elu(config.inputs.x);
-  },
-  EluDer: (backend: MathBackend, config: UnaryInputConfig<NDArray>) => {
-    return backend.eluDer(config.inputs.x);
-  },
-  Selu: (backend: MathBackend, config: UnaryInputConfig<NDArray>) => {
-    return backend.selu(config.inputs.x);
-  },
-  Abs: (backend: MathBackend, config: UnaryInputConfig<NDArray>) => {
-    return backend.abs(config.inputs.x);
-  },
-  Sigmoid: (backend: MathBackend, config: UnaryInputConfig<NDArray>) => {
-    return backend.sigmoid(config.inputs.x);
-  },
-  Step: (backend: MathBackend, config: StepInputConfig<NDArray>) => {
-    return backend.step(config.inputs.x, config.args.alpha);
-  },
-  Sin: (backend: MathBackend, config: UnaryInputConfig<NDArray>) => {
-    return backend.sin(config.inputs.x);
-  },
-  Cos: (backend: MathBackend, config: UnaryInputConfig<NDArray>) => {
-    return backend.cos(config.inputs.x);
-  },
-  Tan: (backend: MathBackend, config: UnaryInputConfig<NDArray>) => {
-    return backend.tan(config.inputs.x);
-  },
-  Asin: (backend: MathBackend, config: UnaryInputConfig<NDArray>) => {
-    return backend.asin(config.inputs.x);
-  },
-  Acos: (backend: MathBackend, config: UnaryInputConfig<NDArray>) => {
-    return backend.acos(config.inputs.x);
-  },
-  Atan: (backend: MathBackend, config: UnaryInputConfig<NDArray>) => {
-    return backend.atan(config.inputs.x);
-  },
-  Sinh: (backend: MathBackend, config: UnaryInputConfig<NDArray>) => {
-    return backend.sinh(config.inputs.x);
-  },
-  Cosh: (backend: MathBackend, config: UnaryInputConfig<NDArray>) => {
-    return backend.cosh(config.inputs.x);
-  },
-  Tanh: (backend: MathBackend, config: UnaryInputConfig<NDArray>) => {
-    return backend.tanh(config.inputs.x);
-  },
-  Clip: (backend: MathBackend, config: ClipInputConfig<NDArray>) => {
-    return backend.clip(config.inputs.x, config.args.min, config.args.max);
-  },
-  Tile: (backend: MathBackend, config: TileInputConfig<NDArray>) => {
-    return backend.tile(config.inputs.x, config.args.reps);
-  },
-  Gather: (backend: MathBackend, config: GatherInputConfig<NDArray>) => {
-    return backend.gather(
-        config.inputs.x, config.inputs.indices, config.args.axis);
-  },
-  Pad1D: (backend: MathBackend, config: Pad1DInputConfig) => {
+  LeakyRelu:
+      (backend: MathBackend,
+       config: LeakyReluNode<DataType, Rank>['inputAndArgs']) => {
+        return backend.leakyRelu(config.inputs.x, config.args.alpha);
+      },
+  PReLU:
+      (backend: MathBackend,
+       config: PReLUNode<DataType, Rank>['inputAndArgs']) => {
+        return backend.prelu(config.inputs.x, config.inputs.alpha);
+      },
+  PReLUDer:
+      (backend: MathBackend,
+       config: PReLUNode<DataType, Rank>['inputAndArgs']) => {
+        return backend.preluDer(config.inputs.x, config.inputs.alpha);
+      },
+  Elu:
+      (backend: MathBackend,
+       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
+        return backend.elu(config.inputs.x);
+      },
+  EluDer:
+      (backend: MathBackend,
+       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
+        return backend.eluDer(config.inputs.x);
+      },
+  Selu:
+      (backend: MathBackend,
+       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
+        return backend.selu(config.inputs.x);
+      },
+  Abs:
+      (backend: MathBackend,
+       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
+        return backend.abs(config.inputs.x);
+      },
+  Sigmoid:
+      (backend: MathBackend,
+       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
+        return backend.sigmoid(config.inputs.x);
+      },
+  Step:
+      (backend: MathBackend,
+       config: StepNode<DataType, Rank>['inputAndArgs']) => {
+        return backend.step(config.inputs.x, config.args.alpha);
+      },
+  Sin:
+      (backend: MathBackend,
+       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
+        return backend.sin(config.inputs.x);
+      },
+  Cos:
+      (backend: MathBackend,
+       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
+        return backend.cos(config.inputs.x);
+      },
+  Tan:
+      (backend: MathBackend,
+       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
+        return backend.tan(config.inputs.x);
+      },
+  Asin:
+      (backend: MathBackend,
+       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
+        return backend.asin(config.inputs.x);
+      },
+  Acos:
+      (backend: MathBackend,
+       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
+        return backend.acos(config.inputs.x);
+      },
+  Atan:
+      (backend: MathBackend,
+       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
+        return backend.atan(config.inputs.x);
+      },
+  Sinh:
+      (backend: MathBackend,
+       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
+        return backend.sinh(config.inputs.x);
+      },
+  Cosh:
+      (backend: MathBackend,
+       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
+        return backend.cosh(config.inputs.x);
+      },
+  Tanh:
+      (backend: MathBackend,
+       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
+        return backend.tanh(config.inputs.x);
+      },
+  Clip:
+      (backend: MathBackend,
+       config: ClipNode<DataType, Rank>['inputAndArgs']) => {
+        return backend.clip(config.inputs.x, config.args.min, config.args.max);
+      },
+  Tile:
+      (backend: MathBackend,
+       config: TileNode<DataType, Rank>['inputAndArgs']) => {
+        return backend.tile(config.inputs.x, config.args.reps);
+      },
+  Gather:
+      (backend: MathBackend,
+       config: GatherNode<DataType, Rank>['inputAndArgs']) => {
+        return backend.gather(
+            config.inputs.x, config.inputs.indices, config.args.axis);
+      },
+  Pad1D: (backend: MathBackend, config: Pad1DNode['inputAndArgs']) => {
     return backend.pad1D(
         config.inputs.x, config.args.paddings, config.args.constantValue);
   },
-  Pad2D: (backend: MathBackend, config: Pad2DInputConfig) => {
+  Pad2D: (backend: MathBackend, config: Pad2DNode['inputAndArgs']) => {
     return backend.pad2D(
         config.inputs.x, config.args.paddings, config.args.constantValue);
   },
-  Transpose: (backend: MathBackend, config: TransposeInputConfig<NDArray>) => {
-    return backend.transpose(config.inputs.x, config.args.perm);
-  },
-  Conv2D: (backend: MathBackend, config: Conv2DInputConfig) => {
+  Transpose:
+      (backend: MathBackend,
+       config: TransposeNode<DataType, Rank>['inputAndArgs']) => {
+        return backend.transpose(config.inputs.x, config.args.perm);
+      },
+  Conv2D: (backend: MathBackend, config: Conv2DNode['inputAndArgs']) => {
     return backend.conv2d(
         config.inputs.x, config.inputs.filter, config.inputs.bias,
         config.args.convInfo);
   },
-  Conv2DDerInput: (backend: MathBackend, config: Conv2DDerInputInputConfig) => {
-    return backend.conv2dDerInput(
-        config.inputs.dy, config.inputs.filter, config.args.convInfo);
-  },
+  Conv2DDerInput:
+      (backend: MathBackend, config: Conv2DDerInputNode['inputAndArgs']) => {
+        return backend.conv2dDerInput(
+            config.inputs.dy, config.inputs.filter, config.args.convInfo);
+      },
   Conv2DDerFilter:
-      (backend: MathBackend, config: Conv2DDerFilterInputConfig) => {
+      (backend: MathBackend, config: Conv2DDerFilterNode['inputAndArgs']) => {
         return backend.conv2dDerFilter(
             config.inputs.x, config.inputs.dy, config.args.convInfo);
       },
-  Conv2DDerBias: (backend: MathBackend, config: Conv2DDerBiasInputConfig) => {
-    return backend.conv2dDerBias(config.inputs.dy);
-  },
+  Conv2DDerBias:
+      (backend: MathBackend, config: Conv2DDerBiasNode['inputAndArgs']) => {
+        return backend.conv2dDerBias(config.inputs.dy);
+      },
   DepthwiseConv2D:
-      (backend: MathBackend, config: DepthwiseConv2DInputConfig) => {
+      (backend: MathBackend, config: DepthwiseConv2DNode['inputAndArgs']) => {
         return backend.depthwiseConv2D(
             config.inputs.x, config.inputs.filter, config.args.convInfo);
       },
-  MaxPool: (backend: MathBackend, config: PoolInputConfig) => {
+  MaxPool: (backend: MathBackend, config: PoolNode['inputAndArgs']) => {
     return backend.maxPool(config.inputs.x, config.args.convInfo);
   },
-  MaxPoolBackprop: (backend: MathBackend, config: PoolBackpropInputConfig) => {
-    return backend.maxPoolBackprop(
-        config.inputs.dy, config.inputs.x, config.args.convInfo);
-  },
-  AvgPool: (backend: MathBackend, config: PoolInputConfig) => {
+  MaxPoolBackprop:
+      (backend: MathBackend, config: PoolBackpropNode['inputAndArgs']) => {
+        return backend.maxPoolBackprop(
+            config.inputs.dy, config.inputs.x, config.args.convInfo);
+      },
+  AvgPool: (backend: MathBackend, config: PoolNode['inputAndArgs']) => {
     return backend.avgPool(config.inputs.x, config.args.convInfo);
   },
-  AvgPoolBackprop: (backend: MathBackend, config: PoolBackpropInputConfig) => {
-    return backend.avgPoolBackprop(
-        config.inputs.dy, config.inputs.x, config.args.convInfo);
-  },
-  MinPool: (backend: MathBackend, config: PoolInputConfig) => {
+  AvgPoolBackprop:
+      (backend: MathBackend, config: PoolBackpropNode['inputAndArgs']) => {
+        return backend.avgPoolBackprop(
+            config.inputs.dy, config.inputs.x, config.args.convInfo);
+      },
+  MinPool: (backend: MathBackend, config: PoolNode['inputAndArgs']) => {
     return backend.minPool(config.inputs.x, config.args.convInfo);
   },
   ResizeBilinear3D:
-      (backend: MathBackend, config: ResizeBilinear3DInputConfig) => {
+      (backend: MathBackend, config: ResizeBilinear3DNode['inputAndArgs']) => {
         return backend.resizeBilinear3D(
             config.inputs.x, config.args.newShape2D, config.args.alignCorners);
       },
-  BatchNorm4D: (backend: MathBackend, config: BatchNorm4DInputConfig) => {
+  BatchNorm4D: (
+      backend: MathBackend, config: BatchNorm4DNode['inputAndArgs']) => {
     return backend.batchNormalization4D(
         config.inputs.x, config.inputs.mean, config.inputs.variance,
         config.args.varianceEpsilon, config.inputs.scale, config.inputs.offset);
   },
-  BatchNorm3D: (backend: MathBackend, config: BatchNorm3DInputConfig) => {
+  BatchNorm3D: (
+      backend: MathBackend, config: BatchNorm3DNode['inputAndArgs']) => {
     return backend.batchNormalization3D(
         config.inputs.x, config.inputs.mean, config.inputs.variance,
         config.args.varianceEpsilon, config.inputs.scale, config.inputs.offset);
   },
-  BatchNorm2D: (backend: MathBackend, config: BatchNorm2DInputConfig) => {
+  BatchNorm2D: (
+      backend: MathBackend, config: BatchNorm2DNode['inputAndArgs']) => {
     return backend.batchNormalization2D(
         config.inputs.x, config.inputs.mean, config.inputs.variance,
         config.args.varianceEpsilon, config.inputs.scale, config.inputs.offset);
   },
-  LRN4D: (backend: MathBackend, config: LRN4DInputConfig) => {
+  LRN4D: (backend: MathBackend, config: LRN4DNode['inputAndArgs']) => {
     return backend.localResponseNormalization4D(
         config.inputs.x, config.args.radius, config.args.bias,
         config.args.alpha, config.args.beta, config.args.normRegion);
   },
-  Multinomial: (backend: MathBackend, config: MultinomialInputConfig) => {
-    return backend.multinomial(
-        config.inputs.probs, config.args.numSamples, config.args.seed);
-  },
-  OneHot: (backend: MathBackend, config: OneHotInputConfig) => {
+  Multinomial:
+      (backend: MathBackend, config: MultinomialNode['inputAndArgs']) => {
+        return backend.multinomial(
+            config.inputs.probs, config.args.numSamples, config.args.seed);
+      },
+  OneHot: (backend: MathBackend, config: OneHotNode['inputAndArgs']) => {
     return backend.oneHot(
         config.inputs.indices, config.args.depth, config.args.onValue,
         config.args.offValue);

--- a/src/math/backends/kernel_registry.ts
+++ b/src/math/backends/kernel_registry.ts
@@ -447,7 +447,7 @@ export interface KernelConfigRegistry<D extends DataType, R extends Rank> {
   Pad1D: Pad1DNode;
   Pad2D: Pad2DNode;
   Tile: TileNode<D, R>;
-  Gather: GatherNode<NDArray>;
+  Gather: GatherNode<D, R>;
   Conv2D: Conv2DNode;
   Conv2DDerInput: Conv2DDerInputNode;
   Conv2DDerFilter: Conv2DDerFilterNode;

--- a/src/math/backends/kernel_registry.ts
+++ b/src/math/backends/kernel_registry.ts
@@ -19,7 +19,6 @@ import * as util from '../../util';
 import {DataType, NDArray, Rank, Scalar} from '../ndarray';
 
 import {MathBackend} from './backend';
-import {KernelInputConfig} from './tape_types';
 import {ArgMaxNode, ArgMinNode} from './types/argminmax';
 // tslint:disable-next-line:max-line-length
 import {BatchNorm2DNode, BatchNorm3DNode, BatchNorm4DNode} from './types/batchnorm';
@@ -51,404 +50,329 @@ import {TopKIndicesNode, TopKValuesNode} from './types/topk';
 // tslint:disable-next-line:max-line-length
 import {ClipNode, LeakyReluNode, StepNode, TileNode, TransposeNode, UnaryNode} from './types/unary';
 
-const KERNEL_METHODS: {
-  [kernel in keyof KernelConfigRegistry<DataType, Rank>]: (
-      backend: MathBackend, config: KernelInputConfig) => NDArray
-} = {
-  // NOTE: Using {} and "return" makes VSCode run much faster.
-  MatMul: (backend: MathBackend, config: MatMulNode['inputAndArgs']) => {
-    return backend.matMul(
-        config.inputs.a, config.inputs.b, config.args.aOrientation,
-        config.args.bOrientation);
-  },
-  Clone:
-      (backend: MathBackend,
-       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
-        return backend.clone(config.inputs.x);
-      },
-  Slice1D:
-      (backend: MathBackend, config: Slice1DNode<DataType>['inputAndArgs']) => {
-        return backend.slice1D(
-            config.inputs.x, config.args.begin, config.args.size);
-      },
-  Slice2D:
-      (backend: MathBackend, config: Slice2DNode<DataType>['inputAndArgs']) => {
-        return backend.slice2D(
-            config.inputs.x, config.args.begin, config.args.size);
-      },
-  Slice3D:
-      (backend: MathBackend, config: Slice3DNode<DataType>['inputAndArgs']) => {
-        return backend.slice3D(
-            config.inputs.x, config.args.begin, config.args.size);
-      },
-  Slice4D:
-      (backend: MathBackend, config: Slice4DNode<DataType>['inputAndArgs']) => {
-        return backend.slice4D(
-            config.inputs.x, config.args.begin, config.args.size);
-      },
-  Reverse4D: (backend: MathBackend, config: Reverse4DNode['inputAndArgs']) => {
-    return backend.reverse4D(config.inputs.x, config.args.axis);
-  },
-  Concat1D: (backend: MathBackend, config: Concat1DNode['inputAndArgs']) => {
-    return backend.concat1D(config.inputs.a, config.inputs.b);
-  },
-  Concat2D: (backend: MathBackend, config: Concat2DNode['inputAndArgs']) => {
-    return backend.concat2D(config.inputs.a, config.inputs.b, config.args.axis);
-  },
-  Concat3D: (backend: MathBackend, config: Concat3DNode['inputAndArgs']) => {
-    return backend.concat3D(config.inputs.a, config.inputs.b, config.args.axis);
-  },
-  Concat4D: (backend: MathBackend, config: Concat4DNode['inputAndArgs']) => {
-    return backend.concat4D(config.inputs.a, config.inputs.b, config.args.axis);
-  },
-  Neg:
-      (backend: MathBackend,
-       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
-        return backend.neg(config.inputs.x);
-      },
-  Add: (backend: MathBackend, config: BinaryNode['inputAndArgs']) => {
-    return backend.add(config.inputs.a, config.inputs.b);
-  },
-  Sub: (backend: MathBackend, config: BinaryNode['inputAndArgs']) => {
-    return backend.subtract(config.inputs.a, config.inputs.b);
-  },
-  Mul: (backend: MathBackend, config: BinaryNode['inputAndArgs']) => {
-    return backend.multiply(config.inputs.a, config.inputs.b);
-  },
-  Div: (backend: MathBackend, config: BinaryNode['inputAndArgs']) => {
-    return backend.divide(config.inputs.a, config.inputs.b);
-  },
-  Sum:
-      (backend: MathBackend,
-       config: SumNode<'float32'|'int32'>['inputAndArgs']) => {
-        return backend.sum(config.inputs.x, config.args.axes);
-      },
-  ArgMax: (backend: MathBackend, config: ArgMaxNode['inputAndArgs']) => {
-    return backend.argMax(config.inputs.x, config.args.axes);
-  },
-  ArgMin: (backend: MathBackend, config: ArgMinNode['inputAndArgs']) => {
-    return backend.argMin(config.inputs.x, config.args.axes);
-  },
-  Equal: (backend: MathBackend, config: EqualNode['inputAndArgs']) => {
-    return backend.equal(config.inputs.a, config.inputs.b);
-  },
-  NotEqual: (backend: MathBackend, config: EqualNode['inputAndArgs']) => {
-    return backend.notEqual(config.inputs.a, config.inputs.b);
-  },
-  Less: (backend: MathBackend, config: EqualNode['inputAndArgs']) => {
-    return backend.less(config.inputs.a, config.inputs.b);
-  },
-  LessEqual: (backend: MathBackend, config: EqualNode['inputAndArgs']) => {
-    return backend.lessEqual(config.inputs.a, config.inputs.b);
-  },
-  Greater: (backend: MathBackend, config: EqualNode['inputAndArgs']) => {
-    return backend.greater(config.inputs.a, config.inputs.b);
-  },
-  GreaterEqual: (backend: MathBackend, config: EqualNode['inputAndArgs']) => {
-    return backend.greaterEqual(config.inputs.a, config.inputs.b);
-  },
-  LogicalAnd: (backend: MathBackend, config: LogicalNode['inputAndArgs']) => {
-    return backend.logicalAnd(config.inputs.a, config.inputs.b);
-  },
-  LogicalOr: (backend: MathBackend, config: LogicalNode['inputAndArgs']) => {
-    return backend.logicalOr(config.inputs.a, config.inputs.b);
-  },
-  Where: (backend: MathBackend, config: WhereNode['inputAndArgs']) => {
-    return backend.where(
-        config.inputs.condition, config.inputs.a, config.inputs.b,
-        config.args.dtype);
-  },
-  TopKValues:
-      (backend: MathBackend,
-       config: TopKValuesNode<DataType, Rank>['inputAndArgs']) => {
-        return backend.topKValues(config.inputs.x, config.args.k);
-      },
-  TopKIndices:
-      (backend: MathBackend, config: TopKIndicesNode['inputAndArgs']) => {
-        return backend.topKIndices(config.inputs.x, config.args.k);
-      },
-  Min: (backend: MathBackend, config: MinNode<DataType>['inputAndArgs']) => {
-    return backend.min(config.inputs.x, config.args.axes);
-  },
-  Minimum:
-      (backend: MathBackend, config: MinimumNode<DataType>['inputAndArgs']) => {
-        return backend.minimum(config.inputs.a, config.inputs.b);
-      },
-  Max: (backend: MathBackend, config: MaxNode<DataType>['inputAndArgs']) => {
-    return backend.max(config.inputs.x, config.args.axes);
-  },
-  Maximum:
-      (backend: MathBackend, config: MaximumNode<DataType>['inputAndArgs']) => {
-        return backend.maximum(config.inputs.a, config.inputs.b);
-      },
-  Ceil:
-      (backend: MathBackend,
-       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
-        return backend.ceil(config.inputs.x);
-      },
-  Floor:
-      (backend: MathBackend,
-       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
-        return backend.floor(config.inputs.x);
-      },
-  Pow:
-      (backend: MathBackend,
-       config: PowNode<DataType, Rank>['inputAndArgs']) => {
-        return backend.pow(config.inputs.a, config.inputs.b);
-      },
-  Exp:
-      (backend: MathBackend,
-       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
-        return backend.exp(config.inputs.x);
-      },
-  Log:
-      (backend: MathBackend,
-       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
-        return backend.log(config.inputs.x);
-      },
-  Sqrt:
-      (backend: MathBackend,
-       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
-        return backend.sqrt(config.inputs.x);
-      },
-  Square:
-      (backend: MathBackend,
-       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
-        return backend.square(config.inputs.x);
-      },
-  Relu:
-      (backend: MathBackend,
-       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
-        return backend.relu(config.inputs.x);
-      },
-  Reshape: (backend: MathBackend, config: ReshapeNode['inputAndArgs']) => {
-    const x = config.inputs.x;
-    const newShape = config.args.newShape;
-    return NDArray.make(newShape, {dataId: x.dataId}, x.dtype);
-  },
-  Cast: (backend: MathBackend, config: CastNode['inputAndArgs']) => {
-    const x = config.inputs.x;
-    const newDType = config.args.newDType;
-
-    if (!util.hasEncodingLoss(x.dtype, newDType)) {
-      // We don't change the underlying data, since we cast to higher precision.
-      return NDArray.make(x.shape, {dataId: x.dataId}, newDType);
-    }
-    if (newDType === 'int32') {
-      return backend.int(x);
-    } else if (newDType === 'bool') {
-      return backend.notEqual(x, Scalar.new(0, x.dtype));
-    } else {
-      throw new Error(`Error in Cast: unknown dtype argument (${newDType})`);
-    }
-  },
-  LeakyRelu:
-      (backend: MathBackend,
-       config: LeakyReluNode<DataType, Rank>['inputAndArgs']) => {
-        return backend.leakyRelu(config.inputs.x, config.args.alpha);
-      },
-  PReLU:
-      (backend: MathBackend,
-       config: PReLUNode<DataType, Rank>['inputAndArgs']) => {
-        return backend.prelu(config.inputs.x, config.inputs.alpha);
-      },
-  PReLUDer:
-      (backend: MathBackend,
-       config: PReLUNode<DataType, Rank>['inputAndArgs']) => {
-        return backend.preluDer(config.inputs.x, config.inputs.alpha);
-      },
-  Elu:
-      (backend: MathBackend,
-       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
-        return backend.elu(config.inputs.x);
-      },
-  EluDer:
-      (backend: MathBackend,
-       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
-        return backend.eluDer(config.inputs.x);
-      },
-  Selu:
-      (backend: MathBackend,
-       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
-        return backend.selu(config.inputs.x);
-      },
-  Abs:
-      (backend: MathBackend,
-       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
-        return backend.abs(config.inputs.x);
-      },
-  Sigmoid:
-      (backend: MathBackend,
-       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
-        return backend.sigmoid(config.inputs.x);
-      },
-  Step:
-      (backend: MathBackend,
-       config: StepNode<DataType, Rank>['inputAndArgs']) => {
-        return backend.step(config.inputs.x, config.args.alpha);
-      },
-  Sin:
-      (backend: MathBackend,
-       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
-        return backend.sin(config.inputs.x);
-      },
-  Cos:
-      (backend: MathBackend,
-       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
-        return backend.cos(config.inputs.x);
-      },
-  Tan:
-      (backend: MathBackend,
-       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
-        return backend.tan(config.inputs.x);
-      },
-  Asin:
-      (backend: MathBackend,
-       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
-        return backend.asin(config.inputs.x);
-      },
-  Acos:
-      (backend: MathBackend,
-       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
-        return backend.acos(config.inputs.x);
-      },
-  Atan:
-      (backend: MathBackend,
-       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
-        return backend.atan(config.inputs.x);
-      },
-  Sinh:
-      (backend: MathBackend,
-       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
-        return backend.sinh(config.inputs.x);
-      },
-  Cosh:
-      (backend: MathBackend,
-       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
-        return backend.cosh(config.inputs.x);
-      },
-  Tanh:
-      (backend: MathBackend,
-       config: UnaryNode<DataType, Rank>['inputAndArgs']) => {
-        return backend.tanh(config.inputs.x);
-      },
-  Clip:
-      (backend: MathBackend,
-       config: ClipNode<DataType, Rank>['inputAndArgs']) => {
-        return backend.clip(config.inputs.x, config.args.min, config.args.max);
-      },
-  Tile:
-      (backend: MathBackend,
-       config: TileNode<DataType, Rank>['inputAndArgs']) => {
-        return backend.tile(config.inputs.x, config.args.reps);
-      },
-  Gather:
-      (backend: MathBackend,
-       config: GatherNode<DataType, Rank>['inputAndArgs']) => {
-        return backend.gather(
-            config.inputs.x, config.inputs.indices, config.args.axis);
-      },
-  Pad1D: (backend: MathBackend, config: Pad1DNode['inputAndArgs']) => {
-    return backend.pad1D(
-        config.inputs.x, config.args.paddings, config.args.constantValue);
-  },
-  Pad2D: (backend: MathBackend, config: Pad2DNode['inputAndArgs']) => {
-    return backend.pad2D(
-        config.inputs.x, config.args.paddings, config.args.constantValue);
-  },
-  Transpose:
-      (backend: MathBackend,
-       config: TransposeNode<DataType, Rank>['inputAndArgs']) => {
-        return backend.transpose(config.inputs.x, config.args.perm);
-      },
-  Conv2D: (backend: MathBackend, config: Conv2DNode['inputAndArgs']) => {
-    return backend.conv2d(
-        config.inputs.x, config.inputs.filter, config.inputs.bias,
-        config.args.convInfo);
-  },
-  Conv2DDerInput:
-      (backend: MathBackend, config: Conv2DDerInputNode['inputAndArgs']) => {
-        return backend.conv2dDerInput(
-            config.inputs.dy, config.inputs.filter, config.args.convInfo);
-      },
-  Conv2DDerFilter:
-      (backend: MathBackend, config: Conv2DDerFilterNode['inputAndArgs']) => {
-        return backend.conv2dDerFilter(
-            config.inputs.x, config.inputs.dy, config.args.convInfo);
-      },
-  Conv2DDerBias:
-      (backend: MathBackend, config: Conv2DDerBiasNode['inputAndArgs']) => {
-        return backend.conv2dDerBias(config.inputs.dy);
-      },
-  DepthwiseConv2D:
-      (backend: MathBackend, config: DepthwiseConv2DNode['inputAndArgs']) => {
-        return backend.depthwiseConv2D(
-            config.inputs.x, config.inputs.filter, config.args.convInfo);
-      },
-  MaxPool: (backend: MathBackend, config: PoolNode['inputAndArgs']) => {
-    return backend.maxPool(config.inputs.x, config.args.convInfo);
-  },
-  MaxPoolBackprop:
-      (backend: MathBackend, config: PoolBackpropNode['inputAndArgs']) => {
-        return backend.maxPoolBackprop(
-            config.inputs.dy, config.inputs.x, config.args.convInfo);
-      },
-  AvgPool: (backend: MathBackend, config: PoolNode['inputAndArgs']) => {
-    return backend.avgPool(config.inputs.x, config.args.convInfo);
-  },
-  AvgPoolBackprop:
-      (backend: MathBackend, config: PoolBackpropNode['inputAndArgs']) => {
-        return backend.avgPoolBackprop(
-            config.inputs.dy, config.inputs.x, config.args.convInfo);
-      },
-  MinPool: (backend: MathBackend, config: PoolNode['inputAndArgs']) => {
-    return backend.minPool(config.inputs.x, config.args.convInfo);
-  },
-  ResizeBilinear3D:
-      (backend: MathBackend, config: ResizeBilinear3DNode['inputAndArgs']) => {
-        return backend.resizeBilinear3D(
-            config.inputs.x, config.args.newShape2D, config.args.alignCorners);
-      },
-  BatchNorm4D: (
-      backend: MathBackend, config: BatchNorm4DNode['inputAndArgs']) => {
-    return backend.batchNormalization4D(
-        config.inputs.x, config.inputs.mean, config.inputs.variance,
-        config.args.varianceEpsilon, config.inputs.scale, config.inputs.offset);
-  },
-  BatchNorm3D: (
-      backend: MathBackend, config: BatchNorm3DNode['inputAndArgs']) => {
-    return backend.batchNormalization3D(
-        config.inputs.x, config.inputs.mean, config.inputs.variance,
-        config.args.varianceEpsilon, config.inputs.scale, config.inputs.offset);
-  },
-  BatchNorm2D: (
-      backend: MathBackend, config: BatchNorm2DNode['inputAndArgs']) => {
-    return backend.batchNormalization2D(
-        config.inputs.x, config.inputs.mean, config.inputs.variance,
-        config.args.varianceEpsilon, config.inputs.scale, config.inputs.offset);
-  },
-  LRN4D: (backend: MathBackend, config: LRN4DNode['inputAndArgs']) => {
-    return backend.localResponseNormalization4D(
-        config.inputs.x, config.args.radius, config.args.bias,
-        config.args.alpha, config.args.beta, config.args.normRegion);
-  },
-  Multinomial:
-      (backend: MathBackend, config: MultinomialNode['inputAndArgs']) => {
-        return backend.multinomial(
-            config.inputs.probs, config.args.numSamples, config.args.seed);
-      },
-  OneHot: (backend: MathBackend, config: OneHotNode['inputAndArgs']) => {
-    return backend.oneHot(
-        config.inputs.indices, config.args.depth, config.args.onValue,
-        config.args.offValue);
-  }
-};
 export function executeKernel<D extends DataType, R extends Rank, K extends
                                   keyof KernelConfigRegistry<D, R>, O extends
                                       KernelConfigRegistry<D, R>[K]['output']>(
     backend: MathBackend, kernelName: K,
-    config: KernelConfigRegistry<D, R>[K]['inputAndArgs']): O {
-  return KERNEL_METHODS[kernelName](backend, config) as O;
+    inputAndArgs: KernelConfigRegistry<D, R>[K]['inputAndArgs']): O {
+  if (kernelName === 'MatMul') {
+    const config = inputAndArgs as MatMulNode['inputAndArgs'];
+    return backend.matMul(
+               config.inputs.a, config.inputs.b, config.args.aOrientation,
+               config.args.bOrientation) as O;
+  } else if (kernelName === 'Clone') {
+    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
+    return backend.clone(config.inputs.x) as O;
+  } else if (kernelName === 'Slice1D') {
+    const config = inputAndArgs as Slice1DNode<D>['inputAndArgs'];
+    return backend.slice1D(
+               config.inputs.x, config.args.begin, config.args.size) as O;
+  } else if (kernelName === 'Slice2D') {
+    const config = inputAndArgs as Slice2DNode<D>['inputAndArgs'];
+    return backend.slice2D(
+               config.inputs.x, config.args.begin, config.args.size) as O;
+  } else if (kernelName === 'Slice3D') {
+    const config = inputAndArgs as Slice3DNode<D>['inputAndArgs'];
+    return backend.slice3D(
+               config.inputs.x, config.args.begin, config.args.size) as O;
+  } else if (kernelName === 'Slice4D') {
+    const config = inputAndArgs as Slice4DNode<DataType>['inputAndArgs'];
+    return backend.slice4D(
+               config.inputs.x, config.args.begin, config.args.size) as O;
+  } else if (kernelName === 'Reverse4D') {
+    const config = inputAndArgs as Reverse4DNode['inputAndArgs'];
+    return backend.reverse4D(config.inputs.x, config.args.axis) as O;
+  } else if (kernelName === 'Concat1D') {
+    const config = inputAndArgs as Concat1DNode['inputAndArgs'];
+    return backend.concat1D(config.inputs.a, config.inputs.b) as O;
+  } else if (kernelName === 'Concat2D') {
+    const config = inputAndArgs as Concat2DNode['inputAndArgs'];
+    return backend.concat2D(
+               config.inputs.a, config.inputs.b, config.args.axis) as O;
+  } else if (kernelName === 'Concat3D') {
+    const config = inputAndArgs as Concat3DNode['inputAndArgs'];
+    return backend.concat3D(
+               config.inputs.a, config.inputs.b, config.args.axis) as O;
+  } else if (kernelName === 'Concat4D') {
+    const config = inputAndArgs as Concat4DNode['inputAndArgs'];
+    return backend.concat4D(
+               config.inputs.a, config.inputs.b, config.args.axis) as O;
+  } else if (kernelName === 'Neg') {
+    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    return backend.neg(config.inputs.x) as O;
+  } else if (kernelName === 'Add') {
+    const config = inputAndArgs as BinaryNode['inputAndArgs'];
+    return backend.add(config.inputs.a, config.inputs.b) as O;
+  } else if (kernelName === 'Sub') {
+    const config = inputAndArgs as BinaryNode['inputAndArgs'];
+    return backend.subtract(config.inputs.a, config.inputs.b) as O;
+  } else if (kernelName === 'Mul') {
+    const config = inputAndArgs as BinaryNode['inputAndArgs'];
+    return backend.multiply(config.inputs.a, config.inputs.b) as O;
+  } else if (kernelName === 'Div') {
+    const config = inputAndArgs as BinaryNode['inputAndArgs'];
+    return backend.divide(config.inputs.a, config.inputs.b) as O;
+  } else if (kernelName === 'Sum') {
+    const config = inputAndArgs as SumNode<'float32'|'int32'>['inputAndArgs'];
+    return backend.sum(config.inputs.x, config.args.axes) as O;
+  } else if (kernelName === 'ArgMax') {
+    const config = inputAndArgs as ArgMaxNode['inputAndArgs'];
+    return backend.argMax(config.inputs.x, config.args.axes) as O;
+  } else if (kernelName === 'ArgMin') {
+    const config = inputAndArgs as ArgMinNode['inputAndArgs'];
+    return backend.argMin(config.inputs.x, config.args.axes) as O;
+  } else if (kernelName === 'Equal') {
+    const config = inputAndArgs as EqualNode['inputAndArgs'];
+    return backend.equal(config.inputs.a, config.inputs.b) as O;
+  } else if (kernelName === 'NotEqual') {
+    const config = inputAndArgs as EqualNode['inputAndArgs'];
+    return backend.notEqual(config.inputs.a, config.inputs.b) as O;
+  } else if (kernelName === 'Less') {
+    const config = inputAndArgs as EqualNode['inputAndArgs'];
+    return backend.less(config.inputs.a, config.inputs.b) as O;
+  } else if (kernelName === 'LessEqual') {
+    const config = inputAndArgs as EqualNode['inputAndArgs'];
+    return backend.lessEqual(config.inputs.a, config.inputs.b) as O;
+  } else if (kernelName === 'Greater') {
+    const config = inputAndArgs as EqualNode['inputAndArgs'];
+    return backend.greater(config.inputs.a, config.inputs.b) as O;
+  } else if (kernelName === 'GreaterEqual') {
+    const config = inputAndArgs as EqualNode['inputAndArgs'];
+    return backend.greaterEqual(config.inputs.a, config.inputs.b) as O;
+  } else if (kernelName === 'LogicalAnd') {
+    const config = inputAndArgs as LogicalNode['inputAndArgs'];
+    return backend.logicalAnd(config.inputs.a, config.inputs.b) as O;
+  } else if (kernelName === 'LogicalOr') {
+    const config = inputAndArgs as LogicalNode['inputAndArgs'];
+    return backend.logicalOr(config.inputs.a, config.inputs.b) as O;
+  } else if (kernelName === 'Where') {
+    const config = inputAndArgs as WhereNode['inputAndArgs'];
+    return backend.where(
+               config.inputs.condition, config.inputs.a, config.inputs.b,
+               config.args.dtype) as O;
+  } else if (kernelName === 'TopKValues') {
+    const config =
+        inputAndArgs as TopKValuesNode<DataType, Rank>['inputAndArgs'];
+    return backend.topKValues(config.inputs.x, config.args.k) as O;
+  } else if (kernelName === 'TopKIndices') {
+    const config = inputAndArgs as TopKIndicesNode['inputAndArgs'];
+    return backend.topKIndices(config.inputs.x, config.args.k) as O;
+  } else if (kernelName === 'Min') {
+    const config = inputAndArgs as MinNode<DataType>['inputAndArgs'];
+    return backend.min(config.inputs.x, config.args.axes) as O;
+  } else if (kernelName === 'Minimum') {
+    const config = inputAndArgs as MinimumNode<DataType>['inputAndArgs'];
+    return backend.minimum(config.inputs.a, config.inputs.b) as O;
+  } else if (kernelName === 'Max') {
+    const config = inputAndArgs as MaxNode<DataType>['inputAndArgs'];
+    return backend.max(config.inputs.x, config.args.axes) as O;
+  } else if (kernelName === 'Maximum') {
+    const config = inputAndArgs as MaximumNode<DataType>['inputAndArgs'];
+    return backend.maximum(config.inputs.a, config.inputs.b) as O;
+  } else if (kernelName === 'Ceil') {
+    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    return backend.ceil(config.inputs.x) as O;
+  } else if (kernelName === 'Floor') {
+    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    return backend.floor(config.inputs.x) as O;
+  } else if (kernelName === 'Pow') {
+    const config = inputAndArgs as PowNode<DataType, Rank>['inputAndArgs'];
+    return backend.pow(config.inputs.a, config.inputs.b) as O;
+  } else if (kernelName === 'Exp') {
+    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    return backend.exp(config.inputs.x) as O;
+  } else if (kernelName === 'Log') {
+    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    return backend.log(config.inputs.x) as O;
+  } else if (kernelName === 'Sqrt') {
+    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    return backend.sqrt(config.inputs.x) as O;
+  } else if (kernelName === 'Square') {
+    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    return backend.square(config.inputs.x) as O;
+  } else if (kernelName === 'Relu') {
+    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    return backend.relu(config.inputs.x) as O;
+  } else if (kernelName === 'Reshape') {
+    const config = inputAndArgs as ReshapeNode['inputAndArgs'];
+    const x = config.inputs.x;
+    const newShape = config.args.newShape;
+    return NDArray.make(newShape, {dataId: x.dataId}, x.dtype) as O;
+  } else if (kernelName === 'Cast') {
+    const config = inputAndArgs as CastNode['inputAndArgs'];
+    const x = config.inputs.x;
+    const newDType = config.args.newDType;
+
+    if (!util.hasEncodingLoss(x.dtype, newDType)) {
+      // We don't change the underlying data, since we cast to higher
+      // precision.
+      return NDArray.make(x.shape, {dataId: x.dataId}, newDType) as O;
+    }
+    if (newDType === 'int32') {
+      return backend.int(x) as O;
+    } else if (newDType === 'bool') {
+      return backend.notEqual(x, Scalar.new(0, x.dtype)) as O;
+    } else {
+      throw new Error(`Error in Cast: unknown dtype argument (${newDType})`);
+    }
+  } else if (kernelName === 'LeakyRelu') {
+    const config = inputAndArgs as LeakyReluNode<D, R>['inputAndArgs'];
+    return backend.leakyRelu(config.inputs.x, config.args.alpha) as O;
+  } else if (kernelName === 'PReLU') {
+    const config = inputAndArgs as PReLUNode<D, R>['inputAndArgs'];
+    return backend.prelu(config.inputs.x, config.inputs.alpha) as O;
+  } else if (kernelName === 'PReLUDer') {
+    const config = inputAndArgs as PReLUNode<D, R>['inputAndArgs'];
+    return backend.preluDer(config.inputs.x, config.inputs.alpha) as O;
+  } else if (kernelName === 'Elu') {
+    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    return backend.elu(config.inputs.x) as O;
+  } else if (kernelName === 'EluDer') {
+    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    return backend.eluDer(config.inputs.x) as O;
+  } else if (kernelName === 'Selu') {
+    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    return backend.selu(config.inputs.x) as O;
+  } else if (kernelName === 'Abs') {
+    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    return backend.abs(config.inputs.x) as O;
+  } else if (kernelName === 'Sigmoid') {
+    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    return backend.sigmoid(config.inputs.x) as O;
+  } else if (kernelName === 'Step') {
+    const config = inputAndArgs as StepNode<DataType, Rank>['inputAndArgs'];
+    return backend.step(config.inputs.x, config.args.alpha) as O;
+  } else if (kernelName === 'Sin') {
+    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    return backend.sin(config.inputs.x) as O;
+  } else if (kernelName === 'Cos') {
+    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    return backend.cos(config.inputs.x) as O;
+  } else if (kernelName === 'Tan') {
+    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    return backend.tan(config.inputs.x) as O;
+  } else if (kernelName === 'Asin') {
+    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    return backend.asin(config.inputs.x) as O;
+  } else if (kernelName === 'Acos') {
+    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    return backend.acos(config.inputs.x) as O;
+  } else if (kernelName === 'Atan') {
+    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    return backend.atan(config.inputs.x) as O;
+  } else if (kernelName === 'Sinh') {
+    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    return backend.sinh(config.inputs.x) as O;
+  } else if (kernelName === 'Cosh') {
+    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    return backend.cosh(config.inputs.x) as O;
+  } else if (kernelName === 'Tanh') {
+    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    return backend.tanh(config.inputs.x) as O;
+  } else if (kernelName === 'Clip') {
+    const config = inputAndArgs as ClipNode<DataType, Rank>['inputAndArgs'];
+    return backend.clip(config.inputs.x, config.args.min, config.args.max) as O;
+  } else if (kernelName === 'Tile') {
+    const config = inputAndArgs as TileNode<DataType, Rank>['inputAndArgs'];
+    return backend.tile(config.inputs.x, config.args.reps) as O;
+  } else if (kernelName === 'Gather') {
+    const config = inputAndArgs as GatherNode<DataType, Rank>['inputAndArgs'];
+    return backend.gather(
+               config.inputs.x, config.inputs.indices, config.args.axis) as O;
+  } else if (kernelName === 'Pad1D') {
+    const config = inputAndArgs as Pad1DNode['inputAndArgs'];
+    return backend.pad1D(
+               config.inputs.x, config.args.paddings,
+               config.args.constantValue) as O;
+  } else if (kernelName === 'Pad2D') {
+    const config = inputAndArgs as Pad2DNode['inputAndArgs'];
+    return backend.pad2D(
+               config.inputs.x, config.args.paddings,
+               config.args.constantValue) as O;
+  } else if (kernelName === 'Transpose') {
+    const config =
+        inputAndArgs as TransposeNode<DataType, Rank>['inputAndArgs'];
+    return backend.transpose(config.inputs.x, config.args.perm) as O;
+  } else if (kernelName === 'Conv2D') {
+    const config = inputAndArgs as Conv2DNode['inputAndArgs'];
+    return backend.conv2d(
+               config.inputs.x, config.inputs.filter, config.inputs.bias,
+               config.args.convInfo) as O;
+  } else if (kernelName === 'Conv2DDerInput') {
+    const config = inputAndArgs as Conv2DDerInputNode['inputAndArgs'];
+    return backend.conv2dDerInput(
+               config.inputs.dy, config.inputs.filter, config.args.convInfo) as
+        O;
+  } else if (kernelName === 'Conv2DDerFilter') {
+    const config = inputAndArgs as Conv2DDerFilterNode['inputAndArgs'];
+    return backend.conv2dDerFilter(
+               config.inputs.x, config.inputs.dy, config.args.convInfo) as O;
+  } else if (kernelName === 'Conv2DDerBias') {
+    const config = inputAndArgs as Conv2DDerBiasNode['inputAndArgs'];
+    return backend.conv2dDerBias(config.inputs.dy) as O;
+  } else if (kernelName === 'DepthwiseConv2D') {
+    const config = inputAndArgs as DepthwiseConv2DNode['inputAndArgs'];
+    return backend.depthwiseConv2D(
+               config.inputs.x, config.inputs.filter, config.args.convInfo) as
+        O;
+  } else if (kernelName === 'MaxPool') {
+    const config = inputAndArgs as PoolNode['inputAndArgs'];
+    return backend.maxPool(config.inputs.x, config.args.convInfo) as O;
+  } else if (kernelName === 'MaxPoolBackprop') {
+    const config = inputAndArgs as PoolBackpropNode['inputAndArgs'];
+    return backend.maxPoolBackprop(
+               config.inputs.dy, config.inputs.x, config.args.convInfo) as O;
+  } else if (kernelName === 'AvgPool') {
+    const config = inputAndArgs as PoolNode['inputAndArgs'];
+    return backend.avgPool(config.inputs.x, config.args.convInfo) as O;
+  } else if (kernelName === 'AvgPoolBackprop') {
+    const config = inputAndArgs as PoolBackpropNode['inputAndArgs'];
+    return backend.avgPoolBackprop(
+               config.inputs.dy, config.inputs.x, config.args.convInfo) as O;
+  } else if (kernelName === 'MinPool') {
+    const config = inputAndArgs as PoolNode['inputAndArgs'];
+    return backend.minPool(config.inputs.x, config.args.convInfo) as O;
+  } else if (kernelName === 'ResizeBilinear3D') {
+    const config = inputAndArgs as ResizeBilinear3DNode['inputAndArgs'];
+    return backend.resizeBilinear3D(
+               config.inputs.x, config.args.newShape2D,
+               config.args.alignCorners) as O;
+  } else if (kernelName === 'BatchNorm4D') {
+    const config = inputAndArgs as BatchNorm4DNode['inputAndArgs'];
+    return backend.batchNormalization4D(
+               config.inputs.x, config.inputs.mean, config.inputs.variance,
+               config.args.varianceEpsilon, config.inputs.scale,
+               config.inputs.offset) as O;
+  } else if (kernelName === 'BatchNorm3D') {
+    const config = inputAndArgs as BatchNorm3DNode['inputAndArgs'];
+    return backend.batchNormalization3D(
+               config.inputs.x, config.inputs.mean, config.inputs.variance,
+               config.args.varianceEpsilon, config.inputs.scale,
+               config.inputs.offset) as O;
+  } else if (kernelName === 'BatchNorm2D') {
+    const config = inputAndArgs as BatchNorm2DNode['inputAndArgs'];
+    return backend.batchNormalization2D(
+               config.inputs.x, config.inputs.mean, config.inputs.variance,
+               config.args.varianceEpsilon, config.inputs.scale,
+               config.inputs.offset) as O;
+  } else if (kernelName === 'LRN4D') {
+    const config = inputAndArgs as LRN4DNode['inputAndArgs'];
+    return backend.localResponseNormalization4D(
+               config.inputs.x, config.args.radius, config.args.bias,
+               config.args.alpha, config.args.beta, config.args.normRegion) as
+        O;
+  } else if (kernelName === 'Multinomial') {
+    const config = inputAndArgs as MultinomialNode['inputAndArgs'];
+    return backend.multinomial(
+               config.inputs.probs, config.args.numSamples, config.args.seed) as
+        O;
+  } else if (kernelName === 'OneHot') {
+    const config = inputAndArgs as OneHotNode['inputAndArgs'];
+    return backend.oneHot(
+               config.inputs.indices, config.args.depth, config.args.onValue,
+               config.args.offValue) as O;
+  }
+  throw new Error(`No backend method found for kernel ${kernelName}`);
 }
 
 export interface KernelConfigRegistry<D extends DataType, R extends Rank> {

--- a/src/math/backends/kernel_registry.ts
+++ b/src/math/backends/kernel_registry.ts
@@ -76,7 +76,7 @@ export function executeKernel<D extends DataType, R extends Rank, K extends
     return backend.slice3D(
                config.inputs.x, config.args.begin, config.args.size) as O;
   } else if (kernelName === 'Slice4D') {
-    const config = inputAndArgs as Slice4DNode<DataType>['inputAndArgs'];
+    const config = inputAndArgs as Slice4DNode<D>['inputAndArgs'];
     return backend.slice4D(
                config.inputs.x, config.args.begin, config.args.size) as O;
   } else if (kernelName === 'Reverse4D') {
@@ -98,7 +98,7 @@ export function executeKernel<D extends DataType, R extends Rank, K extends
     return backend.concat4D(
                config.inputs.a, config.inputs.b, config.args.axis) as O;
   } else if (kernelName === 'Neg') {
-    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
     return backend.neg(config.inputs.x) as O;
   } else if (kernelName === 'Add') {
     const config = inputAndArgs as BinaryNode['inputAndArgs'];
@@ -151,47 +151,46 @@ export function executeKernel<D extends DataType, R extends Rank, K extends
                config.inputs.condition, config.inputs.a, config.inputs.b,
                config.args.dtype) as O;
   } else if (kernelName === 'TopKValues') {
-    const config =
-        inputAndArgs as TopKValuesNode<DataType, Rank>['inputAndArgs'];
+    const config = inputAndArgs as TopKValuesNode<D, R>['inputAndArgs'];
     return backend.topKValues(config.inputs.x, config.args.k) as O;
   } else if (kernelName === 'TopKIndices') {
     const config = inputAndArgs as TopKIndicesNode['inputAndArgs'];
     return backend.topKIndices(config.inputs.x, config.args.k) as O;
   } else if (kernelName === 'Min') {
-    const config = inputAndArgs as MinNode<DataType>['inputAndArgs'];
+    const config = inputAndArgs as MinNode<D>['inputAndArgs'];
     return backend.min(config.inputs.x, config.args.axes) as O;
   } else if (kernelName === 'Minimum') {
-    const config = inputAndArgs as MinimumNode<DataType>['inputAndArgs'];
+    const config = inputAndArgs as MinimumNode<D>['inputAndArgs'];
     return backend.minimum(config.inputs.a, config.inputs.b) as O;
   } else if (kernelName === 'Max') {
-    const config = inputAndArgs as MaxNode<DataType>['inputAndArgs'];
+    const config = inputAndArgs as MaxNode<D>['inputAndArgs'];
     return backend.max(config.inputs.x, config.args.axes) as O;
   } else if (kernelName === 'Maximum') {
-    const config = inputAndArgs as MaximumNode<DataType>['inputAndArgs'];
+    const config = inputAndArgs as MaximumNode<D>['inputAndArgs'];
     return backend.maximum(config.inputs.a, config.inputs.b) as O;
   } else if (kernelName === 'Ceil') {
-    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
     return backend.ceil(config.inputs.x) as O;
   } else if (kernelName === 'Floor') {
-    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
     return backend.floor(config.inputs.x) as O;
   } else if (kernelName === 'Pow') {
-    const config = inputAndArgs as PowNode<DataType, Rank>['inputAndArgs'];
+    const config = inputAndArgs as PowNode<D, R>['inputAndArgs'];
     return backend.pow(config.inputs.a, config.inputs.b) as O;
   } else if (kernelName === 'Exp') {
-    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
     return backend.exp(config.inputs.x) as O;
   } else if (kernelName === 'Log') {
-    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
     return backend.log(config.inputs.x) as O;
   } else if (kernelName === 'Sqrt') {
-    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
     return backend.sqrt(config.inputs.x) as O;
   } else if (kernelName === 'Square') {
-    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
     return backend.square(config.inputs.x) as O;
   } else if (kernelName === 'Relu') {
-    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
     return backend.relu(config.inputs.x) as O;
   } else if (kernelName === 'Reshape') {
     const config = inputAndArgs as ReshapeNode['inputAndArgs'];
@@ -225,58 +224,58 @@ export function executeKernel<D extends DataType, R extends Rank, K extends
     const config = inputAndArgs as PReLUNode<D, R>['inputAndArgs'];
     return backend.preluDer(config.inputs.x, config.inputs.alpha) as O;
   } else if (kernelName === 'Elu') {
-    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
     return backend.elu(config.inputs.x) as O;
   } else if (kernelName === 'EluDer') {
-    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
     return backend.eluDer(config.inputs.x) as O;
   } else if (kernelName === 'Selu') {
-    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
     return backend.selu(config.inputs.x) as O;
   } else if (kernelName === 'Abs') {
-    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
     return backend.abs(config.inputs.x) as O;
   } else if (kernelName === 'Sigmoid') {
-    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
     return backend.sigmoid(config.inputs.x) as O;
   } else if (kernelName === 'Step') {
-    const config = inputAndArgs as StepNode<DataType, Rank>['inputAndArgs'];
+    const config = inputAndArgs as StepNode<D, R>['inputAndArgs'];
     return backend.step(config.inputs.x, config.args.alpha) as O;
   } else if (kernelName === 'Sin') {
-    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
     return backend.sin(config.inputs.x) as O;
   } else if (kernelName === 'Cos') {
-    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
     return backend.cos(config.inputs.x) as O;
   } else if (kernelName === 'Tan') {
-    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
     return backend.tan(config.inputs.x) as O;
   } else if (kernelName === 'Asin') {
-    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
     return backend.asin(config.inputs.x) as O;
   } else if (kernelName === 'Acos') {
-    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
     return backend.acos(config.inputs.x) as O;
   } else if (kernelName === 'Atan') {
-    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
     return backend.atan(config.inputs.x) as O;
   } else if (kernelName === 'Sinh') {
-    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
     return backend.sinh(config.inputs.x) as O;
   } else if (kernelName === 'Cosh') {
-    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
     return backend.cosh(config.inputs.x) as O;
   } else if (kernelName === 'Tanh') {
-    const config = inputAndArgs as UnaryNode<DataType, Rank>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
     return backend.tanh(config.inputs.x) as O;
   } else if (kernelName === 'Clip') {
-    const config = inputAndArgs as ClipNode<DataType, Rank>['inputAndArgs'];
+    const config = inputAndArgs as ClipNode<D, R>['inputAndArgs'];
     return backend.clip(config.inputs.x, config.args.min, config.args.max) as O;
   } else if (kernelName === 'Tile') {
-    const config = inputAndArgs as TileNode<DataType, Rank>['inputAndArgs'];
+    const config = inputAndArgs as TileNode<D, R>['inputAndArgs'];
     return backend.tile(config.inputs.x, config.args.reps) as O;
   } else if (kernelName === 'Gather') {
-    const config = inputAndArgs as GatherNode<DataType, Rank>['inputAndArgs'];
+    const config = inputAndArgs as GatherNode<D, R>['inputAndArgs'];
     return backend.gather(
                config.inputs.x, config.inputs.indices, config.args.axis) as O;
   } else if (kernelName === 'Pad1D') {
@@ -290,8 +289,7 @@ export function executeKernel<D extends DataType, R extends Rank, K extends
                config.inputs.x, config.args.paddings,
                config.args.constantValue) as O;
   } else if (kernelName === 'Transpose') {
-    const config =
-        inputAndArgs as TransposeNode<DataType, Rank>['inputAndArgs'];
+    const config = inputAndArgs as TransposeNode<D, R>['inputAndArgs'];
     return backend.transpose(config.inputs.x, config.args.perm) as O;
   } else if (kernelName === 'Conv2D') {
     const config = inputAndArgs as Conv2DNode['inputAndArgs'];

--- a/src/math/backends/tape_types.ts
+++ b/src/math/backends/tape_types.ts
@@ -16,7 +16,7 @@
  */
 
 import {NamedArrayMap} from '../../util';
-import {NDArray} from '../ndarray';
+import {DataType, NDArray, Rank} from '../ndarray';
 
 import {KernelConfigRegistry} from './kernel_registry';
 
@@ -33,18 +33,20 @@ export interface TapeNode<T extends TapeNodeOutput> {
   inputAndArgs: TapeNodeInputConfig;
 
   output: T;
-  gradient: (dy: NDArray|NamedArrayMap, y: T) => TapeNodeInputGradientArrays;
+  gradient:
+      (dy: NDArray<'float32'>|NamedArrayMap<'float32'>,
+       y: T) => TapeNodeInputGradientArrays;
 }
 
 export interface TapeNodeInputConfig { inputs: NamedArrayMap; }
 
 export type TapeNodeInputGradientArrays = {
-  [inputName: string]: () => NDArray;
+  [inputName: string]: () => NDArray<'float32'>;
 };
 
 // Kernel nodes
 export interface KernelNode extends TapeNode<NDArray> {
-  kernel: keyof KernelConfigRegistry;
+  kernel: keyof KernelConfigRegistry<DataType, Rank>;
   inputAndArgs: KernelInputConfig;
   output: NDArray;
 }

--- a/src/math/backends/tape_util.ts
+++ b/src/math/backends/tape_util.ts
@@ -17,7 +17,8 @@
 
 import {ENV} from '../../environment';
 import * as util from '../../util';
-import {NDArray} from '../ndarray';
+import {NamedArrayMap} from '../../util';
+import {NDArray, Variable} from '../ndarray';
 
 // tslint:disable-next-line:max-line-length
 import {Tape, TapeNode, TapeNodeInputConfig, TapeNodeOutput} from './tape_types';
@@ -150,13 +151,13 @@ export function getFilteredNodesXToY(
  * @param filteredTape The filtered TapeNodes to backprop through.
  */
 export function backpropagateGradients(
-    arrayAccumulatedGradientMap: {[ndarrayId: number]: NDArray},
+    arrayAccumulatedGradientMap: {[ndarrayId: number]: NDArray<'float32'>},
     filteredTape: Tape) {
   // Walk the tape backwards and keep a map of NDArray to its gradient.
   for (let i = filteredTape.length - 1; i >= 0; i--) {
     const node = filteredTape[i];
 
-    let dy: TapeNodeOutput;
+    let dy: NDArray<'float32'>|NamedArrayMap<'float32'>;
     if (node.output instanceof NDArray) {
       dy = arrayAccumulatedGradientMap[node.output.id];
     } else {
@@ -203,36 +204,40 @@ export function backpropagateGradients(
   }
 }
 
-export function computeInputs(tape: Tape): {[idx: string]: NDArray} {
-  const outputArrays: {[id: number]: boolean} = {};
-  for (let i = 0; i < tape.length; i++) {
-    const node = tape[i];
-    if (node.output instanceof NDArray) {
-      outputArrays[node.output.id] = true;
-    } else {
-      const keys = Object.keys(node.output);
-      for (const key of keys) {
-        outputArrays[node.output[key].id] = true;
-      }
-    }
+export function computeTrainableVariableInputs(
+    tape: Tape, varList?: Variable[]): Variable[] {
+  const trainableVariables: Variable[] = [];
+  const trainableVariablesSeen: {[ndarrayId: number]: boolean} = {};
+
+  const variableIds: {[ndarrayId: number]: boolean} = {};
+  if (varList != null) {
+    varList.forEach(variable => {
+      variableIds[variable.id] = true;
+    });
   }
 
-  const inputArrays: {[idx: string]: NDArray} = {};
-  const inputArraysSeen: {[ndarrayId: number]: boolean} = {};
-  let idx = 0;
   for (let i = 0; i < tape.length; i++) {
     const node = tape[i];
     const inputs = node.inputAndArgs.inputs;
 
     const keys = Object.keys(inputs);
     for (const key of keys) {
-      if (!outputArrays[inputs[key].id] && !inputArraysSeen[inputs[key].id]) {
-        inputArrays[(idx++).toString()] = inputs[key];
-        inputArraysSeen[inputs[key].id] = true;
+      const input = inputs[key];
+      if (!trainableVariablesSeen[input.id] && input instanceof Variable &&
+          input.trainable) {
+        // When specifying a variable list, filter out variables that aren't
+        // specified explicitly.
+        if (varList != null) {
+          if (variableIds[input.id] == null) {
+            continue;
+          }
+        }
+        trainableVariables.push(input);
+        trainableVariablesSeen[inputs[key].id] = true;
       }
     }
   }
-  return inputArrays;
+  return trainableVariables;
 }
 
 export type ScopeResultImmediate =

--- a/src/math/backends/tape_util.ts
+++ b/src/math/backends/tape_util.ts
@@ -204,17 +204,15 @@ export function backpropagateGradients(
   }
 }
 
-export function computeTrainableVariableInputs(
-    tape: Tape, varList?: Variable[]): Variable[] {
+export function computeVariableInputs(
+    tape: Tape, varList: Variable[]): Variable[] {
   const trainableVariables: Variable[] = [];
   const trainableVariablesSeen: {[ndarrayId: number]: boolean} = {};
 
   const variableIds: {[ndarrayId: number]: boolean} = {};
-  if (varList != null) {
-    varList.forEach(variable => {
-      variableIds[variable.id] = true;
-    });
-  }
+  varList.forEach(variable => {
+    variableIds[variable.id] = true;
+  });
 
   for (let i = 0; i < tape.length; i++) {
     const node = tape[i];
@@ -223,8 +221,7 @@ export function computeTrainableVariableInputs(
     const keys = Object.keys(inputs);
     for (const key of keys) {
       const input = inputs[key];
-      if (!trainableVariablesSeen[input.id] && input instanceof Variable &&
-          input.trainable) {
+      if (input instanceof Variable && !trainableVariablesSeen[input.id]) {
         // When specifying a variable list, filter out variables that aren't
         // specified explicitly.
         if (varList != null) {

--- a/src/math/backends/tape_util_test.ts
+++ b/src/math/backends/tape_util_test.ts
@@ -19,7 +19,7 @@
 import * as test_util from '../../test_util';
 import {MathTests} from '../../test_util';
 import {NamedArrayMap} from '../../util';
-import {NDArray, Scalar} from '../ndarray';
+import {NDArray, Scalar, variable, Variable} from '../ndarray';
 
 // tslint:disable-next-line:max-line-length
 import {Tape, TapeNode, TapeNodeInputConfig, TapeNodeOutput} from './tape_types';
@@ -433,7 +433,8 @@ import * as tape_util from './tape_util';
 
       const dy = Scalar.new(1);
 
-      const accumulatedGradientsMap: {[ndarrayId: number]: NDArray} = {};
+      const accumulatedGradientsMap:
+          {[ndarrayId: number]: NDArray<'float32'>} = {};
       accumulatedGradientsMap[y.id] = dy;
 
       const tape: Tape = [{
@@ -458,7 +459,8 @@ import * as tape_util from './tape_util';
 
       const dy = Scalar.new(1);
 
-      const accumulatedGradientsMap: {[ndarrayId: number]: NDArray} = {};
+      const accumulatedGradientsMap:
+          {[ndarrayId: number]: NDArray<'float32'>} = {};
       accumulatedGradientsMap[y.id] = dy;
 
       const tape: Tape = [{
@@ -469,7 +471,7 @@ import * as tape_util from './tape_util';
           inputs: {x},
         },
         output: y,
-        gradient: (dy: Scalar, y: Scalar) => {
+        gradient: (dy: Scalar<'float32'>, y: Scalar) => {
           return {x: () => math.add(dy, Scalar.new(1))};
         }
       }];
@@ -486,7 +488,8 @@ import * as tape_util from './tape_util';
 
       const dy = Scalar.new(1);
 
-      const accumulatedGradientsMap: {[ndarrayId: number]: NDArray} = {};
+      const accumulatedGradientsMap:
+          {[ndarrayId: number]: NDArray<'float32'>} = {};
       accumulatedGradientsMap[y.id] = dy;
 
       const tape: Tape = [
@@ -498,7 +501,7 @@ import * as tape_util from './tape_util';
             inputs: {x},
           },
           output: intermediate,
-          gradient: (dy: Scalar, y: Scalar) => {
+          gradient: (dy: Scalar<'float32'>, y: Scalar) => {
             return {x: () => math.add(dy, Scalar.new(1))};
           }
         },
@@ -510,7 +513,7 @@ import * as tape_util from './tape_util';
             inputs: {intermediate},
           },
           output: y,
-          gradient: (dy: Scalar, y: Scalar) => {
+          gradient: (dy: Scalar<'float32'>, y: Scalar) => {
             return {intermediate: () => math.add(dy, Scalar.new(1))};
           }
         }
@@ -530,7 +533,8 @@ import * as tape_util from './tape_util';
 
       const dy = Scalar.new(1);
 
-      const accumulatedGradientsMap: {[ndarrayId: number]: NDArray} = {};
+      const accumulatedGradientsMap:
+          {[ndarrayId: number]: NDArray<'float32'>} = {};
       accumulatedGradientsMap[y.id] = dy;
 
       const tape: Tape = [
@@ -542,7 +546,7 @@ import * as tape_util from './tape_util';
             inputs: {x},
           },
           output: intermediate1,
-          gradient: (dy: Scalar, y: Scalar) => {
+          gradient: (dy: Scalar<'float32'>, y: Scalar) => {
             return {x: () => math.add(dy, Scalar.new(1))};
           }
         },
@@ -554,7 +558,7 @@ import * as tape_util from './tape_util';
             inputs: {x},
           },
           output: intermediate2,
-          gradient: (dy: Scalar, y: Scalar) => {
+          gradient: (dy: Scalar<'float32'>, y: Scalar) => {
             return {x: () => math.add(dy, Scalar.new(1))};
           }
         },
@@ -566,7 +570,7 @@ import * as tape_util from './tape_util';
             inputs: {intermediate1, intermediate2},
           },
           output: y,
-          gradient: (dy: Scalar, y: Scalar) => {
+          gradient: (dy: Scalar<'float32'>, y: Scalar) => {
             return {
               intermediate1: () => math.add(dy, Scalar.new(1)),
               intermediate2: () => math.add(dy, Scalar.new(1))
@@ -591,7 +595,8 @@ import * as tape_util from './tape_util';
 
          const dy = Scalar.new(1);
 
-         const accumulatedGradientsMap: {[ndarrayId: number]: NDArray} = {};
+         const accumulatedGradientsMap:
+             {[ndarrayId: number]: NDArray<'float32'>} = {};
          accumulatedGradientsMap[y.id] = dy;
 
          const tape: Array<TapeNode<TapeNodeOutput>> = [
@@ -603,7 +608,7 @@ import * as tape_util from './tape_util';
                inputs: {x},
              },
              output: {intermediate1, intermediate2},
-             gradient: (dy: NamedArrayMap, y: NamedArrayMap) => {
+             gradient: (dy: NamedArrayMap<'float32'>, y: NamedArrayMap) => {
                return {
                  x: () =>
                      math.multiply(dy['intermediate1'], dy['intermediate2'])
@@ -618,7 +623,7 @@ import * as tape_util from './tape_util';
                inputs: {intermediate1, intermediate2},
              },
              output: y,
-             gradient: (dy: Scalar, y: Scalar) => {
+             gradient: (dy: Scalar<'float32'>, y: Scalar) => {
                return {
                  intermediate1: () => math.add(dy, Scalar.new(2)),
                  intermediate2: () => math.add(dy, Scalar.new(3))
@@ -637,7 +642,7 @@ import * as tape_util from './tape_util';
   test_util.describeMathCPU('tape_util.backpropagateGradients', [tests]);
 }
 
-// computeInputs
+// computeTrainableVariableInputs
 {
   const tests: MathTests = it => {
     it('no inputs', math => {
@@ -654,12 +659,12 @@ import * as tape_util from './tape_util';
         gradient: null
       }];
 
-      const inputs = tape_util.computeInputs(tape);
+      const inputs = tape_util.computeTrainableVariableInputs(tape);
 
-      expect(inputs).toEqual({});
+      expect(inputs).toEqual([]);
     });
 
-    it('basic', math => {
+    it('no variable inputs', math => {
       const x = Scalar.new(1);
       const y = Scalar.new(2);
 
@@ -674,12 +679,95 @@ import * as tape_util from './tape_util';
         gradient: null
       }];
 
-      const inputs = tape_util.computeInputs(tape);
+      const inputs = tape_util.computeTrainableVariableInputs(tape);
 
-      expect(inputs).toEqual({'0': x});
+      expect(inputs).toEqual([]);
     });
 
-    it('multiple inputs from multiple ops', math => {
+    it('one variable input, not trainable', math => {
+      const trainable = false;
+      const x = variable(Scalar.new(1), trainable);
+      const y = Scalar.new(2);
+
+      const tape: Tape = [{
+        id: 0,
+        type: 'kernel',
+        name: 'node0',
+        inputAndArgs: {
+          inputs: {x},
+        },
+        output: y,
+        gradient: null
+      }];
+
+      const inputs = tape_util.computeTrainableVariableInputs(tape);
+
+      expect(inputs).toEqual([]);
+    });
+
+    it('one variable input, not in varList', math => {
+      const x = variable(Scalar.new(1));
+      const y = Scalar.new(2);
+
+      const tape: Tape = [{
+        id: 0,
+        type: 'kernel',
+        name: 'node0',
+        inputAndArgs: {
+          inputs: {x},
+        },
+        output: y,
+        gradient: null
+      }];
+
+      const varList: Variable[] = [];
+      const inputs = tape_util.computeTrainableVariableInputs(tape, varList);
+
+      expect(inputs).toEqual([]);
+    });
+
+    it('one variable input in varList', math => {
+      const x = variable(Scalar.new(1));
+      const y = Scalar.new(2);
+
+      const tape: Tape = [{
+        id: 0,
+        type: 'kernel',
+        name: 'node0',
+        inputAndArgs: {
+          inputs: {x},
+        },
+        output: y,
+        gradient: null
+      }];
+
+      const varList: Variable[] = [x];
+      const inputs = tape_util.computeTrainableVariableInputs(tape, varList);
+
+      expect(inputs).toEqual([x]);
+    });
+
+    it('one variable input', math => {
+      const x = variable(Scalar.new(1));
+      const y = Scalar.new(2);
+
+      const tape: Tape = [{
+        id: 0,
+        type: 'kernel',
+        name: 'node0',
+        inputAndArgs: {
+          inputs: {x},
+        },
+        output: y,
+        gradient: null
+      }];
+
+      const inputs = tape_util.computeTrainableVariableInputs(tape);
+
+      expect(inputs).toEqual([x]);
+    });
+
+    it('multiple inputs from multiple ops, no variables', math => {
       const x1 = Scalar.new(1);
       const intermediate1 = Scalar.new(0);
 
@@ -709,10 +797,176 @@ import * as tape_util from './tape_util';
         }
       ];
 
-      const inputs = tape_util.computeInputs(tape);
+      const inputs = tape_util.computeTrainableVariableInputs(tape);
 
-      expect(inputs).toEqual({'0': x1, '1': x2});
+      expect(inputs).toEqual([]);
     });
+
+    it('multiple inputs from multiple ops, two variables', math => {
+      const x1 = variable(Scalar.new(1));
+      const intermediate1 = Scalar.new(0);
+
+      const x2 = variable(Scalar.new(0));
+      const y = Scalar.new(2);
+
+      const notInTape = variable(Scalar.new(3));
+      // Silence the compiler, we just want to make sure that a variable not in
+      // the tape is not included in the trainable variable inputs.
+      expect(notInTape).not.toBeNull();
+
+      const tape: Tape = [
+        {
+          id: 0,
+          type: 'kernel',
+          name: 'node0',
+          inputAndArgs: {
+            inputs: {x1},
+          },
+          output: intermediate1,
+          gradient: null
+        },
+        {
+          id: 1,
+          type: 'kernel',
+          name: 'node1',
+          inputAndArgs: {
+            inputs: {intermediate1, x2},
+          },
+          output: y,
+          gradient: null
+        }
+      ];
+
+      const inputs = tape_util.computeTrainableVariableInputs(tape);
+
+      expect(inputs).toEqual([x1, x2]);
+    });
+
+    it('multiple inputs, two variables, one not trainable', math => {
+      const x1 = variable(Scalar.new(1));
+      const intermediate1 = Scalar.new(0);
+
+      const trainable = false;
+      const x2 = variable(Scalar.new(0), trainable);
+      const y = Scalar.new(2);
+
+      const notInTape = variable(Scalar.new(3));
+      // Silence the compiler, we just want to make sure that a variable not
+      // in the tape is not included in the trainable variable inputs.
+      expect(notInTape).not.toBeNull();
+
+      const tape: Tape = [
+        {
+          id: 0,
+          type: 'kernel',
+          name: 'node0',
+          inputAndArgs: {
+            inputs: {x1},
+          },
+          output: intermediate1,
+          gradient: null
+        },
+        {
+          id: 1,
+          type: 'kernel',
+          name: 'node1',
+          inputAndArgs: {
+            inputs: {intermediate1, x2},
+          },
+          output: y,
+          gradient: null
+        }
+      ];
+
+      const inputs = tape_util.computeTrainableVariableInputs(tape);
+
+      // Only x1 is trainable.
+      expect(inputs).toEqual([x1]);
+    });
+
+    it('multiple inputs, two variables, only one in varList', math => {
+      const x1 = variable(Scalar.new(1));
+      const intermediate1 = Scalar.new(0);
+
+      const x2 = variable(Scalar.new(0));
+      const y = Scalar.new(2);
+
+      const notInTape = variable(Scalar.new(3));
+      // Silence the compiler, we just want to make sure that a variable not
+      // in the tape is not included in the trainable variable inputs.
+      expect(notInTape).not.toBeNull();
+
+      const tape: Tape = [
+        {
+          id: 0,
+          type: 'kernel',
+          name: 'node0',
+          inputAndArgs: {
+            inputs: {x1},
+          },
+          output: intermediate1,
+          gradient: null
+        },
+        {
+          id: 1,
+          type: 'kernel',
+          name: 'node1',
+          inputAndArgs: {
+            inputs: {intermediate1, x2},
+          },
+          output: y,
+          gradient: null
+        }
+      ];
+
+      const inputs = tape_util.computeTrainableVariableInputs(tape, [x2]);
+
+      // Only x2 is in varList.
+      expect(inputs).toEqual([x2]);
+    });
+
+    it('multiple inputs, two variables, only one in varList not trainable',
+       math => {
+         const x1 = variable(Scalar.new(1));
+         const intermediate1 = Scalar.new(0);
+
+         const trainable = false;
+         const x2 = variable(Scalar.new(0), trainable);
+         const y = Scalar.new(2);
+
+         const notInTape = variable(Scalar.new(3));
+         // Silence the compiler, we just want to make sure that a variable not
+         // in the tape is not included in the trainable variable inputs.
+         expect(notInTape).not.toBeNull();
+
+         const tape: Tape = [
+           {
+             id: 0,
+             type: 'kernel',
+             name: 'node0',
+             inputAndArgs: {
+               inputs: {x1},
+             },
+             output: intermediate1,
+             gradient: null
+           },
+           {
+             id: 1,
+             type: 'kernel',
+             name: 'node1',
+             inputAndArgs: {
+               inputs: {intermediate1, x2},
+             },
+             output: y,
+             gradient: null
+           }
+         ];
+
+         const inputs = tape_util.computeTrainableVariableInputs(tape, [x2]);
+
+         // Only x2 is in varList, but is not trainable.
+         expect(inputs).toEqual([]);
+       });
   };
   test_util.describeMathCPU('tape_util.computeInputs', [tests]);
 }

--- a/src/math/backends/tape_util_test.ts
+++ b/src/math/backends/tape_util_test.ts
@@ -659,7 +659,8 @@ import * as tape_util from './tape_util';
         gradient: null
       }];
 
-      const inputs = tape_util.computeTrainableVariableInputs(tape);
+      const varList: Variable[] = [];
+      const inputs = tape_util.computeVariableInputs(tape, varList);
 
       expect(inputs).toEqual([]);
     });
@@ -679,28 +680,8 @@ import * as tape_util from './tape_util';
         gradient: null
       }];
 
-      const inputs = tape_util.computeTrainableVariableInputs(tape);
-
-      expect(inputs).toEqual([]);
-    });
-
-    it('one variable input, not trainable', math => {
-      const trainable = false;
-      const x = variable(Scalar.new(1), trainable);
-      const y = Scalar.new(2);
-
-      const tape: Tape = [{
-        id: 0,
-        type: 'kernel',
-        name: 'node0',
-        inputAndArgs: {
-          inputs: {x},
-        },
-        output: y,
-        gradient: null
-      }];
-
-      const inputs = tape_util.computeTrainableVariableInputs(tape);
+      const varList: Variable[] = [];
+      const inputs = tape_util.computeVariableInputs(tape, varList);
 
       expect(inputs).toEqual([]);
     });
@@ -721,7 +702,7 @@ import * as tape_util from './tape_util';
       }];
 
       const varList: Variable[] = [];
-      const inputs = tape_util.computeTrainableVariableInputs(tape, varList);
+      const inputs = tape_util.computeVariableInputs(tape, varList);
 
       expect(inputs).toEqual([]);
     });
@@ -742,27 +723,7 @@ import * as tape_util from './tape_util';
       }];
 
       const varList: Variable[] = [x];
-      const inputs = tape_util.computeTrainableVariableInputs(tape, varList);
-
-      expect(inputs).toEqual([x]);
-    });
-
-    it('one variable input', math => {
-      const x = variable(Scalar.new(1));
-      const y = Scalar.new(2);
-
-      const tape: Tape = [{
-        id: 0,
-        type: 'kernel',
-        name: 'node0',
-        inputAndArgs: {
-          inputs: {x},
-        },
-        output: y,
-        gradient: null
-      }];
-
-      const inputs = tape_util.computeTrainableVariableInputs(tape);
+      const inputs = tape_util.computeVariableInputs(tape, varList);
 
       expect(inputs).toEqual([x]);
     });
@@ -797,7 +758,8 @@ import * as tape_util from './tape_util';
         }
       ];
 
-      const inputs = tape_util.computeTrainableVariableInputs(tape);
+      const varList: Variable[] = [];
+      const inputs = tape_util.computeVariableInputs(tape, varList);
 
       expect(inputs).toEqual([]);
     });
@@ -837,51 +799,10 @@ import * as tape_util from './tape_util';
         }
       ];
 
-      const inputs = tape_util.computeTrainableVariableInputs(tape);
+      const varList: Variable[] = [x1, x2];
+      const inputs = tape_util.computeVariableInputs(tape, varList);
 
       expect(inputs).toEqual([x1, x2]);
-    });
-
-    it('multiple inputs, two variables, one not trainable', math => {
-      const x1 = variable(Scalar.new(1));
-      const intermediate1 = Scalar.new(0);
-
-      const trainable = false;
-      const x2 = variable(Scalar.new(0), trainable);
-      const y = Scalar.new(2);
-
-      const notInTape = variable(Scalar.new(3));
-      // Silence the compiler, we just want to make sure that a variable not
-      // in the tape is not included in the trainable variable inputs.
-      expect(notInTape).not.toBeNull();
-
-      const tape: Tape = [
-        {
-          id: 0,
-          type: 'kernel',
-          name: 'node0',
-          inputAndArgs: {
-            inputs: {x1},
-          },
-          output: intermediate1,
-          gradient: null
-        },
-        {
-          id: 1,
-          type: 'kernel',
-          name: 'node1',
-          inputAndArgs: {
-            inputs: {intermediate1, x2},
-          },
-          output: y,
-          gradient: null
-        }
-      ];
-
-      const inputs = tape_util.computeTrainableVariableInputs(tape);
-
-      // Only x1 is trainable.
-      expect(inputs).toEqual([x1]);
     });
 
     it('multiple inputs, two variables, only one in varList', math => {
@@ -919,54 +840,12 @@ import * as tape_util from './tape_util';
         }
       ];
 
-      const inputs = tape_util.computeTrainableVariableInputs(tape, [x2]);
+      const varList: Variable[] = [x2];
+      const inputs = tape_util.computeVariableInputs(tape, varList);
 
       // Only x2 is in varList.
       expect(inputs).toEqual([x2]);
     });
-
-    it('multiple inputs, two variables, only one in varList not trainable',
-       math => {
-         const x1 = variable(Scalar.new(1));
-         const intermediate1 = Scalar.new(0);
-
-         const trainable = false;
-         const x2 = variable(Scalar.new(0), trainable);
-         const y = Scalar.new(2);
-
-         const notInTape = variable(Scalar.new(3));
-         // Silence the compiler, we just want to make sure that a variable not
-         // in the tape is not included in the trainable variable inputs.
-         expect(notInTape).not.toBeNull();
-
-         const tape: Tape = [
-           {
-             id: 0,
-             type: 'kernel',
-             name: 'node0',
-             inputAndArgs: {
-               inputs: {x1},
-             },
-             output: intermediate1,
-             gradient: null
-           },
-           {
-             id: 1,
-             type: 'kernel',
-             name: 'node1',
-             inputAndArgs: {
-               inputs: {intermediate1, x2},
-             },
-             output: y,
-             gradient: null
-           }
-         ];
-
-         const inputs = tape_util.computeTrainableVariableInputs(tape, [x2]);
-
-         // Only x2 is in varList, but is not trainable.
-         expect(inputs).toEqual([]);
-       });
   };
   test_util.describeMathCPU('tape_util.computeInputs', [tests]);
 }

--- a/src/math/backends/types/argminmax.ts
+++ b/src/math/backends/types/argminmax.ts
@@ -15,47 +15,31 @@
  * =============================================================================
  */
 
-import {NamedArrayMap} from '../../../util';
 import {NDArray} from '../../ndarray';
-// tslint:disable-next-line:max-line-length
-import {KernelInputConfig, KernelNode, TapeNodeInputGradientArrays} from '../tape_types';
+import {KernelInputConfig, KernelNode} from '../tape_types';
 
 export interface ArgMaxNode extends KernelNode {
   inputAndArgs: ArgMaxInputConfig;
   output: NDArray<'int32'>;
-  gradient:
-      (dy: NDArray<'int32'>, y: NDArray<'int32'>) => ArgMaxGradientInputArrays;
+  gradient: (dy: NDArray<'float32'>, y: NDArray<'int32'>) => {
+    x: () => NDArray<'float32'>;
+  };
 }
 
 export interface ArgMaxInputConfig extends KernelInputConfig {
-  inputs: ArgMaxInputArrays;
+  inputs: {x: NDArray;};
   args: {axes: number[];};
-}
-
-export interface ArgMaxInputArrays extends NamedArrayMap {
-  x: NDArray;
-}
-
-export interface ArgMaxGradientInputArrays extends TapeNodeInputGradientArrays {
-  x: () => NDArray;
 }
 
 export interface ArgMinNode extends KernelNode {
   inputAndArgs: ArgMinInputConfig;
   output: NDArray<'int32'>;
-  gradient:
-      (dy: NDArray<'int32'>, y: NDArray<'int32'>) => ArgMinGradientInputArrays;
+  gradient: (dy: NDArray<'float32'>, y: NDArray<'int32'>) => {
+    x: () => NDArray<'float32'>;
+  };
 }
 
 export interface ArgMinInputConfig extends KernelInputConfig {
-  inputs: ArgMinInputArrays;
+  inputs: {x: NDArray;};
   args: {axes: number[];};
-}
-
-export interface ArgMinInputArrays extends NamedArrayMap {
-  x: NDArray;
-}
-
-export interface ArgMinGradientInputArrays extends TapeNodeInputGradientArrays {
-  x: () => NDArray;
 }

--- a/src/math/backends/types/argminmax.ts
+++ b/src/math/backends/types/argminmax.ts
@@ -16,30 +16,20 @@
  */
 
 import {NDArray} from '../../ndarray';
-import {KernelInputConfig, KernelNode} from '../tape_types';
+import {KernelNode} from '../tape_types';
 
 export interface ArgMaxNode extends KernelNode {
-  inputAndArgs: ArgMaxInputConfig;
+  inputAndArgs: {inputs: {x: NDArray;}; args: {axes: number[];};};
   output: NDArray<'int32'>;
   gradient: (dy: NDArray<'float32'>, y: NDArray<'int32'>) => {
     x: () => NDArray<'float32'>;
   };
-}
-
-export interface ArgMaxInputConfig extends KernelInputConfig {
-  inputs: {x: NDArray;};
-  args: {axes: number[];};
 }
 
 export interface ArgMinNode extends KernelNode {
-  inputAndArgs: ArgMinInputConfig;
+  inputAndArgs: {inputs: {x: NDArray;}; args: {axes: number[];};};
   output: NDArray<'int32'>;
   gradient: (dy: NDArray<'float32'>, y: NDArray<'int32'>) => {
     x: () => NDArray<'float32'>;
   };
-}
-
-export interface ArgMinInputConfig extends KernelInputConfig {
-  inputs: {x: NDArray;};
-  args: {axes: number[];};
 }

--- a/src/math/backends/types/batchnorm.ts
+++ b/src/math/backends/types/batchnorm.ts
@@ -16,94 +16,71 @@
  * =============================================================================
  */
 
-import {NamedArrayMap} from '../../../util';
 import {Array1D, Array2D, Array3D, Array4D} from '../../ndarray';
-// tslint:disable-next-line:max-line-length
-import {KernelInputConfig, KernelNode, TapeNodeInputGradientArrays} from '../tape_types';
+import {KernelInputConfig, KernelNode} from '../tape_types';
 
 // 4D
 export interface BatchNorm4DNode extends KernelNode {
   inputAndArgs: BatchNorm4DInputConfig;
   output: Array4D;
-  gradient: (dy: Array4D, y: Array4D) => BatchNorm4DGradientInputArrays;
+  gradient: (dy: Array4D<'float32'>, y: Array4D) => {
+    x: () => Array4D<'float32'>;
+    mean: () => Array4D<'float32'>| Array1D<'float32'>;
+    variance: () => Array4D<'float32'>| Array1D<'float32'>;
+    scale?: () => Array4D<'float32'>| Array1D<'float32'>;
+    offset?: () => Array4D<'float32'>| Array1D<'float32'>;
+  };
 }
 
 export interface BatchNorm4DInputConfig extends KernelInputConfig {
-  inputs: BatchNorm4DInputArrays;
+  inputs: {
+    x: Array4D; mean: Array4D | Array1D; variance: Array4D | Array1D;
+    scale?: Array4D | Array1D;
+    offset?: Array4D | Array1D;
+  };
   args: {varianceEpsilon: number};
-}
-
-export interface BatchNorm4DInputArrays extends NamedArrayMap {
-  x: Array4D;
-  mean: Array4D|Array1D;
-  variance: Array4D|Array1D;
-  scale?: Array4D|Array1D;
-  offset?: Array4D|Array1D;
-}
-
-export interface BatchNorm4DGradientInputArrays extends
-    TapeNodeInputGradientArrays {
-  x: () => Array4D;
-  mean: () => Array4D | Array1D;
-  variance: () => Array4D | Array1D;
-  scale?: () => Array4D | Array1D;
-  offset?: () => Array4D | Array1D;
 }
 
 // 3D
 export interface BatchNorm3DNode extends KernelNode {
   inputAndArgs: BatchNorm3DInputConfig;
   output: Array3D;
-  gradient: (dy: Array3D, y: Array3D) => BatchNorm3DGradientInputArrays;
+  gradient: (dy: Array3D<'float32'>, y: Array3D) => {
+    x: () => Array3D<'float32'>;
+    mean: () => Array3D<'float32'>| Array1D<'float32'>;
+    variance: () => Array3D<'float32'>| Array1D<'float32'>;
+    scale?: () => Array3D<'float32'>| Array1D<'float32'>;
+    offset?: () => Array3D<'float32'>| Array1D<'float32'>;
+  };
 }
 
 export interface BatchNorm3DInputConfig extends KernelInputConfig {
-  inputs: BatchNorm3DInputArrays;
+  inputs: {
+    x: Array3D; mean: Array3D | Array1D; variance: Array3D | Array1D;
+    scale?: Array3D | Array1D;
+    offset?: Array3D | Array1D;
+  };
   args: {varianceEpsilon: number};
-}
-
-export interface BatchNorm3DInputArrays extends NamedArrayMap {
-  x: Array3D;
-  mean: Array3D|Array1D;
-  variance: Array3D|Array1D;
-  scale?: Array3D|Array1D;
-  offset?: Array3D|Array1D;
-}
-
-export interface BatchNorm3DGradientInputArrays extends
-    TapeNodeInputGradientArrays {
-  x: () => Array3D;
-  mean: () => Array3D | Array1D;
-  variance: () => Array3D | Array1D;
-  scale?: () => Array3D | Array1D;
-  offset?: () => Array3D | Array1D;
 }
 
 // 2D
 export interface BatchNorm2DNode extends KernelNode {
   inputAndArgs: BatchNorm2DInputConfig;
   output: Array2D;
-  gradient: (dy: Array2D, y: Array2D) => BatchNorm2DGradientInputArrays;
+  gradient: (dy: Array2D<'float32'>, y: Array2D) => {
+    x: () => Array2D<'float32'>;
+    mean: () => Array2D<'float32'>| Array1D<'float32'>;
+    variance: () => Array2D<'float32'>| Array1D<'float32'>;
+    scale?: () => Array2D<'float32'>| Array1D<'float32'>;
+    offset?: () => Array2D<'float32'>| Array1D<'float32'>;
+  };
 }
 
 export interface BatchNorm2DInputConfig extends KernelInputConfig {
-  inputs: BatchNorm2DInputArrays;
+  inputs: {
+    x: Array2D; mean: Array2D | Array1D; variance: Array2D | Array1D;
+    scale?: Array2D | Array1D;
+    offset?: Array2D | Array1D;
+  };
   args: {varianceEpsilon: number};
-}
-
-export interface BatchNorm2DInputArrays extends NamedArrayMap {
-  x: Array2D;
-  mean: Array2D|Array1D;
-  variance: Array2D|Array1D;
-  scale?: Array2D|Array1D;
-  offset?: Array2D|Array1D;
-}
-
-export interface BatchNorm2DGradientInputArrays extends
-    TapeNodeInputGradientArrays {
-  x: () => Array2D;
-  mean: () => Array2D | Array1D;
-  variance: () => Array2D | Array1D;
-  scale?: () => Array2D | Array1D;
-  offset?: () => Array2D | Array1D;
 }

--- a/src/math/backends/types/batchnorm.ts
+++ b/src/math/backends/types/batchnorm.ts
@@ -17,11 +17,17 @@
  */
 
 import {Array1D, Array2D, Array3D, Array4D} from '../../ndarray';
-import {KernelInputConfig, KernelNode} from '../tape_types';
+import {KernelNode} from '../tape_types';
 
-// 4D
 export interface BatchNorm4DNode extends KernelNode {
-  inputAndArgs: BatchNorm4DInputConfig;
+  inputAndArgs: {
+    inputs: {
+      x: Array4D; mean: Array4D | Array1D; variance: Array4D | Array1D;
+      scale?: Array4D | Array1D;
+      offset?: Array4D | Array1D;
+    };
+    args: {varianceEpsilon: number};
+  };
   output: Array4D;
   gradient: (dy: Array4D<'float32'>, y: Array4D) => {
     x: () => Array4D<'float32'>;
@@ -32,18 +38,15 @@ export interface BatchNorm4DNode extends KernelNode {
   };
 }
 
-export interface BatchNorm4DInputConfig extends KernelInputConfig {
-  inputs: {
-    x: Array4D; mean: Array4D | Array1D; variance: Array4D | Array1D;
-    scale?: Array4D | Array1D;
-    offset?: Array4D | Array1D;
-  };
-  args: {varianceEpsilon: number};
-}
-
-// 3D
 export interface BatchNorm3DNode extends KernelNode {
-  inputAndArgs: BatchNorm3DInputConfig;
+  inputAndArgs: {
+    inputs: {
+      x: Array3D; mean: Array3D | Array1D; variance: Array3D | Array1D;
+      scale?: Array3D | Array1D;
+      offset?: Array3D | Array1D;
+    };
+    args: {varianceEpsilon: number};
+  };
   output: Array3D;
   gradient: (dy: Array3D<'float32'>, y: Array3D) => {
     x: () => Array3D<'float32'>;
@@ -54,18 +57,15 @@ export interface BatchNorm3DNode extends KernelNode {
   };
 }
 
-export interface BatchNorm3DInputConfig extends KernelInputConfig {
-  inputs: {
-    x: Array3D; mean: Array3D | Array1D; variance: Array3D | Array1D;
-    scale?: Array3D | Array1D;
-    offset?: Array3D | Array1D;
-  };
-  args: {varianceEpsilon: number};
-}
-
-// 2D
 export interface BatchNorm2DNode extends KernelNode {
-  inputAndArgs: BatchNorm2DInputConfig;
+  inputAndArgs: {
+    inputs: {
+      x: Array2D; mean: Array2D | Array1D; variance: Array2D | Array1D;
+      scale?: Array2D | Array1D;
+      offset?: Array2D | Array1D;
+    };
+    args: {varianceEpsilon: number};
+  };
   output: Array2D;
   gradient: (dy: Array2D<'float32'>, y: Array2D) => {
     x: () => Array2D<'float32'>;
@@ -74,13 +74,4 @@ export interface BatchNorm2DNode extends KernelNode {
     scale?: () => Array2D<'float32'>| Array1D<'float32'>;
     offset?: () => Array2D<'float32'>| Array1D<'float32'>;
   };
-}
-
-export interface BatchNorm2DInputConfig extends KernelInputConfig {
-  inputs: {
-    x: Array2D; mean: Array2D | Array1D; variance: Array2D | Array1D;
-    scale?: Array2D | Array1D;
-    offset?: Array2D | Array1D;
-  };
-  args: {varianceEpsilon: number};
 }

--- a/src/math/backends/types/binary.ts
+++ b/src/math/backends/types/binary.ts
@@ -16,17 +16,13 @@
  */
 
 import {NDArray} from '../../ndarray';
-import {KernelInputConfig, KernelNode} from '../tape_types';
+import {KernelNode} from '../tape_types';
 
 export interface BinaryNode extends KernelNode {
-  inputAndArgs: BinaryInputConfig;
+  inputAndArgs: {inputs: {a: NDArray; b: NDArray;};};
   output: NDArray;
   gradient: (dy: NDArray<'float32'>, y: NDArray) => {
     a: () => NDArray<'float32'>;
     b: () => NDArray<'float32'>;
   };
-}
-
-export interface BinaryInputConfig extends KernelInputConfig {
-  inputs: {a: NDArray; b: NDArray;};
 }

--- a/src/math/backends/types/binary.ts
+++ b/src/math/backends/types/binary.ts
@@ -15,27 +15,18 @@
  * =============================================================================
  */
 
-import {NamedArrayMap} from '../../../util';
 import {NDArray} from '../../ndarray';
-// tslint:disable-next-line:max-line-length
-import {KernelInputConfig, KernelNode, TapeNodeInputGradientArrays} from '../tape_types';
+import {KernelInputConfig, KernelNode} from '../tape_types';
 
 export interface BinaryNode extends KernelNode {
   inputAndArgs: BinaryInputConfig;
   output: NDArray;
-  gradient: (dy: NDArray, y: NDArray) => BinaryInputGradientArrays;
+  gradient: (dy: NDArray<'float32'>, y: NDArray) => {
+    a: () => NDArray<'float32'>;
+    b: () => NDArray<'float32'>;
+  };
 }
 
 export interface BinaryInputConfig extends KernelInputConfig {
-  inputs: BinaryInputArrays;
-}
-
-export interface BinaryInputArrays extends NamedArrayMap {
-  a: NDArray;
-  b: NDArray;
-}
-
-export interface BinaryInputGradientArrays extends TapeNodeInputGradientArrays {
-  a: () => NDArray;
-  b: () => NDArray;
+  inputs: {a: NDArray; b: NDArray;};
 }

--- a/src/math/backends/types/cast.ts
+++ b/src/math/backends/types/cast.ts
@@ -21,8 +21,8 @@ import {KernelInputConfig, KernelNode} from '../tape_types';
 export interface CastNode extends KernelNode {
   inputAndArgs: CastInputConfig;
   output: NDArray;
-  gradient: (dy: NDArray, y: NDArray) => {
-    x: () => NDArray
+  gradient: (dy: NDArray<'float32'>, y: NDArray) => {
+    x: () => NDArray<'float32'>
   };
 }
 

--- a/src/math/backends/types/cast.ts
+++ b/src/math/backends/types/cast.ts
@@ -16,17 +16,12 @@
  */
 
 import {DataType, NDArray} from '../../ndarray';
-import {KernelInputConfig, KernelNode} from '../tape_types';
+import {KernelNode} from '../tape_types';
 
 export interface CastNode extends KernelNode {
-  inputAndArgs: CastInputConfig;
+  inputAndArgs: {inputs: {x: NDArray}; args: {newDType: DataType};};
   output: NDArray;
   gradient: (dy: NDArray<'float32'>, y: NDArray) => {
     x: () => NDArray<'float32'>
   };
-}
-
-export interface CastInputConfig extends KernelInputConfig {
-  inputs: {x: NDArray};
-  args: {newDType: DataType};
 }

--- a/src/math/backends/types/concat.ts
+++ b/src/math/backends/types/concat.ts
@@ -16,11 +16,10 @@
  */
 
 import {Array1D, Array2D, Array3D, Array4D} from '../../ndarray';
-import {KernelInputConfig, KernelNode} from '../tape_types';
+import {KernelNode} from '../tape_types';
 
-// 1D
 export interface Concat1DNode extends KernelNode {
-  inputAndArgs: Concat1DInputConfig;
+  inputAndArgs: {inputs: {a: Array1D; b: Array1D;};};
   output: Array1D;
   gradient: (dy: Array1D<'float32'>, y: Array1D) => {
     a: () => Array1D<'float32'>;
@@ -28,13 +27,8 @@ export interface Concat1DNode extends KernelNode {
   };
 }
 
-export interface Concat1DInputConfig extends KernelInputConfig {
-  inputs: {a: Array1D; b: Array1D;};
-}
-
-// 2D
 export interface Concat2DNode extends KernelNode {
-  inputAndArgs: Concat2DInputConfig;
+  inputAndArgs: {inputs: {a: Array2D; b: Array2D;}; args: {axis: number};};
   output: Array2D;
   gradient: (dy: Array2D<'float32'>, y: Array2D) => {
     a: () => Array2D<'float32'>;
@@ -42,14 +36,8 @@ export interface Concat2DNode extends KernelNode {
   };
 }
 
-export interface Concat2DInputConfig extends KernelInputConfig {
-  inputs: {a: Array2D; b: Array2D;};
-  args: {axis: number};
-}
-
-// 3D
 export interface Concat3DNode extends KernelNode {
-  inputAndArgs: Concat3DInputConfig;
+  inputAndArgs: {inputs: {a: Array3D; b: Array3D;}; args: {axis: number};};
   output: Array3D;
   gradient: (dy: Array3D<'float32'>, y: Array3D) => {
     a: () => Array3D<'float32'>;
@@ -57,22 +45,11 @@ export interface Concat3DNode extends KernelNode {
   };
 }
 
-export interface Concat3DInputConfig extends KernelInputConfig {
-  inputs: {a: Array3D; b: Array3D;};
-  args: {axis: number};
-}
-
-// 4D
 export interface Concat4DNode extends KernelNode {
-  inputAndArgs: Concat4DInputConfig;
+  inputAndArgs: {inputs: {a: Array4D; b: Array4D;}; args: {axis: number};};
   output: Array4D;
   gradient: (dy: Array4D<'float32'>, y: Array4D) => {
     a: () => Array4D<'float32'>;
     b: () => Array4D<'float32'>;
   };
-}
-
-export interface Concat4DInputConfig extends KernelInputConfig {
-  inputs: {a: Array4D; b: Array4D;};
-  args: {axis: number};
 }

--- a/src/math/backends/types/concat.ts
+++ b/src/math/backends/types/concat.ts
@@ -15,94 +15,64 @@
  * =============================================================================
  */
 
-import {NamedArrayMap} from '../../../util';
 import {Array1D, Array2D, Array3D, Array4D} from '../../ndarray';
-// tslint:disable-next-line:max-line-length
-import {KernelInputConfig, KernelNode, TapeNodeInputGradientArrays} from '../tape_types';
+import {KernelInputConfig, KernelNode} from '../tape_types';
 
 // 1D
 export interface Concat1DNode extends KernelNode {
   inputAndArgs: Concat1DInputConfig;
   output: Array1D;
-  gradient: (dy: Array1D, y: Array1D) => Concat1DGradientArrays;
+  gradient: (dy: Array1D<'float32'>, y: Array1D) => {
+    a: () => Array1D<'float32'>;
+    b: () => Array1D<'float32'>;
+  };
 }
 
 export interface Concat1DInputConfig extends KernelInputConfig {
-  inputs: Concat1DInputArrays;
-}
-
-export interface Concat1DInputArrays extends NamedArrayMap {
-  a: Array1D;
-  b: Array1D;
-}
-
-export interface Concat1DGradientArrays extends TapeNodeInputGradientArrays {
-  a: () => Array1D;
-  b: () => Array1D;
+  inputs: {a: Array1D; b: Array1D;};
 }
 
 // 2D
 export interface Concat2DNode extends KernelNode {
   inputAndArgs: Concat2DInputConfig;
   output: Array2D;
-  gradient: (dy: Array2D, y: Array2D) => Concat2DGradientArrays;
+  gradient: (dy: Array2D<'float32'>, y: Array2D) => {
+    a: () => Array2D<'float32'>;
+    b: () => Array2D<'float32'>;
+  };
 }
 
 export interface Concat2DInputConfig extends KernelInputConfig {
-  inputs: Concat2DInputArrays;
+  inputs: {a: Array2D; b: Array2D;};
   args: {axis: number};
-}
-
-export interface Concat2DInputArrays extends NamedArrayMap {
-  a: Array2D;
-  b: Array2D;
-}
-
-export interface Concat2DGradientArrays extends TapeNodeInputGradientArrays {
-  a: () => Array2D;
-  b: () => Array2D;
 }
 
 // 3D
 export interface Concat3DNode extends KernelNode {
   inputAndArgs: Concat3DInputConfig;
   output: Array3D;
-  gradient: (dy: Array3D, y: Array3D) => Concat3DGradientArrays;
+  gradient: (dy: Array3D<'float32'>, y: Array3D) => {
+    a: () => Array3D<'float32'>;
+    b: () => Array3D<'float32'>;
+  };
 }
 
 export interface Concat3DInputConfig extends KernelInputConfig {
-  inputs: Concat3DInputArrays;
+  inputs: {a: Array3D; b: Array3D;};
   args: {axis: number};
-}
-
-export interface Concat3DInputArrays extends NamedArrayMap {
-  a: Array3D;
-  b: Array3D;
-}
-
-export interface Concat3DGradientArrays extends TapeNodeInputGradientArrays {
-  a: () => Array3D;
-  b: () => Array3D;
 }
 
 // 4D
 export interface Concat4DNode extends KernelNode {
   inputAndArgs: Concat4DInputConfig;
   output: Array4D;
-  gradient: (dy: Array4D, y: Array4D) => Concat4DGradientArrays;
+  gradient: (dy: Array4D<'float32'>, y: Array4D) => {
+    a: () => Array4D<'float32'>;
+    b: () => Array4D<'float32'>;
+  };
 }
 
 export interface Concat4DInputConfig extends KernelInputConfig {
-  inputs: Concat4DInputArrays;
+  inputs: {a: Array4D; b: Array4D;};
   args: {axis: number};
-}
-
-export interface Concat4DInputArrays extends NamedArrayMap {
-  a: Array4D;
-  b: Array4D;
-}
-
-export interface Concat4DGradientArrays extends TapeNodeInputGradientArrays {
-  a: () => Array4D;
-  b: () => Array4D;
 }

--- a/src/math/backends/types/conv.ts
+++ b/src/math/backends/types/conv.ts
@@ -17,11 +17,13 @@
 
 import {Conv2DInfo} from '../../conv_util';
 import {Array1D, Array4D} from '../../ndarray';
-import {KernelInputConfig, KernelNode} from '../tape_types';
+import {KernelNode} from '../tape_types';
 
-// Conv2D
 export interface Conv2DNode extends KernelNode {
-  inputAndArgs: Conv2DInputConfig;
+  inputAndArgs: {
+    inputs: {x: Array4D; filter: Array4D; bias?: Array1D;};
+    args: {convInfo: Conv2DInfo;};
+  };
   output: Array4D;
   gradient: (dy: Array4D<'float32'>, y: Array4D) => {
     x: () => Array4D<'float32'>;
@@ -30,14 +32,11 @@ export interface Conv2DNode extends KernelNode {
   };
 }
 
-export interface Conv2DInputConfig extends KernelInputConfig {
-  inputs: {x: Array4D; filter: Array4D; bias?: Array1D;};
-  args: {convInfo: Conv2DInfo;};
-}
-
-// Conv2DDerInput
 export interface Conv2DDerInputNode extends KernelNode {
-  inputAndArgs: Conv2DDerInputInputConfig;
+  inputAndArgs: {
+    inputs: {dy: Array4D<'float32'>; filter: Array4D;};
+    args: {convInfo: Conv2DInfo;};
+  };
   output: Array4D<'float32'>;
   gradient: (dy: Array4D<'float32'>, y: Array4D) => {
     dy: () => Array4D<'float32'>;
@@ -45,14 +44,11 @@ export interface Conv2DDerInputNode extends KernelNode {
   };
 }
 
-export interface Conv2DDerInputInputConfig extends KernelInputConfig {
-  inputs: {dy: Array4D<'float32'>; filter: Array4D;};
-  args: {convInfo: Conv2DInfo;};
-}
-
-// Conv2DDerFilter
 export interface Conv2DDerFilterNode extends KernelNode {
-  inputAndArgs: Conv2DDerFilterInputConfig;
+  inputAndArgs: {
+    inputs: {x: Array4D; dy: Array4D<'float32'>;};
+    args: {convInfo: Conv2DInfo;};
+  };
   output: Array4D<'float32'>;
   gradient: (dy: Array4D<'float32'>, y: Array4D<'float32'>) => {
     x: () => Array4D<'float32'>;
@@ -60,35 +56,20 @@ export interface Conv2DDerFilterNode extends KernelNode {
   };
 }
 
-export interface Conv2DDerFilterInputConfig extends KernelInputConfig {
-  inputs: {x: Array4D; dy: Array4D<'float32'>;};
-  args: {convInfo: Conv2DInfo;};
-}
-
-// Conv2DDerBias
 export interface Conv2DDerBiasNode extends KernelNode {
-  inputAndArgs: Conv2DDerBiasInputConfig;
+  inputAndArgs: {inputs: {dy: Array4D;};};
   output: Array1D<'float32'>;
   gradient: (dy: Array1D<'float32'>, y: Array1D<'float32'>) => {
     dy: () => Array4D<'float32'>;
   };
 }
 
-export interface Conv2DDerBiasInputConfig extends KernelInputConfig {
-  inputs: {dy: Array4D;};
-}
-
-// DepthwiseConv2D
 export interface DepthwiseConv2DNode extends KernelNode {
-  inputAndArgs: DepthwiseConv2DInputConfig;
+  inputAndArgs:
+      {inputs: {x: Array4D; filter: Array4D;}; args: {convInfo: Conv2DInfo;};};
   output: Array4D;
   gradient: (dy: Array4D<'float32'>, y: Array4D) => {
     x: () => Array4D<'float32'>;
     filter: () => Array4D<'float32'>;
   };
-}
-
-export interface DepthwiseConv2DInputConfig extends KernelInputConfig {
-  inputs: {x: Array4D; filter: Array4D;};
-  args: {convInfo: Conv2DInfo;};
 }

--- a/src/math/backends/types/conv.ts
+++ b/src/math/backends/types/conv.ts
@@ -15,119 +15,80 @@
  * =============================================================================
  */
 
-import {NamedArrayMap} from '../../../util';
 import {Conv2DInfo} from '../../conv_util';
 import {Array1D, Array4D} from '../../ndarray';
-// tslint:disable-next-line:max-line-length
-import {KernelInputConfig, KernelNode, TapeNodeInputGradientArrays} from '../tape_types';
+import {KernelInputConfig, KernelNode} from '../tape_types';
 
 // Conv2D
 export interface Conv2DNode extends KernelNode {
   inputAndArgs: Conv2DInputConfig;
   output: Array4D;
-  gradient: (dy: Array4D, y: Array4D) => Conv2DGradientInputArrays;
+  gradient: (dy: Array4D<'float32'>, y: Array4D) => {
+    x: () => Array4D<'float32'>;
+    filter: () => Array4D<'float32'>;
+    bias?: () => Array1D<'float32'>;
+  };
 }
 
 export interface Conv2DInputConfig extends KernelInputConfig {
-  inputs: Conv2DInputArrays;
+  inputs: {x: Array4D; filter: Array4D; bias?: Array1D;};
   args: {convInfo: Conv2DInfo;};
-}
-
-export interface Conv2DInputArrays extends NamedArrayMap {
-  x: Array4D;
-  filter: Array4D;
-  bias?: Array1D;
-}
-
-export interface Conv2DGradientInputArrays extends TapeNodeInputGradientArrays {
-  x: () => Array4D;
-  filter: () => Array4D;
-  bias?: () => Array1D;
 }
 
 // Conv2DDerInput
 export interface Conv2DDerInputNode extends KernelNode {
   inputAndArgs: Conv2DDerInputInputConfig;
-  output: Array4D;
-  gradient: (dy: Array4D, y: Array4D) => Conv2DDerInputGradientInputArrays;
+  output: Array4D<'float32'>;
+  gradient: (dy: Array4D<'float32'>, y: Array4D) => {
+    dy: () => Array4D<'float32'>;
+    filter: () => Array4D<'float32'>;
+  };
 }
 
 export interface Conv2DDerInputInputConfig extends KernelInputConfig {
-  inputs: Conv2DDerInputInputArrays;
+  inputs: {dy: Array4D<'float32'>; filter: Array4D;};
   args: {convInfo: Conv2DInfo;};
-}
-
-export interface Conv2DDerInputInputArrays extends NamedArrayMap {
-  dy: Array4D;
-  filter: Array4D;
-}
-
-export interface Conv2DDerInputGradientInputArrays extends
-    TapeNodeInputGradientArrays {
-  dy: () => Array4D;
-  filter: () => Array4D;
 }
 
 // Conv2DDerFilter
 export interface Conv2DDerFilterNode extends KernelNode {
   inputAndArgs: Conv2DDerFilterInputConfig;
-  output: Array4D;
-  gradient: (dy: Array4D, y: Array4D) => Conv2DDerFilterGradientInputArrays;
+  output: Array4D<'float32'>;
+  gradient: (dy: Array4D<'float32'>, y: Array4D<'float32'>) => {
+    x: () => Array4D<'float32'>;
+    dy: () => Array4D<'float32'>;
+  };
 }
 
 export interface Conv2DDerFilterInputConfig extends KernelInputConfig {
-  inputs: Conv2DDerFilterInputArrays;
+  inputs: {x: Array4D; dy: Array4D<'float32'>;};
   args: {convInfo: Conv2DInfo;};
-}
-
-export interface Conv2DDerFilterInputArrays extends NamedArrayMap {
-  x: Array4D;
-  dy: Array4D;
-}
-
-export interface Conv2DDerFilterGradientInputArrays extends
-    TapeNodeInputGradientArrays {
-  x: () => Array4D;
-  dy: () => Array4D;
 }
 
 // Conv2DDerBias
 export interface Conv2DDerBiasNode extends KernelNode {
   inputAndArgs: Conv2DDerBiasInputConfig;
-  output: Array1D;
-  gradient: (dy: Array1D, y: Array1D) => Conv2DDerBiasGradientInputArrays;
+  output: Array1D<'float32'>;
+  gradient: (dy: Array1D<'float32'>, y: Array1D<'float32'>) => {
+    dy: () => Array4D<'float32'>;
+  };
 }
 
 export interface Conv2DDerBiasInputConfig extends KernelInputConfig {
-  inputs: Conv2DDerBiasInputArrays;
-}
-
-export interface Conv2DDerBiasInputArrays extends NamedArrayMap { dy: Array4D; }
-
-export interface Conv2DDerBiasGradientInputArrays extends
-    TapeNodeInputGradientArrays {
-  dy: () => Array4D;
+  inputs: {dy: Array4D;};
 }
 
 // DepthwiseConv2D
 export interface DepthwiseConv2DNode extends KernelNode {
   inputAndArgs: DepthwiseConv2DInputConfig;
   output: Array4D;
-  gradient: (dy: Array4D, y: Array4D) => DepthwiseConv2DGradientInputArrays;
+  gradient: (dy: Array4D<'float32'>, y: Array4D) => {
+    x: () => Array4D<'float32'>;
+    filter: () => Array4D<'float32'>;
+  };
 }
 
 export interface DepthwiseConv2DInputConfig extends KernelInputConfig {
-  inputs: DepthwiseConv2DInputArrays;
+  inputs: {x: Array4D; filter: Array4D;};
   args: {convInfo: Conv2DInfo;};
-}
-
-export interface DepthwiseConv2DInputArrays extends NamedArrayMap {
-  x: Array4D;
-  filter: Array4D;
-}
-
-export interface DepthwiseConv2DGradientInputArrays extends
-    TapeNodeInputGradientArrays {
-  x: () => Array4D;
-  filter: () => Array4D;
 }

--- a/src/math/backends/types/gather.ts
+++ b/src/math/backends/types/gather.ts
@@ -16,21 +16,16 @@
  */
 
 import {Array1D, DataType, NDArray, Rank} from '../../ndarray';
-import {KernelInputConfig, KernelNode} from '../tape_types';
+import {KernelNode} from '../tape_types';
 
 export interface GatherNode<D extends DataType, R extends Rank, T extends
                                 NDArray<D, R> = NDArray<D, R>> extends
     KernelNode {
-  inputAndArgs: GatherInputConfig<T>;
+  inputAndArgs:
+      {inputs: {x: T; indices: Array1D<'int32'>;}; args: {axis: number};};
   output: T;
   gradient: (dy: NDArray<'float32', R>, y: T) => {
     x: () => NDArray<'float32', R>;
     indices: () => Array1D<'float32'>;
   };
-}
-
-export interface GatherInputConfig<T extends NDArray> extends
-    KernelInputConfig {
-  inputs: {x: T; indices: Array1D<'int32'>;};
-  args: {axis: number};
 }

--- a/src/math/backends/types/gather.ts
+++ b/src/math/backends/types/gather.ts
@@ -19,7 +19,8 @@ import {Array1D, DataType, NDArray, Rank} from '../../ndarray';
 import {KernelInputConfig, KernelNode} from '../tape_types';
 
 export interface GatherNode<D extends DataType, R extends Rank, T extends
-                                NDArray<D, R>> extends KernelNode {
+                                NDArray<D, R> = NDArray<D, R>> extends
+    KernelNode {
   inputAndArgs: GatherInputConfig<T>;
   output: T;
   gradient: (dy: NDArray<'float32', R>, y: T) => {

--- a/src/math/backends/types/logical.ts
+++ b/src/math/backends/types/logical.ts
@@ -15,41 +15,33 @@
  * =============================================================================
  */
 
-import {NamedArrayMap} from '../../../util';
 import {NDArray} from '../../ndarray';
-// tslint:disable-next-line:max-line-length
-import {KernelInputConfig, KernelNode, TapeNodeInputGradientArrays} from '../tape_types';
-
-export interface DualInputArrays extends NamedArrayMap {
-  a: NDArray;
-  b: NDArray;
-}
-
-export interface DualGradientInputArrays extends TapeNodeInputGradientArrays {
-  a: () => NDArray;
-  b: () => NDArray;
-}
+import {KernelInputConfig, KernelNode} from '../tape_types';
 
 // Equal/NotEqual/LessEqual/Greater/GreaterEqual
 export interface EqualNode extends KernelNode {
   inputAndArgs: EqualInputConfig;
   output: NDArray<'bool'>;
-  gradient:
-      (dy: NDArray<'bool'>, y: NDArray<'bool'>) => DualGradientInputArrays;
+  gradient: (dy: NDArray<'float32'>, y: NDArray<'bool'>) => {
+    a: () => NDArray<'float32'>;
+    b: () => NDArray<'float32'>;
+  };
 }
 
 export interface EqualInputConfig extends KernelInputConfig {
-  inputs: DualInputArrays;
+  inputs: {a: NDArray; b: NDArray;};
 }
 
 // LogicalOr
 export interface LogicalOrNode extends KernelNode {
   inputAndArgs: LogicalOrInputConfig;
   output: NDArray<'bool'>;
-  gradient:
-      (dy: NDArray<'bool'>, y: NDArray<'bool'>) => DualGradientInputArrays;
+  gradient: (dy: NDArray<'float32'>, y: NDArray<'bool'>) => {
+    a: () => NDArray<'float32'>;
+    b: () => NDArray<'float32'>;
+  };
 }
 
 export interface LogicalOrInputConfig extends KernelInputConfig {
-  inputs: DualInputArrays;
+  inputs: {a: NDArray; b: NDArray;};
 }

--- a/src/math/backends/types/logical.ts
+++ b/src/math/backends/types/logical.ts
@@ -16,25 +16,21 @@
  */
 
 import {DataType, NDArray} from '../../ndarray';
-import {KernelInputConfig, KernelNode} from '../tape_types';
+import {KernelNode} from '../tape_types';
 
 // Equal/NotEqual/Less/LessEqual/Greater/GreaterEqual
 export interface EqualNode extends KernelNode {
-  inputAndArgs: EqualInputConfig;
+  inputAndArgs: {inputs: {a: NDArray; b: NDArray;};};
   output: NDArray<'bool'>;
   gradient: (dy: NDArray<'float32'>, y: NDArray<'bool'>) => {
     a: () => NDArray<'float32'>;
     b: () => NDArray<'float32'>;
   };
-}
-
-export interface EqualInputConfig extends KernelInputConfig {
-  inputs: {a: NDArray; b: NDArray;};
 }
 
 // LogicalAnd/LogicalOr
 export interface LogicalNode extends KernelNode {
-  inputAndArgs: LogicalInputConfig;
+  inputAndArgs: {inputs: {a: NDArray; b: NDArray;};};
   output: NDArray<'bool'>;
   gradient: (dy: NDArray<'float32'>, y: NDArray<'bool'>) => {
     a: () => NDArray<'float32'>;
@@ -42,22 +38,16 @@ export interface LogicalNode extends KernelNode {
   };
 }
 
-export interface LogicalInputConfig extends KernelInputConfig {
-  inputs: {a: NDArray; b: NDArray;};
-}
-
 // Where
 export interface WhereNode extends KernelNode {
-  inputAndArgs: WhereInputConfig;
+  inputAndArgs: {
+    inputs: {condition: NDArray; a: NDArray; b: NDArray;};
+    args: {dtype: DataType};
+  };
   output: NDArray;
   gradient: (dy: NDArray<'float32'>, y: NDArray) => {
     condition: () => NDArray<'float32'>;
     a: () => NDArray<'float32'>;
     b: () => NDArray<'float32'>;
   };
-}
-
-export interface WhereInputConfig extends KernelInputConfig {
-  inputs: {condition: NDArray; a: NDArray; b: NDArray;};
-  args: {dtype: DataType};
 }

--- a/src/math/backends/types/lrn.ts
+++ b/src/math/backends/types/lrn.ts
@@ -17,7 +17,7 @@
  */
 
 import {Array4D} from '../../ndarray';
-import {KernelInputConfig, KernelNode} from '../tape_types';
+import {KernelNode} from '../tape_types';
 
 // 4D
 export interface LRN4DNode extends KernelNode {

--- a/src/math/backends/types/lrn.ts
+++ b/src/math/backends/types/lrn.ts
@@ -16,20 +16,20 @@
  * =============================================================================
  */
 
-import {NamedArrayMap} from '../../../util';
 import {Array4D} from '../../ndarray';
-// tslint:disable-next-line:max-line-length
-import {KernelInputConfig, KernelNode, TapeNodeInputGradientArrays} from '../tape_types';
+import {KernelInputConfig, KernelNode} from '../tape_types';
 
 // 4D
 export interface LRN4DNode extends KernelNode {
   inputAndArgs: LRN4DInputConfig;
   output: Array4D;
-  gradient: (dy: Array4D, y: Array4D) => LRN4DGradientInputArrays;
+  gradient: (dy: Array4D<'float32'>, y: Array4D) => {
+    x: () => Array4D<'float32'>;
+  };
 }
 
 export interface LRN4DInputConfig extends KernelInputConfig {
-  inputs: LRN4DInputArrays;
+  inputs: {x: Array4D;};
   args: {
     radius: number,
     bias: number,
@@ -37,12 +37,4 @@ export interface LRN4DInputConfig extends KernelInputConfig {
     beta: number,
     normRegion: 'acrossChannels'|'withinChannel'
   };
-}
-
-export interface LRN4DInputArrays extends NamedArrayMap {
-  x: Array4D;
-}
-
-export interface LRN4DGradientInputArrays extends TapeNodeInputGradientArrays {
-  x: () => Array4D;
 }

--- a/src/math/backends/types/lrn.ts
+++ b/src/math/backends/types/lrn.ts
@@ -21,20 +21,17 @@ import {KernelInputConfig, KernelNode} from '../tape_types';
 
 // 4D
 export interface LRN4DNode extends KernelNode {
-  inputAndArgs: LRN4DInputConfig;
+  inputAndArgs: {
+    inputs: {x: Array4D;}; args: {
+      radius: number,
+      bias: number,
+      alpha: number,
+      beta: number,
+      normRegion: 'acrossChannels'|'withinChannel'
+    };
+  };
   output: Array4D;
   gradient: (dy: Array4D<'float32'>, y: Array4D) => {
     x: () => Array4D<'float32'>;
-  };
-}
-
-export interface LRN4DInputConfig extends KernelInputConfig {
-  inputs: {x: Array4D;};
-  args: {
-    radius: number,
-    bias: number,
-    alpha: number,
-    beta: number,
-    normRegion: 'acrossChannels'|'withinChannel'
   };
 }

--- a/src/math/backends/types/matmul.ts
+++ b/src/math/backends/types/matmul.ts
@@ -16,20 +16,18 @@
  */
 
 import {Array2D} from '../../ndarray';
-import {KernelInputConfig, KernelNode} from '../tape_types';
+import {KernelNode} from '../tape_types';
 
 export interface MatMulNode extends KernelNode {
-  inputAndArgs: MatMulInputConfig;
+  inputAndArgs: {
+    inputs: {a: Array2D; b: Array2D;};
+    args: {aOrientation: MatrixOrientation; bOrientation: MatrixOrientation};
+  };
   output: Array2D;
   gradient: (dy: Array2D<'float32'>, y: Array2D) => {
     a: () => Array2D<'float32'>;
     b: () => Array2D<'float32'>;
   };
-}
-
-export interface MatMulInputConfig extends KernelInputConfig {
-  inputs: {a: Array2D; b: Array2D;};
-  args: {aOrientation: MatrixOrientation; bOrientation: MatrixOrientation};
 }
 
 export enum MatrixOrientation {

--- a/src/math/backends/types/matmul.ts
+++ b/src/math/backends/types/matmul.ts
@@ -15,30 +15,21 @@
  * =============================================================================
  */
 
-import {NamedArrayMap} from '../../../util';
 import {Array2D} from '../../ndarray';
-// tslint:disable-next-line:max-line-length
-import {KernelInputConfig, KernelNode, TapeNodeInputGradientArrays} from '../tape_types';
+import {KernelInputConfig, KernelNode} from '../tape_types';
 
 export interface MatMulNode extends KernelNode {
   inputAndArgs: MatMulInputConfig;
   output: Array2D;
-  gradient: (dy: Array2D, y: Array2D) => MatMulGradientInputArrays;
+  gradient: (dy: Array2D<'float32'>, y: Array2D) => {
+    a: () => Array2D<'float32'>;
+    b: () => Array2D<'float32'>;
+  };
 }
 
 export interface MatMulInputConfig extends KernelInputConfig {
-  inputs: MatMulInputArrays;
+  inputs: {a: Array2D; b: Array2D;};
   args: {aOrientation: MatrixOrientation; bOrientation: MatrixOrientation};
-}
-
-export interface MatMulInputArrays extends NamedArrayMap {
-  a: Array2D;
-  b: Array2D;
-}
-
-export interface MatMulGradientInputArrays extends TapeNodeInputGradientArrays {
-  a: () => Array2D;
-  b: () => Array2D;
 }
 
 export enum MatrixOrientation {

--- a/src/math/backends/types/minmax.ts
+++ b/src/math/backends/types/minmax.ts
@@ -15,24 +15,28 @@
  * =============================================================================
  */
 
-import {NamedArrayMap} from '../../../util';
 import {DataType, NDArray} from '../../ndarray';
-// tslint:disable-next-line:max-line-length
-import {KernelInputConfig, KernelNode, TapeNodeInputGradientArrays} from '../tape_types';
+import {KernelInputConfig, KernelNode} from '../tape_types';
 
 // Reduction min.
 export interface MinNode<D extends DataType> extends KernelNode {
   inputAndArgs: MinInputConfig<D>;
   output: NDArray<D>;
-  gradient: (dy: NDArray<D>, y: NDArray<D>) => MinGradientInputArrays<D>;
+  gradient: (dy: NDArray<'float32'>, y: NDArray<D>) => {
+    x: () => NDArray<'float32'>;
+  };
+}
+
+export interface MinInputConfig<D extends DataType> extends KernelInputConfig {
+  inputs: {x: NDArray<D>;};
 }
 
 // Element-wise min.
 export interface MinimumNode<D extends DataType> extends KernelNode {
   inputAndArgs: MinimumInputConfig<D>;
   output: NDArray<D>;
-  gradient: (dy: NDArray<D>, y: NDArray<D>) => {
-    a: () => NDArray<D>, b: () => NDArray<D>
+  gradient: (dy: NDArray<'float32'>, y: NDArray<D>) => {
+    a: () => NDArray<'float32'>, b: () => NDArray<'float32'>
   };
 }
 
@@ -41,49 +45,29 @@ export interface MinimumInputConfig<D extends DataType> extends
   inputs: {a: NDArray<D>, b: NDArray<D>};
 }
 
-export interface MinInputConfig<D extends DataType> extends KernelInputConfig {
-  inputs: MinInputArrays<D>;
-}
-
-export interface MinInputArrays<D extends DataType> extends NamedArrayMap {
-  x: NDArray<D>;
-}
-
-export interface MinGradientInputArrays<D extends DataType> extends
-    TapeNodeInputGradientArrays {
-  x: () => NDArray<D>;
-}
-
 // Reduction Max
 export interface MaxNode<D extends DataType> extends KernelNode {
   inputAndArgs: MaxInputConfig<D>;
   output: NDArray<D>;
-  gradient: (dy: NDArray<D>, y: NDArray<D>) => MaxGradientInputArrays<D>;
+  gradient: (dy: NDArray<'float32'>, y: NDArray<D>) => {
+    x: () => NDArray<'float32'>;
+  };
+}
+
+export interface MaxInputConfig<D extends DataType> extends KernelInputConfig {
+  inputs: {x: NDArray<D>;};
 }
 
 // Element-wise max.
 export interface MaximumNode<D extends DataType> extends KernelNode {
   inputAndArgs: MaximumInputConfig<D>;
   output: NDArray<D>;
-  gradient: (dy: NDArray<D>, y: NDArray<D>) => {
-    a: () => NDArray<D>, b: () => NDArray<D>
+  gradient: (dy: NDArray<'float32'>, y: NDArray<D>) => {
+    a: () => NDArray<'float32'>, b: () => NDArray<'float32'>
   };
 }
 
 export interface MaximumInputConfig<D extends DataType> extends
     KernelInputConfig {
   inputs: {a: NDArray<D>, b: NDArray<D>};
-}
-
-export interface MaxInputConfig<D extends DataType> extends KernelInputConfig {
-  inputs: MaxInputArrays<D>;
-}
-
-export interface MaxInputArrays<D extends DataType> extends NamedArrayMap {
-  x: NDArray<D>;
-}
-
-export interface MaxGradientInputArrays<D extends DataType> extends
-    TapeNodeInputGradientArrays {
-  x: () => NDArray<D>;
 }

--- a/src/math/backends/types/minmax.ts
+++ b/src/math/backends/types/minmax.ts
@@ -20,7 +20,7 @@ import {KernelNode} from '../tape_types';
 
 // Reduction min.
 export interface MinNode<D extends DataType> extends KernelNode {
-  inputAndArgs: {inputs: {x: NDArray<D>;};};
+  inputAndArgs: {inputs: {x: NDArray<D>;}; args: {axes: number[]}};
   output: NDArray<D>;
   gradient: (dy: NDArray<'float32'>, y: NDArray<D>) => {
     x: () => NDArray<'float32'>;
@@ -38,7 +38,7 @@ export interface MinimumNode<D extends DataType> extends KernelNode {
 
 // Reduction Max
 export interface MaxNode<D extends DataType> extends KernelNode {
-  inputAndArgs: {inputs: {x: NDArray<D>;};};
+  inputAndArgs: {inputs: {x: NDArray<D>;}; args: {axes: number[]}};
   output: NDArray<D>;
   gradient: (dy: NDArray<'float32'>, y: NDArray<D>) => {
     x: () => NDArray<'float32'>;

--- a/src/math/backends/types/minmax.ts
+++ b/src/math/backends/types/minmax.ts
@@ -16,58 +16,40 @@
  */
 
 import {DataType, NDArray} from '../../ndarray';
-import {KernelInputConfig, KernelNode} from '../tape_types';
+import {KernelNode} from '../tape_types';
 
 // Reduction min.
 export interface MinNode<D extends DataType> extends KernelNode {
-  inputAndArgs: MinInputConfig<D>;
+  inputAndArgs: {inputs: {x: NDArray<D>;};};
   output: NDArray<D>;
   gradient: (dy: NDArray<'float32'>, y: NDArray<D>) => {
     x: () => NDArray<'float32'>;
   };
-}
-
-export interface MinInputConfig<D extends DataType> extends KernelInputConfig {
-  inputs: {x: NDArray<D>;};
 }
 
 // Element-wise min.
 export interface MinimumNode<D extends DataType> extends KernelNode {
-  inputAndArgs: MinimumInputConfig<D>;
+  inputAndArgs: {inputs: {a: NDArray<D>, b: NDArray<D>};};
   output: NDArray<D>;
   gradient: (dy: NDArray<'float32'>, y: NDArray<D>) => {
     a: () => NDArray<'float32'>, b: () => NDArray<'float32'>
   };
 }
 
-export interface MinimumInputConfig<D extends DataType> extends
-    KernelInputConfig {
-  inputs: {a: NDArray<D>, b: NDArray<D>};
-}
-
 // Reduction Max
 export interface MaxNode<D extends DataType> extends KernelNode {
-  inputAndArgs: MaxInputConfig<D>;
+  inputAndArgs: {inputs: {x: NDArray<D>;};};
   output: NDArray<D>;
   gradient: (dy: NDArray<'float32'>, y: NDArray<D>) => {
     x: () => NDArray<'float32'>;
   };
 }
 
-export interface MaxInputConfig<D extends DataType> extends KernelInputConfig {
-  inputs: {x: NDArray<D>;};
-}
-
 // Element-wise max.
 export interface MaximumNode<D extends DataType> extends KernelNode {
-  inputAndArgs: MaximumInputConfig<D>;
+  inputAndArgs: {inputs: {a: NDArray<D>, b: NDArray<D>};};
   output: NDArray<D>;
   gradient: (dy: NDArray<'float32'>, y: NDArray<D>) => {
     a: () => NDArray<'float32'>, b: () => NDArray<'float32'>
   };
-}
-
-export interface MaximumInputConfig<D extends DataType> extends
-    KernelInputConfig {
-  inputs: {a: NDArray<D>, b: NDArray<D>};
 }

--- a/src/math/backends/types/multinomial.ts
+++ b/src/math/backends/types/multinomial.ts
@@ -17,17 +17,13 @@
  */
 
 import {Array2D} from '../../ndarray';
-import {KernelInputConfig, KernelNode} from '../tape_types';
+import {KernelNode} from '../tape_types';
 
 export interface MultinomialNode extends KernelNode {
-  inputAndArgs: MultinomialInputConfig;
+  inputAndArgs:
+      {inputs: {probs: Array2D;}; args: {numSamples: number; seed: number};};
   output: Array2D<'int32'>;
   gradient: (dy: Array2D<'float32'>, y: Array2D<'int32'>) => {
     probs: () => Array2D<'float32'>;
   };
-}
-
-export interface MultinomialInputConfig extends KernelInputConfig {
-  inputs: {probs: Array2D;};
-  args: {numSamples: number; seed: number};
 }

--- a/src/math/backends/types/multinomial.ts
+++ b/src/math/backends/types/multinomial.ts
@@ -16,29 +16,18 @@
  * =============================================================================
  */
 
-import {NamedArrayMap} from '../../../util';
 import {Array2D} from '../../ndarray';
-// tslint:disable-next-line:max-line-length
-import {KernelInputConfig, KernelNode, TapeNodeInputGradientArrays} from '../tape_types';
+import {KernelInputConfig, KernelNode} from '../tape_types';
 
 export interface MultinomialNode extends KernelNode {
   inputAndArgs: MultinomialInputConfig;
   output: Array2D<'int32'>;
-  gradient:
-      (dy: Array2D<'int32'>,
-       y: Array2D<'int32'>) => MultinomialGradientInputArrays;
+  gradient: (dy: Array2D<'float32'>, y: Array2D<'int32'>) => {
+    probs: () => Array2D<'float32'>;
+  };
 }
 
 export interface MultinomialInputConfig extends KernelInputConfig {
-  inputs: MultinomialInputArrays;
+  inputs: {probs: Array2D;};
   args: {numSamples: number; seed: number};
-}
-
-export interface MultinomialInputArrays extends NamedArrayMap {
-  probs: Array2D;
-}
-
-export interface MultinomialGradientInputArrays extends
-    TapeNodeInputGradientArrays {
-  probs: () => Array2D;
 }

--- a/src/math/backends/types/onehot.ts
+++ b/src/math/backends/types/onehot.ts
@@ -15,26 +15,18 @@
  * =============================================================================
  */
 
-import {NamedArrayMap} from '../../../util';
 import {Array1D, Array2D} from '../../ndarray';
-// tslint:disable-next-line:max-line-length
-import {KernelInputConfig, KernelNode, TapeNodeInputGradientArrays} from '../tape_types';
+import {KernelInputConfig, KernelNode} from '../tape_types';
 
 export interface OneHotNode extends KernelNode {
   inputAndArgs: OneHotInputConfig;
   output: Array2D;
-  gradient: (dy: Array2D, y: Array2D) => OneHotGradientInputArrays;
+  gradient: (dy: Array2D<'float32'>, y: Array2D) => {
+    indices: () => Array1D<'float32'>;
+  };
 }
 
 export interface OneHotInputConfig extends KernelInputConfig {
-  inputs: OneHotInputArrays;
+  inputs: {indices: Array1D;};
   args: {depth: number; onValue: number; offValue: number};
-}
-
-export interface OneHotInputArrays extends NamedArrayMap {
-  indices: Array1D;
-}
-
-export interface OneHotGradientInputArrays extends TapeNodeInputGradientArrays {
-  indices: () => Array1D;
 }

--- a/src/math/backends/types/onehot.ts
+++ b/src/math/backends/types/onehot.ts
@@ -16,17 +16,15 @@
  */
 
 import {Array1D, Array2D} from '../../ndarray';
-import {KernelInputConfig, KernelNode} from '../tape_types';
+import {KernelNode} from '../tape_types';
 
 export interface OneHotNode extends KernelNode {
-  inputAndArgs: OneHotInputConfig;
+  inputAndArgs: {
+    inputs: {indices: Array1D;};
+    args: {depth: number; onValue: number; offValue: number};
+  };
   output: Array2D;
   gradient: (dy: Array2D<'float32'>, y: Array2D) => {
     indices: () => Array1D<'float32'>;
   };
-}
-
-export interface OneHotInputConfig extends KernelInputConfig {
-  inputs: {indices: Array1D;};
-  args: {depth: number; onValue: number; offValue: number};
 }

--- a/src/math/backends/types/pad.ts
+++ b/src/math/backends/types/pad.ts
@@ -16,32 +16,28 @@
  */
 
 import {Array1D, Array2D} from '../../ndarray';
-import {KernelInputConfig, KernelNode} from '../tape_types';
+import {KernelNode} from '../tape_types';
 
-// Pad1D
 export interface Pad1DNode extends KernelNode {
-  inputAndArgs: Pad1DInputConfig;
+  inputAndArgs: {
+    inputs: {x: Array1D;};
+    args: {paddings: [number, number], constantValue: number};
+  };
   output: Array1D;
   gradient: (dy: Array1D<'float32'>, y: Array1D) => {
     x: () => Array1D<'float32'>;
   };
 }
 
-export interface Pad1DInputConfig extends KernelInputConfig {
-  inputs: {x: Array1D;};
-  args: {paddings: [number, number], constantValue: number};
-}
-
-// Pad2D
 export interface Pad2DNode extends KernelNode {
-  inputAndArgs: Pad2DInputConfig;
+  inputAndArgs: {
+    inputs: {x: Array2D;}; args: {
+      paddings: [[number, number], [number, number]],
+      constantValue: number
+    };
+  };
   output: Array2D;
   gradient: (dy: Array2D<'float32'>, y: Array2D) => {
     x: () => Array2D<'float32'>;
   };
-}
-
-export interface Pad2DInputConfig extends KernelInputConfig {
-  inputs: {x: Array2D;};
-  args: {paddings: [[number, number], [number, number]], constantValue: number};
 }

--- a/src/math/backends/types/pad.ts
+++ b/src/math/backends/types/pad.ts
@@ -15,43 +15,33 @@
  * =============================================================================
  */
 
-import {NamedArrayMap} from '../../../util';
 import {Array1D, Array2D} from '../../ndarray';
-// tslint:disable-next-line:max-line-length
-import {KernelInputConfig, KernelNode, TapeNodeInputGradientArrays} from '../tape_types';
+import {KernelInputConfig, KernelNode} from '../tape_types';
 
 // Pad1D
 export interface Pad1DNode extends KernelNode {
   inputAndArgs: Pad1DInputConfig;
   output: Array1D;
-  gradient: (dy: Array1D, y: Array1D) => Pad1DGradientInputArrays;
+  gradient: (dy: Array1D<'float32'>, y: Array1D) => {
+    x: () => Array1D<'float32'>;
+  };
 }
 
 export interface Pad1DInputConfig extends KernelInputConfig {
-  inputs: Pad1DInputArrays;
+  inputs: {x: Array1D;};
   args: {paddings: [number, number], constantValue: number};
-}
-
-export interface Pad1DInputArrays extends NamedArrayMap { x: Array1D; }
-
-export interface Pad1DGradientInputArrays extends TapeNodeInputGradientArrays {
-  x: () => Array1D;
 }
 
 // Pad2D
 export interface Pad2DNode extends KernelNode {
   inputAndArgs: Pad2DInputConfig;
   output: Array2D;
-  gradient: (dy: Array2D, y: Array2D) => Pad2DGradientInputArrays;
+  gradient: (dy: Array2D<'float32'>, y: Array2D) => {
+    x: () => Array2D<'float32'>;
+  };
 }
 
 export interface Pad2DInputConfig extends KernelInputConfig {
-  inputs: Pad2DInputArrays;
+  inputs: {x: Array2D;};
   args: {paddings: [[number, number], [number, number]], constantValue: number};
-}
-
-export interface Pad2DInputArrays extends NamedArrayMap { x: Array2D; }
-
-export interface Pad2DGradientInputArrays extends TapeNodeInputGradientArrays {
-  x: () => Array2D;
 }

--- a/src/math/backends/types/pool.ts
+++ b/src/math/backends/types/pool.ts
@@ -15,51 +15,35 @@
  * =============================================================================
  */
 
-import {NamedArrayMap} from '../../../util';
 import {Conv2DInfo} from '../../conv_util';
 import {Array4D} from '../../ndarray';
-// tslint:disable-next-line:max-line-length
-import {KernelInputConfig, KernelNode, TapeNodeInputGradientArrays} from '../tape_types';
+import {KernelInputConfig, KernelNode} from '../tape_types';
 
 // Pool
 export interface PoolNode extends KernelNode {
   inputAndArgs: PoolInputConfig;
   output: Array4D;
-  gradient: (dy: Array4D, y: Array4D) => PoolGradientInputArrays;
+  gradient: (dy: Array4D<'float32'>, y: Array4D) => {
+    x: () => Array4D<'float32'>;
+  };
 }
 
 export interface PoolInputConfig extends KernelInputConfig {
-  inputs: PoolInputArrays;
+  inputs: {x: Array4D;};
   args: {convInfo: Conv2DInfo;};
-}
-
-export interface PoolInputArrays extends NamedArrayMap {
-  x: Array4D;
-}
-
-export interface PoolGradientInputArrays extends TapeNodeInputGradientArrays {
-  x: () => Array4D;
 }
 
 // PoolBackprop
 export interface PoolBackpropNode extends KernelNode {
   inputAndArgs: PoolInputConfig;
   output: Array4D;
-  gradient: (dy: Array4D, y: Array4D) => PoolBackpropGradientInputArrays;
+  gradient: (dy: Array4D<'float32'>, y: Array4D) => {
+    dy: () => Array4D<'float32'>;
+    x: () => Array4D<'float32'>;
+  };
 }
 
 export interface PoolBackpropInputConfig extends KernelInputConfig {
-  inputs: PoolBackpropInputArrays;
+  inputs: {dy: Array4D; x: Array4D;};
   args: {convInfo: Conv2DInfo;};
-}
-
-export interface PoolBackpropInputArrays extends NamedArrayMap {
-  dy: Array4D;
-  x: Array4D;
-}
-
-export interface PoolBackpropGradientInputArrays extends
-    TapeNodeInputGradientArrays {
-  dy: () => Array4D;
-  x: () => Array4D;
 }

--- a/src/math/backends/types/pool.ts
+++ b/src/math/backends/types/pool.ts
@@ -17,33 +17,24 @@
 
 import {Conv2DInfo} from '../../conv_util';
 import {Array4D} from '../../ndarray';
-import {KernelInputConfig, KernelNode} from '../tape_types';
+import {KernelNode} from '../tape_types';
 
 // Pool
 export interface PoolNode extends KernelNode {
-  inputAndArgs: PoolInputConfig;
+  inputAndArgs: {inputs: {x: Array4D;}; args: {convInfo: Conv2DInfo;};};
   output: Array4D;
   gradient: (dy: Array4D<'float32'>, y: Array4D) => {
     x: () => Array4D<'float32'>;
   };
 }
 
-export interface PoolInputConfig extends KernelInputConfig {
-  inputs: {x: Array4D;};
-  args: {convInfo: Conv2DInfo;};
-}
-
 // PoolBackprop
 export interface PoolBackpropNode extends KernelNode {
-  inputAndArgs: PoolInputConfig;
+  inputAndArgs:
+      {inputs: {dy: Array4D; x: Array4D;}; args: {convInfo: Conv2DInfo;};};
   output: Array4D;
   gradient: (dy: Array4D<'float32'>, y: Array4D) => {
     dy: () => Array4D<'float32'>;
     x: () => Array4D<'float32'>;
   };
-}
-
-export interface PoolBackpropInputConfig extends KernelInputConfig {
-  inputs: {dy: Array4D; x: Array4D;};
-  args: {convInfo: Conv2DInfo;};
 }

--- a/src/math/backends/types/pow.ts
+++ b/src/math/backends/types/pow.ts
@@ -25,5 +25,5 @@ export interface PowNode<D extends DataType, R extends Rank, T extends
   gradient: (dy: NDArray<'float32', R>, y: T) => {
     a: () => NDArray<'float32', R>;
     b: () => NDArray<'float32'>;
-  }
+  };
 }

--- a/src/math/backends/types/pow.ts
+++ b/src/math/backends/types/pow.ts
@@ -16,18 +16,14 @@
  */
 
 import {DataType, NDArray, Rank} from '../../ndarray';
-import {KernelInputConfig, KernelNode} from '../tape_types';
+import {KernelNode} from '../tape_types';
 
 export interface PowNode<D extends DataType, R extends Rank, T extends
                              NDArray<D, R> = NDArray<D, R>> extends KernelNode {
-  inputAndArgs: PowInputConfig<T>;
+  inputAndArgs: {inputs: {a: T; b: NDArray<'int32'>;};};
   output: T;
   gradient: (dy: NDArray<'float32', R>, y: T) => {
     a: () => NDArray<'float32', R>;
     b: () => NDArray<'float32'>;
   }
-}
-
-export interface PowInputConfig<T extends NDArray> extends KernelInputConfig {
-  inputs: {a: T; b: NDArray<'int32'>;}
 }

--- a/src/math/backends/types/pow.ts
+++ b/src/math/backends/types/pow.ts
@@ -15,28 +15,19 @@
  * =============================================================================
  */
 
-import {NamedArrayMap} from '../../../util';
-import {NDArray} from '../../ndarray';
-// tslint:disable-next-line:max-line-length
-import {KernelInputConfig, KernelNode, TapeNodeInputGradientArrays} from '../tape_types';
+import {DataType, NDArray, Rank} from '../../ndarray';
+import {KernelInputConfig, KernelNode} from '../tape_types';
 
-export interface PowNode<T extends NDArray> extends KernelNode {
+export interface PowNode<D extends DataType, R extends Rank, T extends
+                             NDArray<D, R> = NDArray<D, R>> extends KernelNode {
   inputAndArgs: PowInputConfig<T>;
   output: T;
-  gradient: (dy: T, y: T) => PowGradientInputArrays<T>;
+  gradient: (dy: NDArray<'float32', R>, y: T) => {
+    a: () => NDArray<'float32', R>;
+    b: () => NDArray<'float32'>;
+  }
 }
 
 export interface PowInputConfig<T extends NDArray> extends KernelInputConfig {
-  inputs: PowInputArrays<T>;
-}
-
-export interface PowInputArrays<T extends NDArray> extends NamedArrayMap {
-  a: T;
-  b: NDArray<'int32'>;
-}
-
-export interface PowGradientInputArrays<T extends NDArray> extends
-    TapeNodeInputGradientArrays {
-  a: () => T;
-  b: () => NDArray<'int32'>;
+  inputs: {a: T; b: NDArray<'int32'>;}
 }

--- a/src/math/backends/types/prelu.ts
+++ b/src/math/backends/types/prelu.ts
@@ -15,29 +15,21 @@
  * =============================================================================
  */
 
-import {NamedArrayMap} from '../../../util';
-import {NDArray} from '../../ndarray';
-// tslint:disable-next-line:max-line-length
-import {KernelInputConfig, KernelNode, TapeNodeInputGradientArrays} from '../tape_types';
+import {DataType, NDArray, Rank} from '../../ndarray';
+import {KernelInputConfig, KernelNode} from '../tape_types';
 
 // PReLU
-export interface PReLUNode<T extends NDArray> extends KernelNode {
+export interface PReLUNode<D extends DataType, R extends Rank, T extends
+                               NDArray<D, R> = NDArray<D, R>> extends
+    KernelNode {
   inputAndArgs: PReLUInputConfig<T>;
   output: T;
-  gradient: (dy: T, y: T) => PReLUGradientInputArrays<T>;
+  gradient: (dy: NDArray<'float32', R>, y: T) => {
+    x: () => NDArray<'float32', R>;
+    alpha: () => NDArray<'float32', R>;
+  }
 }
 
 export interface PReLUInputConfig<T extends NDArray> extends KernelInputConfig {
-  inputs: PReLUInputArrays<T>;
-}
-
-export interface PReLUInputArrays<T extends NDArray> extends NamedArrayMap {
-  x: T;
-  alpha: T;
-}
-
-export interface PReLUGradientInputArrays<T extends NDArray> extends
-    TapeNodeInputGradientArrays {
-  x: () => T;
-  alpha: () => T;
+  inputs: {x: T; alpha: T;}
 }

--- a/src/math/backends/types/prelu.ts
+++ b/src/math/backends/types/prelu.ts
@@ -16,20 +16,16 @@
  */
 
 import {DataType, NDArray, Rank} from '../../ndarray';
-import {KernelInputConfig, KernelNode} from '../tape_types';
+import {KernelNode} from '../tape_types';
 
 // PReLU
 export interface PReLUNode<D extends DataType, R extends Rank, T extends
                                NDArray<D, R> = NDArray<D, R>> extends
     KernelNode {
-  inputAndArgs: PReLUInputConfig<T>;
+  inputAndArgs: {inputs: {x: T; alpha: T;};};
   output: T;
   gradient: (dy: NDArray<'float32', R>, y: T) => {
     x: () => NDArray<'float32', R>;
     alpha: () => NDArray<'float32', R>;
   }
-}
-
-export interface PReLUInputConfig<T extends NDArray> extends KernelInputConfig {
-  inputs: {x: T; alpha: T;}
 }

--- a/src/math/backends/types/prelu.ts
+++ b/src/math/backends/types/prelu.ts
@@ -27,5 +27,5 @@ export interface PReLUNode<D extends DataType, R extends Rank, T extends
   gradient: (dy: NDArray<'float32', R>, y: T) => {
     x: () => NDArray<'float32', R>;
     alpha: () => NDArray<'float32', R>;
-  }
+  };
 }

--- a/src/math/backends/types/reshape.ts
+++ b/src/math/backends/types/reshape.ts
@@ -16,17 +16,12 @@
  */
 
 import {NDArray} from '../../ndarray';
-import {KernelInputConfig, KernelNode} from '../tape_types';
+import {KernelNode} from '../tape_types';
 
 export interface ReshapeNode extends KernelNode {
-  inputAndArgs: ReshapeInputConfig;
+  inputAndArgs: {inputs: {x: NDArray}; args: {newShape: number[]};};
   output: NDArray;
   gradient: (dy: NDArray<'float32'>, y: NDArray) => {
     x: () => NDArray<'float32'>
   };
-}
-
-export interface ReshapeInputConfig extends KernelInputConfig {
-  inputs: {x: NDArray};
-  args: {newShape: number[]};
 }

--- a/src/math/backends/types/reshape.ts
+++ b/src/math/backends/types/reshape.ts
@@ -21,8 +21,8 @@ import {KernelInputConfig, KernelNode} from '../tape_types';
 export interface ReshapeNode extends KernelNode {
   inputAndArgs: ReshapeInputConfig;
   output: NDArray;
-  gradient: (dy: NDArray, y: NDArray) => {
-    x: () => NDArray
+  gradient: (dy: NDArray<'float32'>, y: NDArray) => {
+    x: () => NDArray<'float32'>
   };
 }
 

--- a/src/math/backends/types/resize_bilinear.ts
+++ b/src/math/backends/types/resize_bilinear.ts
@@ -15,27 +15,18 @@
  * =============================================================================
  */
 
-import {NamedArrayMap} from '../../../util';
 import {Array3D} from '../../ndarray';
-// tslint:disable-next-line:max-line-length
-import {KernelInputConfig, KernelNode, TapeNodeInputGradientArrays} from '../tape_types';
+import {KernelInputConfig, KernelNode} from '../tape_types';
 
 export interface ResizeBilinear3DNode extends KernelNode {
   inputAndArgs: ResizeBilinear3DInputConfig;
   output: Array3D;
-  gradient: (dy: Array3D, y: Array3D) => ResizeBilinear3DGradientInputArrays;
+  gradient: (dy: Array3D<'float32'>, y: Array3D) => {
+    x: () => Array3D<'float32'>;
+  };
 }
 
 export interface ResizeBilinear3DInputConfig extends KernelInputConfig {
-  inputs: ResizeBilinear3DInputArrays;
+  inputs: {x: Array3D;};
   args: {newShape2D: [number, number]; alignCorners: boolean};
-}
-
-export interface ResizeBilinear3DInputArrays extends NamedArrayMap {
-  x: Array3D;
-}
-
-export interface ResizeBilinear3DGradientInputArrays extends
-    TapeNodeInputGradientArrays {
-  x: () => Array3D;
 }

--- a/src/math/backends/types/resize_bilinear.ts
+++ b/src/math/backends/types/resize_bilinear.ts
@@ -16,17 +16,15 @@
  */
 
 import {Array3D} from '../../ndarray';
-import {KernelInputConfig, KernelNode} from '../tape_types';
+import {KernelNode} from '../tape_types';
 
 export interface ResizeBilinear3DNode extends KernelNode {
-  inputAndArgs: ResizeBilinear3DInputConfig;
+  inputAndArgs: {
+    inputs: {x: Array3D;};
+    args: {newShape2D: [number, number]; alignCorners: boolean};
+  };
   output: Array3D;
   gradient: (dy: Array3D<'float32'>, y: Array3D) => {
     x: () => Array3D<'float32'>;
   };
-}
-
-export interface ResizeBilinear3DInputConfig extends KernelInputConfig {
-  inputs: {x: Array3D;};
-  args: {newShape2D: [number, number]; alignCorners: boolean};
 }

--- a/src/math/backends/types/reverse.ts
+++ b/src/math/backends/types/reverse.ts
@@ -16,18 +16,12 @@
  */
 
 import {Array4D} from '../../ndarray';
-import {KernelInputConfig, KernelNode} from '../tape_types';
+import {KernelNode} from '../tape_types';
 
-// 4D
 export interface Reverse4DNode extends KernelNode {
-  inputAndArgs: Reverse4DInputConfig;
+  inputAndArgs: {inputs: {x: Array4D;}; args: {axis: number[];};};
   output: Array4D;
   gradient: (dy: Array4D<'float32'>, y: Array4D) => {
     x: () => Array4D<'float32'>;
   };
-}
-
-export interface Reverse4DInputConfig extends KernelInputConfig {
-  inputs: {x: Array4D;};
-  args: {axis: number[];};
 }

--- a/src/math/backends/types/reverse.ts
+++ b/src/math/backends/types/reverse.ts
@@ -15,28 +15,19 @@
  * =============================================================================
  */
 
-import {NamedArrayMap} from '../../../util';
 import {Array4D} from '../../ndarray';
-// tslint:disable-next-line:max-line-length
-import {KernelInputConfig, KernelNode, TapeNodeInputGradientArrays} from '../tape_types';
+import {KernelInputConfig, KernelNode} from '../tape_types';
 
 // 4D
 export interface Reverse4DNode extends KernelNode {
   inputAndArgs: Reverse4DInputConfig;
   output: Array4D;
-  gradient: (dy: Array4D, y: Array4D) => Reverse4DGradientInputArrays;
+  gradient: (dy: Array4D<'float32'>, y: Array4D) => {
+    x: () => Array4D<'float32'>;
+  };
 }
 
 export interface Reverse4DInputConfig extends KernelInputConfig {
-  inputs: Reverse4DInputArrays;
+  inputs: {x: Array4D;};
   args: {axis: number[];};
-}
-
-export interface Reverse4DInputArrays extends NamedArrayMap {
-  x: Array4D;
-}
-
-export interface Reverse4DGradientInputArrays extends
-    TapeNodeInputGradientArrays {
-  x: () => Array4D;
 }

--- a/src/math/backends/types/slice.ts
+++ b/src/math/backends/types/slice.ts
@@ -15,94 +15,69 @@
  * =============================================================================
  */
 
-import {NamedArrayMap} from '../../../util';
-import {Array1D, Array2D, Array3D, Array4D} from '../../ndarray';
+import {Array1D, Array2D, Array3D, Array4D, DataType} from '../../ndarray';
 // tslint:disable-next-line:max-line-length
-import {KernelInputConfig, KernelNode, TapeNodeInputGradientArrays} from '../tape_types';
+import {KernelInputConfig, KernelNode} from '../tape_types';
 
 // 1D
-export interface Slice1DNode extends KernelNode {
-  inputAndArgs: Slice1DInputConfig;
-  output: Array1D;
-  gradient: (dy: Array1D, y: Array1D) => Slice1DGradientInputArrays;
+export interface Slice1DNode<D extends DataType> extends KernelNode {
+  inputAndArgs: Slice1DInputConfig<D>;
+  output: Array1D<D>;
+  gradient: (dy: Array1D<'float32'>, y: Array1D<D>) => {
+    x: () => Array1D<'float32'>;
+  };
 }
 
-export interface Slice1DInputConfig extends KernelInputConfig {
-  inputs: Slice1DInputArrays;
+export interface Slice1DInputConfig<D extends DataType> extends
+    KernelInputConfig {
+  inputs: {x: Array1D<D>;};
   args: {begin: number; size: number;};
 }
 
-export interface Slice1DInputArrays extends NamedArrayMap {
-  x: Array1D;
-}
-
-export interface Slice1DGradientInputArrays extends
-    TapeNodeInputGradientArrays {
-  x: () => Array1D;
-}
-
 // 2D
-export interface Slice2DNode extends KernelNode {
-  inputAndArgs: Slice2DInputConfig;
-  output: Array2D;
-  gradient: (dy: Array2D, y: Array2D) => Slice2DGradientInputArrays;
+export interface Slice2DNode<D extends DataType> extends KernelNode {
+  inputAndArgs: Slice2DInputConfig<D>;
+  output: Array2D<D>;
+  gradient: (dy: Array2D<'float32'>, y: Array2D<D>) => {
+    x: () => Array2D<'float32'>;
+  };
 }
 
-export interface Slice2DInputConfig extends KernelInputConfig {
-  inputs: Slice2DInputArrays;
+export interface Slice2DInputConfig<D extends DataType> extends
+    KernelInputConfig {
+  inputs: {x: Array2D<D>;};
   args: {begin: [number, number]; size: [number, number];};
 }
 
-export interface Slice2DInputArrays extends NamedArrayMap {
-  x: Array2D;
-}
-
-export interface Slice2DGradientInputArrays extends
-    TapeNodeInputGradientArrays {
-  x: () => Array2D;
-}
-
 // 3D
-export interface Slice3DNode extends KernelNode {
-  inputAndArgs: Slice3DInputConfig;
-  output: Array3D;
-  gradient: (dy: Array3D, y: Array3D) => Slice3DGradientInputArrays;
+export interface Slice3DNode<D extends DataType> extends KernelNode {
+  inputAndArgs: Slice3DInputConfig<D>;
+  output: Array3D<D>;
+  gradient: (dy: Array3D<'float32'>, y: Array3D<D>) => {
+    x: () => Array3D<'float32'>;
+  };
 }
 
-export interface Slice3DInputConfig extends KernelInputConfig {
-  inputs: Slice3DInputArrays;
+export interface Slice3DInputConfig<D extends DataType> extends
+    KernelInputConfig {
+  inputs: {x: Array3D<D>;};
   args: {begin: [number, number, number]; size: [number, number, number];};
 }
 
-export interface Slice3DInputArrays extends NamedArrayMap {
-  x: Array3D;
-}
-
-export interface Slice3DGradientInputArrays extends
-    TapeNodeInputGradientArrays {
-  x: () => Array3D;
-}
-
 // 4D
-export interface Slice4DNode extends KernelNode {
-  inputAndArgs: Slice4DInputConfig;
-  output: Array4D;
-  gradient: (dy: Array4D, y: Array4D) => Slice4DGradientInputArrays;
+export interface Slice4DNode<D extends DataType> extends KernelNode {
+  inputAndArgs: Slice4DInputConfig<D>;
+  output: Array4D<D>;
+  gradient: (dy: Array4D<'float32'>, y: Array4D<D>) => {
+    x: () => Array4D<'float32'>;
+  };
 }
 
-export interface Slice4DInputConfig extends KernelInputConfig {
-  inputs: Slice4DInputArrays;
+export interface Slice4DInputConfig<D extends DataType> extends
+    KernelInputConfig {
+  inputs: {x: Array4D<D>;};
   args: {
     begin: [number, number, number, number];
     size: [number, number, number, number];
   };
-}
-
-export interface Slice4DInputArrays extends NamedArrayMap {
-  x: Array4D;
-}
-
-export interface Slice4DGradientInputArrays extends
-    TapeNodeInputGradientArrays {
-  x: () => Array4D;
 }

--- a/src/math/backends/types/slice.ts
+++ b/src/math/backends/types/slice.ts
@@ -16,68 +16,48 @@
  */
 
 import {Array1D, Array2D, Array3D, Array4D, DataType} from '../../ndarray';
-// tslint:disable-next-line:max-line-length
-import {KernelInputConfig, KernelNode} from '../tape_types';
+import {KernelNode} from '../tape_types';
 
-// 1D
 export interface Slice1DNode<D extends DataType> extends KernelNode {
-  inputAndArgs: Slice1DInputConfig<D>;
+  inputAndArgs:
+      {inputs: {x: Array1D<D>;}; args: {begin: number; size: number;};};
   output: Array1D<D>;
   gradient: (dy: Array1D<'float32'>, y: Array1D<D>) => {
     x: () => Array1D<'float32'>;
   };
 }
 
-export interface Slice1DInputConfig<D extends DataType> extends
-    KernelInputConfig {
-  inputs: {x: Array1D<D>;};
-  args: {begin: number; size: number;};
-}
-
-// 2D
 export interface Slice2DNode<D extends DataType> extends KernelNode {
-  inputAndArgs: Slice2DInputConfig<D>;
+  inputAndArgs: {
+    inputs: {x: Array2D<D>;};
+    args: {begin: [number, number]; size: [number, number];};
+  };
   output: Array2D<D>;
   gradient: (dy: Array2D<'float32'>, y: Array2D<D>) => {
     x: () => Array2D<'float32'>;
   };
 }
 
-export interface Slice2DInputConfig<D extends DataType> extends
-    KernelInputConfig {
-  inputs: {x: Array2D<D>;};
-  args: {begin: [number, number]; size: [number, number];};
-}
-
-// 3D
 export interface Slice3DNode<D extends DataType> extends KernelNode {
-  inputAndArgs: Slice3DInputConfig<D>;
+  inputAndArgs: {
+    inputs: {x: Array3D<D>;};
+    args: {begin: [number, number, number]; size: [number, number, number];};
+  };
   output: Array3D<D>;
   gradient: (dy: Array3D<'float32'>, y: Array3D<D>) => {
     x: () => Array3D<'float32'>;
   };
 }
 
-export interface Slice3DInputConfig<D extends DataType> extends
-    KernelInputConfig {
-  inputs: {x: Array3D<D>;};
-  args: {begin: [number, number, number]; size: [number, number, number];};
-}
-
-// 4D
 export interface Slice4DNode<D extends DataType> extends KernelNode {
-  inputAndArgs: Slice4DInputConfig<D>;
+  inputAndArgs: {
+    inputs: {x: Array4D<D>;}; args: {
+      begin: [number, number, number, number];
+      size: [number, number, number, number];
+    };
+  };
   output: Array4D<D>;
   gradient: (dy: Array4D<'float32'>, y: Array4D<D>) => {
     x: () => Array4D<'float32'>;
-  };
-}
-
-export interface Slice4DInputConfig<D extends DataType> extends
-    KernelInputConfig {
-  inputs: {x: Array4D<D>;};
-  args: {
-    begin: [number, number, number, number];
-    size: [number, number, number, number];
   };
 }

--- a/src/math/backends/types/sum.ts
+++ b/src/math/backends/types/sum.ts
@@ -15,30 +15,19 @@
  * =============================================================================
  */
 
-import {NamedArrayMap} from '../../../util';
 import {DataType, NDArray} from '../../ndarray';
 import {SumTypes} from '../../types';
-// tslint:disable-next-line:max-line-length
-import {KernelInputConfig, KernelNode, TapeNodeInputGradientArrays} from '../tape_types';
+import {KernelInputConfig, KernelNode} from '../tape_types';
 
 export interface SumNode<D extends DataType> extends KernelNode {
   inputAndArgs: SumInputConfig<D>;
   output: NDArray<SumTypes[D]>;
-  gradient:
-      (dy: NDArray<SumTypes[D]>,
-       y: NDArray<SumTypes[D]>) => SumGradientInputArrays<D>;
+  gradient: (dy: NDArray<'float32'>, y: NDArray<SumTypes[D]>) => {
+    x: () => NDArray<'float32'>;
+  };
 }
 
 export interface SumInputConfig<D extends DataType> extends KernelInputConfig {
-  inputs: SumInputArrays<D>;
+  inputs: {x: NDArray<D>;};
   args: {axes: number[];};
-}
-
-export interface SumInputArrays<D extends DataType> extends NamedArrayMap {
-  x: NDArray<D>;
-}
-
-export interface SumGradientInputArrays<D extends DataType> extends
-    TapeNodeInputGradientArrays {
-  x: () => NDArray<D>;
 }

--- a/src/math/backends/types/sum.ts
+++ b/src/math/backends/types/sum.ts
@@ -17,17 +17,12 @@
 
 import {DataType, NDArray} from '../../ndarray';
 import {SumTypes} from '../../types';
-import {KernelInputConfig, KernelNode} from '../tape_types';
+import {KernelNode} from '../tape_types';
 
 export interface SumNode<D extends DataType> extends KernelNode {
-  inputAndArgs: SumInputConfig<D>;
+  inputAndArgs: {inputs: {x: NDArray<D>;}; args: {axes: number[];};};
   output: NDArray<SumTypes[D]>;
   gradient: (dy: NDArray<'float32'>, y: NDArray<SumTypes[D]>) => {
     x: () => NDArray<'float32'>;
   };
-}
-
-export interface SumInputConfig<D extends DataType> extends KernelInputConfig {
-  inputs: {x: NDArray<D>;};
-  args: {axes: number[];};
 }

--- a/src/math/backends/types/topk.ts
+++ b/src/math/backends/types/topk.ts
@@ -15,52 +15,36 @@
  * =============================================================================
  */
 
-import {NamedArrayMap} from '../../../util';
-import {Array1D, DataType, NDArray} from '../../ndarray';
-// tslint:disable-next-line:max-line-length
-import {KernelInputConfig, KernelNode, TapeNodeInputGradientArrays} from '../tape_types';
+import {Array1D, DataType, NDArray, Rank} from '../../ndarray';
+import {KernelInputConfig, KernelNode} from '../tape_types';
 
 // Values
-export interface TopKValuesNode<D extends DataType, T extends NDArray<D>>
-    extends KernelNode {
+export interface TopKValuesNode<D extends DataType, R extends Rank, T extends
+                                    NDArray<D, R> = NDArray<D, R>> extends
+    KernelNode {
   inputAndArgs: TopKValuesInputConfig<T>;
   output: Array1D<D>;
-  gradient: (dy: Array1D<D>, y: Array1D<D>) => TopKValuesGradientInputArrays<T>;
+  gradient: (dy: Array1D<'float32'>, y: Array1D<D>) => {
+    x: () => NDArray<'float32', R>;
+  };
 }
 
 export interface TopKValuesInputConfig<T extends NDArray> extends
     KernelInputConfig {
-  inputs: TopKValuesInputArrays<T>;
+  inputs: {x: T;};
   args: {k: number};
-}
-
-export interface TopKValuesInputArrays<T extends NDArray> extends
-    NamedArrayMap {
-  x: T;
-}
-
-export interface TopKValuesGradientInputArrays<T extends NDArray> extends
-    TapeNodeInputGradientArrays {
-  x: () => T;
 }
 
 // Indices
 export interface TopKIndicesNode extends KernelNode {
   inputAndArgs: TopKIndicesInputConfig;
   output: Array1D<'int32'>;
-  gradient:
-      (dy: Array1D<'int32'>,
-       y: Array1D<'int32'>) => TopKIndicesGradientInputArrays;
+  gradient: (dy: Array1D<'float32'>, y: Array1D<'int32'>) => {
+    x: () => NDArray<'float32'>;
+  };
 }
 
 export interface TopKIndicesInputConfig extends KernelInputConfig {
-  inputs: TopKIndicesInputArrays;
+  inputs: {x: NDArray;};
   args: {k: number};
-}
-
-export interface TopKIndicesInputArrays extends NamedArrayMap { x: NDArray; }
-
-export interface TopKIndicesGradientInputArrays extends
-    TapeNodeInputGradientArrays {
-  x: () => NDArray;
 }

--- a/src/math/backends/types/topk.ts
+++ b/src/math/backends/types/topk.ts
@@ -16,35 +16,24 @@
  */
 
 import {Array1D, DataType, NDArray, Rank} from '../../ndarray';
-import {KernelInputConfig, KernelNode} from '../tape_types';
+import {KernelNode} from '../tape_types';
 
 // Values
 export interface TopKValuesNode<D extends DataType, R extends Rank, T extends
                                     NDArray<D, R> = NDArray<D, R>> extends
     KernelNode {
-  inputAndArgs: TopKValuesInputConfig<T>;
+  inputAndArgs: {inputs: {x: T;}; args: {k: number};};
   output: Array1D<D>;
   gradient: (dy: Array1D<'float32'>, y: Array1D<D>) => {
     x: () => NDArray<'float32', R>;
   };
 }
 
-export interface TopKValuesInputConfig<T extends NDArray> extends
-    KernelInputConfig {
-  inputs: {x: T;};
-  args: {k: number};
-}
-
 // Indices
 export interface TopKIndicesNode extends KernelNode {
-  inputAndArgs: TopKIndicesInputConfig;
+  inputAndArgs: {inputs: {x: NDArray;}; args: {k: number};};
   output: Array1D<'int32'>;
   gradient: (dy: Array1D<'float32'>, y: Array1D<'int32'>) => {
     x: () => NDArray<'float32'>;
   };
-}
-
-export interface TopKIndicesInputConfig extends KernelInputConfig {
-  inputs: {x: NDArray;};
-  args: {k: number};
 }

--- a/src/math/backends/types/unary.ts
+++ b/src/math/backends/types/unary.ts
@@ -15,88 +15,101 @@
  * =============================================================================
  */
 
-import {NamedArrayMap} from '../../../util';
-import {NDArray} from '../../ndarray';
-// tslint:disable-next-line:max-line-length
-import {KernelInputConfig, KernelNode, TapeNodeInputGradientArrays} from '../tape_types';
+import {DataType, NDArray, Rank} from '../../ndarray';
+import {KernelInputConfig, KernelNode} from '../tape_types';
 
-export interface UnaryNode<T extends NDArray> extends KernelNode {
+export interface UnaryNode<D extends DataType, R extends Rank, T extends
+                               NDArray<D, R> = NDArray<D, R>> extends
+    KernelNode {
   inputAndArgs: UnaryInputConfig<T>;
   output: T;
-  gradient: (dy: T, y: T) => UnaryGradientInputArrays<T>;
+  gradient: (dy: NDArray<'float32', R>, y: T) => {
+    x: () => NDArray<'float32', R>;
+  };
 }
 
 export interface UnaryInputConfig<T extends NDArray> extends KernelInputConfig {
-  inputs: UnaryInputArrays<T>;
-}
-
-export interface UnaryInputArrays<T extends NDArray> extends NamedArrayMap {
-  x: T;
-}
-
-export interface UnaryGradientInputArrays<T extends NDArray> extends
-    TapeNodeInputGradientArrays {
-  x: () => T;
+  inputs: {x: T;};
 }
 
 // Leaky RELU
-export interface LeakyReluNode<T extends NDArray> extends KernelNode {
+export interface LeakyReluNode<D extends DataType, R extends Rank, T extends
+                                   NDArray<D, R> = NDArray<D, R>> extends
+    KernelNode {
   inputAndArgs: LeakyReluInputConfig<T>;
   output: T;
-  gradient: (dy: T, y: T) => UnaryGradientInputArrays<T>;
+  gradient: (dy: NDArray<'float32', R>, y: T) => {
+    x: () => NDArray<'float32', R>;
+  };
 }
 
 export interface LeakyReluInputConfig<T extends NDArray> extends
     KernelInputConfig {
-  inputs: UnaryInputArrays<T>;
+  inputs: {x: T;};
   args: {alpha: number;};
 }
 
 // Step
-export interface StepNode<T extends NDArray> extends KernelNode {
+export interface StepNode<D extends DataType, R extends Rank, T extends
+                              NDArray<D, R> = NDArray<D, R>> extends
+    KernelNode {
   inputAndArgs: StepInputConfig<T>;
   output: T;
-  gradient: (dy: T, y: T) => UnaryGradientInputArrays<T>;
+  gradient: (dy: NDArray<'float32', R>, y: T) => {
+    x: () => NDArray<'float32', R>;
+  };
 }
 
 export interface StepInputConfig<T extends NDArray> extends KernelInputConfig {
-  inputs: UnaryInputArrays<T>;
+  inputs: {x: T;};
   args: {alpha: number;};
 }
 
 // Clip
-export interface ClipNode<T extends NDArray> extends KernelNode {
+export interface ClipNode<D extends DataType, R extends Rank, T extends
+                              NDArray<D, R> = NDArray<D, R>> extends
+    KernelNode {
   inputAndArgs: ClipInputConfig<T>;
   output: T;
-  gradient: (dy: T, y: T) => UnaryGradientInputArrays<T>;
+  gradient: (dy: NDArray<'float32', R>, y: T) => {
+    x: () => NDArray<'float32', R>;
+  };
 }
 
 export interface ClipInputConfig<T extends NDArray> extends KernelInputConfig {
-  inputs: UnaryInputArrays<T>;
+  inputs: {x: T;};
   args: {min: number; max: number;};
 }
 
 // Transpose
-export interface TransposeNode<T extends NDArray> extends KernelNode {
+export interface TransposeNode<D extends DataType, R extends Rank, T extends
+                                   NDArray<D, R> = NDArray<D, R>> extends
+    KernelNode {
   inputAndArgs: TransposeInputConfig<T>;
   output: T;
-  gradient: (dy: T, y: T) => UnaryGradientInputArrays<T>;
+  gradient: (dy: NDArray<'float32', R>, y: T) => {
+    x: () => NDArray<'float32', R>;
+  };
 }
 
 export interface TransposeInputConfig<T extends NDArray> extends
     KernelInputConfig {
-  inputs: UnaryInputArrays<T>;
+  inputs: {x: T;};
   args: {perm: number[];};
 }
 
 // Tile
-export interface TileNode<T extends NDArray> extends KernelNode {
+export interface TileNode<D extends DataType, R extends Rank, T extends
+                              NDArray<D, R> = NDArray<D, R>> extends
+    KernelNode {
   inputAndArgs: TileInputConfig<T>;
   output: T;
-  gradient: (dy: T, y: T) => UnaryGradientInputArrays<T>;
+  gradient: (dy: NDArray<'float32', R>, y: T) => {
+    x: () => NDArray<'float32', R>;
+  };
 }
 
 export interface TileInputConfig<T extends NDArray> extends KernelInputConfig {
-  inputs: UnaryInputArrays<T>;
+  inputs: {x: T;};
   args: {reps: number[];};
 }

--- a/src/math/backends/types/unary.ts
+++ b/src/math/backends/types/unary.ts
@@ -16,100 +16,63 @@
  */
 
 import {DataType, NDArray, Rank} from '../../ndarray';
-import {KernelInputConfig, KernelNode} from '../tape_types';
+import {KernelNode} from '../tape_types';
 
 export interface UnaryNode<D extends DataType, R extends Rank, T extends
                                NDArray<D, R> = NDArray<D, R>> extends
     KernelNode {
-  inputAndArgs: UnaryInputConfig<T>;
+  inputAndArgs: {inputs: {x: T;};};
   output: T;
   gradient: (dy: NDArray<'float32', R>, y: T) => {
     x: () => NDArray<'float32', R>;
   };
 }
 
-export interface UnaryInputConfig<T extends NDArray> extends KernelInputConfig {
-  inputs: {x: T;};
-}
-
-// Leaky RELU
 export interface LeakyReluNode<D extends DataType, R extends Rank, T extends
                                    NDArray<D, R> = NDArray<D, R>> extends
     KernelNode {
-  inputAndArgs: LeakyReluInputConfig<T>;
+  inputAndArgs: {inputs: {x: T;}; args: {alpha: number;};};
   output: T;
   gradient: (dy: NDArray<'float32', R>, y: T) => {
     x: () => NDArray<'float32', R>;
   };
 }
-
-export interface LeakyReluInputConfig<T extends NDArray> extends
-    KernelInputConfig {
-  inputs: {x: T;};
-  args: {alpha: number;};
-}
-
-// Step
 export interface StepNode<D extends DataType, R extends Rank, T extends
                               NDArray<D, R> = NDArray<D, R>> extends
     KernelNode {
-  inputAndArgs: StepInputConfig<T>;
+  inputAndArgs: {inputs: {x: T;}; args: {alpha: number;};};
   output: T;
   gradient: (dy: NDArray<'float32', R>, y: T) => {
     x: () => NDArray<'float32', R>;
   };
 }
 
-export interface StepInputConfig<T extends NDArray> extends KernelInputConfig {
-  inputs: {x: T;};
-  args: {alpha: number;};
-}
-
-// Clip
 export interface ClipNode<D extends DataType, R extends Rank, T extends
                               NDArray<D, R> = NDArray<D, R>> extends
     KernelNode {
-  inputAndArgs: ClipInputConfig<T>;
+  inputAndArgs: {inputs: {x: T;}; args: {min: number; max: number;};};
   output: T;
   gradient: (dy: NDArray<'float32', R>, y: T) => {
     x: () => NDArray<'float32', R>;
   };
 }
 
-export interface ClipInputConfig<T extends NDArray> extends KernelInputConfig {
-  inputs: {x: T;};
-  args: {min: number; max: number;};
-}
-
-// Transpose
 export interface TransposeNode<D extends DataType, R extends Rank, T extends
                                    NDArray<D, R> = NDArray<D, R>> extends
     KernelNode {
-  inputAndArgs: TransposeInputConfig<T>;
+  inputAndArgs: {inputs: {x: T;}; args: {perm: number[];};};
   output: T;
   gradient: (dy: NDArray<'float32', R>, y: T) => {
     x: () => NDArray<'float32', R>;
   };
 }
 
-export interface TransposeInputConfig<T extends NDArray> extends
-    KernelInputConfig {
-  inputs: {x: T;};
-  args: {perm: number[];};
-}
-
-// Tile
 export interface TileNode<D extends DataType, R extends Rank, T extends
                               NDArray<D, R> = NDArray<D, R>> extends
     KernelNode {
-  inputAndArgs: TileInputConfig<T>;
+  inputAndArgs: {inputs: {x: T;}; args: {reps: number[];};};
   output: T;
   gradient: (dy: NDArray<'float32', R>, y: T) => {
     x: () => NDArray<'float32', R>;
   };
-}
-
-export interface TileInputConfig<T extends NDArray> extends KernelInputConfig {
-  inputs: {x: T;};
-  args: {reps: number[];};
 }

--- a/src/math/math.ts
+++ b/src/math/math.ts
@@ -231,9 +231,11 @@ export class NDArrayMath implements NDArrayManager {
           }
           return {
             a: () => this.matMul(
-                dy, b, MatrixOrientation.REGULAR, MatrixOrientation.TRANSPOSED),
+                         dy, b, MatrixOrientation.REGULAR,
+                         MatrixOrientation.TRANSPOSED) as Array2D<'float32'>,
             b: () => this.matMul(
-                a, dy, MatrixOrientation.TRANSPOSED, MatrixOrientation.REGULAR)
+                         a, dy, MatrixOrientation.TRANSPOSED,
+                         MatrixOrientation.REGULAR) as Array2D<'float32'>
           };
         });
   }
@@ -367,10 +369,11 @@ export class NDArrayMath implements NDArrayManager {
    * @param begin The offset to start the slice from.
    * @param size The size of the slice.
    */
-  slice1D(x: Array1D, begin: number, size: number): Array1D {
+  slice1D<D extends DataType>(x: Array1D<D>, begin: number, size: number):
+      Array1D<D> {
     slice_util.assertParamsValid(x, [begin], [size]);
     return this.backendEngine.executeKernel(
-        'Slice1D', {inputs: {x}, args: {begin, size}});
+               'Slice1D', {inputs: {x}, args: {begin, size}}) as Array1D<D>;
   }
 
   /**
@@ -381,11 +384,12 @@ export class NDArrayMath implements NDArrayManager {
    * @param begin The [row, col] 2d coordinates to start the slice from.
    * @param size The size of the slice.
    */
-  slice2D(x: Array2D, begin: [number, number], size: [number, number]):
-      Array2D {
+  slice2D<D extends DataType>(x: Array2D<D>, begin: [number, number], size: [
+    number, number
+  ]): Array2D<D> {
     slice_util.assertParamsValid(x, begin, size);
     return this.backendEngine.executeKernel(
-        'Slice2D', {inputs: {x}, args: {begin, size}});
+               'Slice2D', {inputs: {x}, args: {begin, size}}) as Array2D<D>;
   }
 
   /**
@@ -396,12 +400,12 @@ export class NDArrayMath implements NDArrayManager {
    * @param begin The [row, col, depth] 3d coordinates to start the slice from.
    * @param size The size of the slice.
    */
-  slice3D(x: Array3D, begin: [number, number, number], size: [
-    number, number, number
-  ]): Array3D {
+  slice3D<D extends DataType>(
+      x: Array3D<D>, begin: [number, number, number],
+      size: [number, number, number]): Array3D<D> {
     slice_util.assertParamsValid(x, begin, size);
     return this.backendEngine.executeKernel(
-        'Slice3D', {inputs: {x}, args: {begin, size}});
+               'Slice3D', {inputs: {x}, args: {begin, size}}) as Array3D<D>;
   }
 
   /**
@@ -413,12 +417,12 @@ export class NDArrayMath implements NDArrayManager {
    *              slice from.
    * @param size The size of the slice.
    */
-  slice4D(x: Array4D, begin: [number, number, number, number], size: [
-    number, number, number, number
-  ]): Array4D {
+  slice4D<D extends DataType>(
+      x: Array4D<D>, begin: [number, number, number, number],
+      size: [number, number, number, number]): Array4D<D> {
     slice_util.assertParamsValid(x, begin, size);
     return this.backendEngine.executeKernel(
-        'Slice4D', {inputs: {x}, args: {begin, size}});
+               'Slice4D', {inputs: {x}, args: {begin, size}}) as Array4D<D>;
   }
 
   /**
@@ -1980,17 +1984,18 @@ export class NDArrayMath implements NDArrayManager {
    *     number. If none is provided, it will not round and error if the output
    *     is of fractional size.
    */
-  conv2dDerInput<T extends NDArray>(
-      xShape: [number, number, number, number]|[number, number, number], dy: T,
-      filter: Array4D, strides: [number, number]|number,
-      pad: 'valid'|'same'|number, dimRoundingMode?: 'floor'|'round'|'ceil'): T {
+  conv2dDerInput<R extends Rank>(
+      xShape: [number, number, number, number]|[number, number, number],
+      dy: NDArray<'float32', R>, filter: Array4D,
+      strides: [number, number]|number, pad: 'valid'|'same'|number,
+      dimRoundingMode?: 'floor'|'round'|'ceil'): NDArray<'float32', R> {
     util.assert(
         xShape.length === dy.rank,
         `Length of inShape ` +
             `(${xShape.length}) and rank of dy (${dy.rank}) must match`);
 
     let xShape4D = xShape as [number, number, number, number];
-    let dy4D = dy as NDArray as Array4D;
+    let dy4D = dy as Array4D<'float32'>;
     let reshapedTo4D = false;
     if (dy.rank === 3) {
       reshapedTo4D = true;
@@ -2033,10 +2038,10 @@ export class NDArrayMath implements NDArrayManager {
       const res = this.backendEngine.executeKernel(
           'Conv2DDerInput', {inputs: {dy: dy4D, filter}, args: {convInfo}});
       if (reshapedTo4D) {
-        return res.as3D(res.shape[1], res.shape[2], res.shape[3]) as NDArray as
-            T;
+        return res.as3D(res.shape[1], res.shape[2], res.shape[3]) as
+            NDArray<'float32', R>;
       }
-      return res as NDArray as T;
+      return res as NDArray<'float32', R>;
     });
   }
 
@@ -2047,7 +2052,7 @@ export class NDArrayMath implements NDArrayManager {
    *   shape [batch, height, width, outDepth]. If rank 3, batch of 1 is
    * assumed.
    */
-  conv2dDerBias(dy: Array3D|Array4D): Array1D {
+  conv2dDerBias(dy: Array3D<'float32'>|Array4D<'float32'>): Array1D<'float32'> {
     let dy4D = dy as Array4D;
     if (dy.rank === 3) {
       dy4D = dy.as4D(1, dy.shape[0], dy.shape[1], dy.shape[2]);
@@ -2074,15 +2079,16 @@ export class NDArrayMath implements NDArrayManager {
    *     number. If none is provided, it will not round and error if the output
    *     is of fractional size.
    */
-  conv2dDerFilter<T extends Array3D|Array4D>(
-      x: T, dy: T, filterShape: [number, number, number, number],
+  conv2dDerFilter<R extends '3'|'4'>(
+      x: NDArray<DataType, R>, dy: NDArray<'float32', R>,
+      filterShape: [number, number, number, number],
       strides: [number, number]|number, pad: 'valid'|'same'|number,
-      dimRoundingMode?: 'floor'|'round'|'ceil'): Array4D {
-    let x4D = x as NDArray as Array4D;
+      dimRoundingMode?: 'floor'|'round'|'ceil'): Array4D<'float32'> {
+    let x4D = x as Array4D;
     if (x.rank === 3) {
       x4D = x.as4D(1, x.shape[0], x.shape[1], x.shape[2]);
     }
-    let dy4D = dy as NDArray as Array4D;
+    let dy4D = dy as Array4D<'float32'>;
     if (dy4D.rank === 3) {
       dy4D = dy.as4D(1, dy.shape[0], dy.shape[1], dy.shape[2]);
     }
@@ -2139,11 +2145,11 @@ export class NDArrayMath implements NDArrayManager {
    *     number. If none is provided, it will not round and error if the output
    *     is of fractional size.
    */
-  conv2dTranspose<T extends NDArray>(
-      x: T, filter: Array4D,
+  conv2dTranspose<R extends Rank>(
+      x: NDArray<'float32', R>, filter: Array4D,
       outputShape: [number, number, number, number]|[number, number, number],
       strides: [number, number]|number, pad: 'valid'|'same'|number,
-      dimRoundingMode?: 'floor'|'round'|'ceil'): T {
+      dimRoundingMode?: 'floor'|'round'|'ceil'): NDArray<'float32', R> {
     return this.conv2dDerInput(
         outputShape, x, filter, strides, pad, dimRoundingMode);
   }
@@ -2310,10 +2316,10 @@ export class NDArrayMath implements NDArrayManager {
    *     number. If none is provided, it will not round and error if the output
    *     is of fractional size.
    */
-  maxPoolBackprop<T extends NDArray>(
-      dy: T, input: T, filterSize: [number, number]|number,
+  maxPoolBackprop<D extends DataType, R extends Rank, T extends NDArray<D, R>>(
+      dy: NDArray<'float32', R>, input: T, filterSize: [number, number]|number,
       strides: [number, number]|number, pad: 'valid'|'same'|number,
-      dimRoundingMode?: 'floor'|'round'|'ceil'): T {
+      dimRoundingMode?: 'floor'|'round'|'ceil'): NDArray<'float32', R> {
     util.assert(
         input.rank === dy.rank,
         `Rank of input (${input.rank}) does not match rank of dy (${dy.rank})`);
@@ -2349,10 +2355,10 @@ export class NDArrayMath implements NDArrayManager {
           'MaxPoolBackprop',
           {inputs: {dy: dy4D, x: input4D}, args: {convInfo}});
       if (reshapedTo4D) {
-        return res.as3D(res.shape[1], res.shape[2], res.shape[3]) as NDArray as
-            T;
+        return res.as3D(res.shape[1], res.shape[2], res.shape[3]) as
+            NDArray<'float32', R>;
       }
-      return res as NDArray as T;
+      return res as NDArray<'float32', R>;
     });
   }
 
@@ -2478,9 +2484,11 @@ export class NDArrayMath implements NDArrayManager {
    * @param pad A string from: 'same', 'valid'. The type of padding algorithm
    *     used in the forward prop of the op.
    */
-  private avgPoolBackprop<T extends NDArray>(
-      dy: T, input: T, filterSize: [number, number]|number,
-      strides: [number, number]|number, pad: 'valid'|'same'|number): T {
+  private avgPoolBackprop<D extends DataType,
+                                    R extends Rank, T extends NDArray<D, R>>(
+      dy: NDArray<'float32', R>, input: T, filterSize: [number, number]|number,
+      strides: [number, number]|number,
+      pad: 'valid'|'same'|number): NDArray<'float32', R> {
     util.assert(
         input.rank === dy.rank,
         `Rank of input (${input.rank}) does not match rank of dy (${dy.rank})`);
@@ -2510,10 +2518,10 @@ export class NDArrayMath implements NDArrayManager {
           'AvgPoolBackprop',
           {inputs: {dy: dy4D, x: input4D}, args: {convInfo}});
       if (reshapedTo4D) {
-        return res.as3D(res.shape[1], res.shape[2], res.shape[3]) as NDArray as
-            T;
+        return res.as3D(res.shape[1], res.shape[2], res.shape[3]) as
+            NDArray<'float32', R>;
       }
-      return res as NDArray as T;
+      return res as NDArray<'float32', R>;
     });
   }
 
@@ -3065,13 +3073,16 @@ export class NDArrayMath implements NDArrayManager {
   }
 
   /**
-   * Computes and returns the gradient of f(x) with respect to every variable.
-   * Computes and returns the gradient of f(x) with respect to every variable.
+   * Computes and returns the gradient of f(x) with respect to every trainable
+   * variable.
+   * @param f The function to execute. f() should return a scalar.
+   * @param varList An optional list of variables to provide gradients with
+   * respect to.
    */
-  variableGradients<D extends DataType>(f: () => Scalar<D>):
-      {value: Scalar<D>, gradients: NamedVariableMap} {
-    return this.valueAndGradients(f, this.registeredVariables) as
-        {value: Scalar<D>, gradients: NamedVariableMap};
+  variableGradients<D extends DataType>(
+      f: () => Scalar<D>,
+      varList?: Variable[]): {value: Scalar<D>, gradients: NamedArrayMap} {
+    return this.backendEngine.variableGradientsAndValue(f, varList);
   }
 
   /**

--- a/src/math/math_test.ts
+++ b/src/math/math_test.ts
@@ -605,7 +605,7 @@ import {Array1D, Array2D, Array3D, NDArray, Scalar} from './ndarray';
         return math.customGradient(() => {
           const value = math.pow(a, b);
 
-          const gradients = (dy: NDArray, y: NDArray) => {
+          const gradients = (dy: NDArray<'float32'>, y: NDArray) => {
             return {a: () => math.multiply(dy, Scalar.new(3))};
           };
 
@@ -628,7 +628,7 @@ import {Array1D, Array2D, Array3D, NDArray, Scalar} from './ndarray';
         return math.vjp(() => {
           return math.customGradient(() => {
             const value = math.pow(a, b);
-            const gradients = (dy: NDArray, y: NDArray) => {
+            const gradients = (dy: NDArray<'float32'>, y: NDArray) => {
               return {a: () => math.multiply(dy, a)};
             };
 

--- a/src/math/optimizers/optimizer.ts
+++ b/src/math/optimizers/optimizer.ts
@@ -37,7 +37,15 @@ export abstract class Optimizer {
   }
 
   /**
-   * Eager mode methods.
+   * Executes `f()` and minimizes the scalar output of `f()` by computing
+   * gradients of y with respect to the list of trainable variables provided by
+   * `varList`. If no list is provided, it defaults to all trainable variables.
+   * @param f The function to execute and whose output to minimize.
+   * @param returnCost Whether to return the scalar cost value produced by
+   * executing `f()`.
+   * @param varList An optional list of variables to update. If specified, only
+   * the trainable variables in varList will be updated by minimize. Defaults to
+   * all trainable variables.
    */
   minimize<D extends DataType>(
       f: () => Scalar<D>, returnCost = false,
@@ -58,12 +66,26 @@ export abstract class Optimizer {
     }
   }
 
+  /**
+   * Executes f() and computes the gradient of the scalar output of f() with
+   * respect to the list of trainable variables provided by `varList`. If no
+   * list is provided, it defaults to all trainable variables.
+   * @param f The function to execute and whose output to use for computing
+   * gradients with respect to variables.
+   * @param varList An optional list of variables to compute gradients with
+   * respect to. If specified, only the trainable variables in varList will have
+   * gradients computed with respect to. Defaults to all trainable variables.
+   */
   computeGradients<D extends DataType>(
       f: () => Scalar<D>,
       varList?: Variable[]): {value: Scalar<D>, gradients: NamedArrayMap} {
     return ENV.math.variableGradients(f, varList);
   }
 
+  /**
+   * Updates variables by using the computed gradients.
+   * @param variableGradients A mapping of variable name to its gradient value.
+   */
   abstract applyGradients(variableGradients: NamedArrayMap): void;
 
   /**

--- a/src/math/optimizers/optimizer.ts
+++ b/src/math/optimizers/optimizer.ts
@@ -22,8 +22,8 @@ import * as session_util from '../../graph/session_util';
 // tslint:disable-next-line:max-line-length
 import {SummedTensorArrayMap, TensorArrayMap} from '../../graph/tensor_array_map';
 import {NDArrayMath} from '../../math/math';
-import {DataType, NDArray, Scalar} from '../../math/ndarray';
-import {NamedVariableMap} from '../../util';
+import {DataType, NDArray, Scalar, Variable} from '../../math/ndarray';
+import {NamedArrayMap} from '../../util';
 
 export abstract class Optimizer {
   protected variableNodes: VariableNode[];
@@ -39,9 +39,10 @@ export abstract class Optimizer {
   /**
    * Eager mode methods.
    */
-  minimize<D extends DataType>(f: () => Scalar<D>, returnCost = false):
-      Scalar<D>|null {
-    const {value, gradients} = this.computeGradients(f);
+  minimize<D extends DataType>(
+      f: () => Scalar<D>, returnCost = false,
+      varList?: Variable[]): Scalar<D>|null {
+    const {value, gradients} = this.computeGradients(f, varList);
 
     this.applyGradients(gradients);
 
@@ -57,12 +58,13 @@ export abstract class Optimizer {
     }
   }
 
-  computeGradients<D extends DataType>(f: () => Scalar<D>):
-      {value: Scalar<D>, gradients: NamedVariableMap} {
-    return ENV.math.variableGradients(f);
+  computeGradients<D extends DataType>(
+      f: () => Scalar<D>,
+      varList?: Variable[]): {value: Scalar<D>, gradients: NamedArrayMap} {
+    return ENV.math.variableGradients(f, varList);
   }
 
-  abstract applyGradients(variableGradients: NamedVariableMap): void;
+  abstract applyGradients(variableGradients: NamedArrayMap): void;
 
   /**
    * Graph mode methods.

--- a/src/math/optimizers/optimizer_test.ts
+++ b/src/math/optimizers/optimizer_test.ts
@@ -1,0 +1,151 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+import {Scalar, variable, Variable} from '../../math/ndarray';
+import * as test_util from '../../test_util';
+import {MathTests} from '../../test_util';
+
+import {SGDOptimizer} from './sgd_optimizer';
+
+const tests: MathTests = it => {
+  it('basic', math => {
+    const learningRate = .1;
+    const optimizer = new SGDOptimizer(learningRate);
+
+    const x = variable(Scalar.new(4));
+    const bias = variable(Scalar.new(1));
+
+    let numArrays = math.getNumArrays();
+
+    let cost = optimizer.minimize(
+        () => math.add(math.square(x), bias), /* returnCost */ true);
+
+    // Cost should be the only additional array.
+    expect(math.getNumArrays()).toBe(numArrays + 1);
+
+    // de/dx = 2x
+    const expectedX1 = -2 * 4 * learningRate + 4;
+    test_util.expectArraysClose(x, [expectedX1]);
+    test_util.expectArraysClose(cost, [Math.pow(4, 2) + 1]);
+
+    cost.dispose();
+    numArrays = math.getNumArrays();
+
+    cost = optimizer.minimize(() => math.square(x), /* returnCost */ false);
+    // There should be no new additional NDArrays.
+    expect(math.getNumArrays()).toBe(numArrays);
+
+    const expectedX2 = -2 * expectedX1 * learningRate + expectedX1;
+    test_util.expectArraysClose(x, [expectedX2]);
+    expect(cost).toBe(null);
+
+    optimizer.dispose();
+    x.dispose();
+    // There should be no more NDArrays.
+    expect(math.getNumArrays()).toBe(0);
+  });
+
+  it('varList array of all variables', math => {
+    const learningRate = .1;
+    const optimizer = new SGDOptimizer(learningRate);
+
+    const x = variable(Scalar.new(4));
+    const bias = variable(Scalar.new(1));
+    const varList = [x];
+
+    let cost = optimizer.minimize(
+        () => math.add(math.square(x), bias), /* returnCost */ true, varList);
+
+    // de/dx = 2x
+    const expectedX1 = -2 * 4 * learningRate + 4;
+    test_util.expectArraysClose(x, [expectedX1]);
+    test_util.expectArraysClose(cost, [Math.pow(4, 2) + 1]);
+
+    cost = optimizer.minimize(
+        () => math.add(math.square(x), bias) as Scalar<'float32'>,
+        /* returnCost */ false, varList);
+
+    const expectedX2 = -2 * expectedX1 * learningRate + expectedX1;
+    test_util.expectArraysClose(x, [expectedX2]);
+    expect(cost).toBe(null);
+
+    optimizer.dispose();
+  });
+
+  it('varList empty array of variables to update updates nothing', math => {
+    const learningRate = .1;
+    const optimizer = new SGDOptimizer(learningRate);
+
+    const x = variable(Scalar.new(4));
+    const bias = variable(Scalar.new(1));
+    const varList: Variable[] = [];
+
+    let cost = optimizer.minimize(
+        () => math.square(x), /* returnCost */ true, varList);
+
+    // x should not have been updated.
+    test_util.expectArraysClose(x, [4]);
+    test_util.expectArraysClose(cost, [Math.pow(4, 2) + 1]);
+
+    cost = optimizer.minimize(
+        () => math.add(math.square(x), bias) as Scalar<'float32'>,
+        /* returnCost */ false, varList);
+
+    // x again should not have been updated.
+    test_util.expectArraysClose(x, [4]);
+    test_util.expectArraysClose(cost, [Math.pow(4, 2) + 1]);
+    expect(cost).toBe(null);
+
+    optimizer.dispose();
+  });
+
+  it('varList subset of variables update', math => {
+    const learningRate = .1;
+    const optimizer = new SGDOptimizer(learningRate);
+
+    const x = variable(Scalar.new(4));
+    const bias = variable(Scalar.new(1));
+    const varList = [x];
+
+    let cost = optimizer.minimize(
+        () => math.add(math.square(x), bias), /* returnCost */ true, varList);
+
+    // de/dx = 2x
+    const expectedValue1 = -2 * 4 * learningRate + 4;
+    test_util.expectArraysClose(x, [expectedValue1]);
+    // Bias should remain unchanged.
+    test_util.expectArraysClose(bias, [1]);
+    test_util.expectArraysClose(cost, [Math.pow(4, 2) + 1]);
+
+    cost = optimizer.minimize(
+        () => math.square(x), /* returnCost */ false, varList);
+
+    const expectedValue2 = -2 * expectedValue1 * learningRate + expectedValue1;
+    test_util.expectArraysClose(x, [expectedValue2]);
+    // Bias still should remain unchanged.
+    test_util.expectArraysClose(bias, [1]);
+    expect(cost).toBe(null);
+
+    optimizer.dispose();
+  });
+};
+
+test_util.describeMathCPU('Optimizer', [tests]);
+test_util.describeMathGPU('Optimizer', [tests], [
+  {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 1},
+  {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2},
+  {'WEBGL_FLOAT_TEXTURE_ENABLED': false, 'WEBGL_VERSION': 1}
+]);

--- a/src/math/optimizers/optimizer_test.ts
+++ b/src/math/optimizers/optimizer_test.ts
@@ -103,8 +103,6 @@ const tests: MathTests = it => {
     // The stray variable should remain unchanged.
     test_util.expectArraysClose(strayVariable, [-1]);
     expect(cost).toBe(null);
-
-    optimizer.dispose();
   });
 
   it('varList empty array of variables to update updates nothing', math => {
@@ -137,8 +135,6 @@ const tests: MathTests = it => {
     // The stray variable should remain unchanged.
     test_util.expectArraysClose(strayVariable, [-1]);
     expect(cost).toBe(null);
-
-    optimizer.dispose();
   });
 
   it('varList subset of variables update', math => {
@@ -172,8 +168,6 @@ const tests: MathTests = it => {
     expect(cost).toBe(null);
     // The stray variable should remain unchanged.
     test_util.expectArraysClose(strayVariable, [-1]);
-
-    optimizer.dispose();
   });
 
   it('only bias trainable', math => {
@@ -207,8 +201,6 @@ const tests: MathTests = it => {
     expect(cost).toBe(null);
     // The stray variable should remain unchanged.
     test_util.expectArraysClose(strayVariable, [-1]);
-
-    optimizer.dispose();
   });
 
   it('only bias trainable, only x in varList does nothing', math => {
@@ -242,8 +234,6 @@ const tests: MathTests = it => {
     expect(cost).toBe(null);
     // The stray variable should remain unchanged.
     test_util.expectArraysClose(strayVariable, [-1]);
-
-    optimizer.dispose();
   });
 };
 

--- a/src/math/optimizers/sgd_optimizer.ts
+++ b/src/math/optimizers/sgd_optimizer.ts
@@ -21,7 +21,7 @@ import {SessionRuntime} from '../../graph/session';
 // tslint:disable-next-line:max-line-length
 import {SummedTensorArrayMap, TensorArrayMap} from '../../graph/tensor_array_map';
 import {NDArrayMath} from '../../math/math';
-import {NamedVariableMap} from '../../util';
+import {NamedArrayMap} from '../../util';
 import {Scalar} from '../ndarray';
 
 import {Optimizer} from './optimizer';
@@ -35,7 +35,7 @@ export class SGDOptimizer extends Optimizer {
   }
 
   // Eager mode
-  applyGradients(variableGradients: NamedVariableMap) {
+  applyGradients(variableGradients: NamedArrayMap) {
     const math = ENV.math;
 
     const varNames = Object.keys(variableGradients);

--- a/src/util.ts
+++ b/src/util.ts
@@ -22,8 +22,8 @@ export type FlatVector = boolean[]|number[]|TypedArray;
 export type RegularArray<T> = T[]|T[][]|T[][][]|T[][][][];
 export type ArrayData = TypedArray|RegularArray<number>|RegularArray<boolean>;
 
-export type NamedArrayMap = {
-  [name: string]: NDArray
+export type NamedArrayMap<D extends DataType = DataType> = {
+  [name: string]: NDArray<D>
 };
 
 export type NamedVariableMap = {


### PR DESCRIPTION
This PR:
* Adds varList as an argument to minimize to choose a subset of variables to minimize.
* Allows stray variables that aren't used in the minimize function closure without complaining.
* Makes optimizers not update non-trainable variables.
* Simplifies Node typings to have a single interface definition.
* Updates dy typings to always be float32.

This fixes https://github.com/PAIR-code/deeplearnjs/issues/537

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/566)
<!-- Reviewable:end -->
