### PR TITLE
Export ops to global namespace and decouple them from NDArrayMath

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -17,7 +17,6 @@
 
 import * as device_util from './device_util';
 import {MathBackend} from './math/backends/backend';
-import {BackendEngine} from './math/backends/backend_engine';
 import {NDArrayMath} from './math/math';
 import * as util from './util';
 
@@ -167,8 +166,6 @@ export class Environment {
   private BACKEND_REGISTRY: {[id in BackendType]: MathBackend} = {} as any;
   private backends: {[id in BackendType]: MathBackend} = this.BACKEND_REGISTRY;
 
-  engine: BackendEngine;
-
   constructor(features?: Features) {
     if (features != null) {
       this.features = features;
@@ -237,7 +234,6 @@ export class Environment {
     if (this.globalMath != null) {
       this.globalMath.dispose();
       this.globalMath = null;
-      this.engine = null;
     }
     if (this.backends !== this.BACKEND_REGISTRY) {
       for (const name in this.backends) {
@@ -249,7 +245,6 @@ export class Environment {
 
   setMath(math: NDArrayMath) {
     this.globalMath = math;
-    this.engine = math.backendEngine;
   }
 
   getBackend(name: BackendType): MathBackend {

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -17,6 +17,7 @@
 
 import * as device_util from './device_util';
 import {MathBackend} from './math/backends/backend';
+import {BackendEngine} from './math/backends/backend_engine';
 import {NDArrayMath} from './math/math';
 import * as util from './util';
 
@@ -301,6 +302,10 @@ export class Environment {
       this.setMath(new NDArrayMath(bestBackend, safeMode));
     }
     return this.globalMath;
+  }
+
+  get engine(): BackendEngine {
+    return this.globalMath.engine;
   }
 }
 

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -163,9 +163,8 @@ export type BackendType = 'webgl'|'cpu';
 export class Environment {
   private features: Features = {};
   private globalMath: NDArrayMath = null;
-  // tslint:disable-next-line:no-any
-  private BACKEND_REGISTRY: {[id in BackendType]: MathBackend} = {} as any;
-  private backends: {[id in BackendType]: MathBackend} = this.BACKEND_REGISTRY;
+  private BACKEND_REGISTRY: {[id: string]: MathBackend} = {};
+  private backends: {[id: string]: MathBackend} = this.BACKEND_REGISTRY;
 
   constructor(features?: Features) {
     if (features != null) {
@@ -226,8 +225,7 @@ export class Environment {
   setFeatures(features: Features) {
     this.reset();
     this.features = features;
-    // tslint:disable-next-line:no-any
-    this.backends = {} as any;
+    this.backends = {};
   }
 
   reset() {
@@ -238,7 +236,7 @@ export class Environment {
     }
     if (this.backends !== this.BACKEND_REGISTRY) {
       for (const name in this.backends) {
-        this.backends[name as BackendType].dispose();
+        this.backends[name].dispose();
       }
       this.backends = this.BACKEND_REGISTRY;
     }

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -17,6 +17,7 @@
 
 import * as device_util from './device_util';
 import {MathBackend} from './math/backends/backend';
+import {BackendEngine} from './math/backends/backend_engine';
 import {NDArrayMath} from './math/math';
 import * as util from './util';
 
@@ -163,8 +164,10 @@ export class Environment {
   private features: Features = {};
   private globalMath: NDArrayMath = null;
   // tslint:disable-next-line:no-any
-  private backendRegistry: {[id in BackendType]: MathBackend} = {} as any;
-  private prevBackendRegistry: {[id in BackendType]: MathBackend} = null;
+  private BACKEND_REGISTRY: {[id in BackendType]: MathBackend} = {} as any;
+  private backends: {[id in BackendType]: MathBackend} = this.BACKEND_REGISTRY;
+
+  engine: BackendEngine;
 
   constructor(features?: Features) {
     if (features != null) {
@@ -186,8 +189,8 @@ export class Environment {
     const orderedBackends: BackendType[] = ['webgl', 'cpu'];
     for (let i = 0; i < orderedBackends.length; ++i) {
       const backendId = orderedBackends[i];
-      if (backendId in this.backendRegistry) {
-        return this.backendRegistry[backendId];
+      if (backendId in this.backends) {
+        return this.backends[backendId];
       }
     }
     throw new Error('No backend found in registry.');
@@ -223,8 +226,10 @@ export class Environment {
   }
 
   setFeatures(features: Features) {
-    this.empty();
+    this.reset();
     this.features = features;
+    // tslint:disable-next-line:no-any
+    this.backends = {} as any;
   }
 
   reset() {
@@ -232,38 +237,62 @@ export class Environment {
     if (this.globalMath != null) {
       this.globalMath.dispose();
       this.globalMath = null;
+      this.engine = null;
     }
-    if (this.prevBackendRegistry != null) {
-      for (const name in this.backendRegistry) {
-        this.backendRegistry[name as BackendType].dispose();
+    if (this.backends !== this.BACKEND_REGISTRY) {
+      for (const name in this.backends) {
+        this.backends[name as BackendType].dispose();
       }
-      this.backendRegistry = this.prevBackendRegistry;
-      this.prevBackendRegistry = null;
+      this.backends = this.BACKEND_REGISTRY;
     }
   }
 
   setMath(math: NDArrayMath) {
     this.globalMath = math;
+    this.engine = math.backendEngine;
   }
 
   getBackend(name: BackendType): MathBackend {
-    return this.backendRegistry[name];
+    return this.backends[name];
   }
 
   /**
-   * Registers the backend to the global environment.
+   * Adds a custom backend. Usually used in tests to simulate different
+   * environments.
+   *
+   * @param factory: The backend factory function. When called, it should return
+   *     an instance of the backend.
+   * @return False if the creation/registration failed. True otherwise.
+   */
+  addCustomBackend(name: BackendType, factory: () => MathBackend): boolean {
+    if (name in this.backends) {
+      throw new Error(`${name} backend was already registered`);
+    }
+    try {
+      const backend = factory();
+      this.backends[name] = backend;
+      return true;
+    } catch (err) {
+      return false;
+    }
+  }
+
+  /**
+   * Registers a global backend. The registration should happen when importing
+   * a module file (e.g. when importing `backend_webgl.ts`), and is used for
+   * modular builds (e.g. custom deeplearn.js bundle with only webgl support).
    *
    * @param factory: The backend factory function. When called, it should return
    *     an instance of the backend.
    * @return False if the creation/registration failed. True otherwise.
    */
   registerBackend(name: BackendType, factory: () => MathBackend): boolean {
-    if (name in this.backendRegistry) {
-      throw new Error(`${name} backend was already registered`);
+    if (name in this.BACKEND_REGISTRY) {
+      throw new Error(`${name} backend was already registered as global`);
     }
     try {
       const backend = factory();
-      this.backendRegistry[name] = backend;
+      this.BACKEND_REGISTRY[name] = backend;
       return true;
     } catch (err) {
       return false;
@@ -274,17 +303,9 @@ export class Environment {
     if (this.globalMath == null) {
       const bestBackend = this.getBestBackend();
       const safeMode = false;
-      this.globalMath = new NDArrayMath(bestBackend, safeMode);
+      this.setMath(new NDArrayMath(bestBackend, safeMode));
     }
     return this.globalMath;
-  }
-
-  private empty() {
-    this.globalMath = null;
-    this.prevBackendRegistry = this.backendRegistry;
-    // tslint:disable-next-line:no-any
-    this.backendRegistry = {} as any;
-    this.features = null;
   }
 }
 

--- a/src/environment_test.ts
+++ b/src/environment_test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  * =============================================================================
  */
+
 import * as device_util from './device_util';
 import {ENV, Environment, Features} from './environment';
 import {MathBackend} from './math/backends/backend';
@@ -231,7 +232,7 @@ describe('Backend', () => {
     ENV.setFeatures(features);
 
     let backend: MathBackend;
-    ENV.registerBackend('webgl', () => {
+    ENV.addCustomBackend('webgl', () => {
       backend = new MathBackendWebGL();
       return backend;
     });
@@ -242,19 +243,17 @@ describe('Backend', () => {
 
   it('double registration fails', () => {
     ENV.setFeatures({'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2});
-    ENV.registerBackend('webgl', () => new MathBackendWebGL());
-    expect(() => ENV.registerBackend('webgl', () => new MathBackendWebGL()))
+    ENV.addCustomBackend('webgl', () => new MathBackendWebGL());
+    expect(() => ENV.addCustomBackend('webgl', () => new MathBackendWebGL()))
         .toThrowError();
-    ENV.reset();
   });
 
   it('webgl not supported, falls back to cpu', () => {
     ENV.setFeatures({'WEBGL_VERSION': 0});
-    ENV.registerBackend('cpu', () => new MathBackendCPU());
-    const success = ENV.registerBackend('webgl', () => new MathBackendWebGL());
+    ENV.addCustomBackend('cpu', () => new MathBackendCPU());
+    const success = ENV.addCustomBackend('webgl', () => new MathBackendWebGL());
     expect(success).toBe(false);
     expect(ENV.getBackend('webgl') == null).toBe(true);
     expect(ENV.getBestBackend()).toBe(ENV.getBackend('cpu'));
-    ENV.reset();
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ export {MatrixOrientation} from './math/backends/types/matmul';
 export {GPGPUContext} from './math/backends/webgl/gpgpu_context';
 // tslint:disable-next-line:max-line-length
 export {LSTMCell, NDArrayMath} from './math/math';
+export {matMul} from './math/matmul';
 // tslint:disable-next-line:max-line-length
 export {Array1D, Array2D, Array3D, Array4D, NDArray, Scalar} from './math/ndarray';
 export {variable, Variable} from './math/ndarray';

--- a/src/math/backends/backend_webgl.ts
+++ b/src/math/backends/backend_webgl.ts
@@ -998,13 +998,11 @@ export class NDArrayMathGPU extends NDArrayMath {
   }
 
   getGPGPUContext(): GPGPUContext {
-    return (this.backendEngine.getBackend() as MathBackendWebGL)
-        .getGPGPUContext();
+    return (this.engine.getBackend() as MathBackendWebGL).getGPGPUContext();
   }
 
   getTextureManager(): TextureManager {
-    return (this.backendEngine.getBackend() as MathBackendWebGL)
-        .getTextureManager();
+    return (this.engine.getBackend() as MathBackendWebGL).getTextureManager();
   }
 }
 

--- a/src/math/backends/backend_webgl.ts
+++ b/src/math/backends/backend_webgl.ts
@@ -41,6 +41,7 @@ import {Conv2DDerBiasProgram, Conv2DDerFilterProgram, Conv2DDerInputProgram} fro
 import {Conv2DProgram} from './webgl/conv_gpu';
 import {DepthwiseConv2DProgram} from './webgl/conv_gpu_depthwise';
 import {Copy2DProgram} from './webgl/copy_gpu';
+import {GatherProgram} from './webgl/gather_gpu';
 import {GPGPUContext} from './webgl/gpgpu_context';
 import * as gpgpu_math from './webgl/gpgpu_math';
 import {ArrayData, GPGPUBinary, GPGPUProgram} from './webgl/gpgpu_math';
@@ -60,7 +61,6 @@ import {TextureData, TextureType} from './webgl/tex_util';
 import {TextureManager} from './webgl/texture_manager';
 import {TileProgram} from './webgl/tile_gpu';
 import {TransposeProgram} from './webgl/transpose_gpu';
-import {GatherProgram} from './webgl/gather_gpu';
 import * as unary_op from './webgl/unaryop_gpu';
 import {UnaryOpProgram} from './webgl/unaryop_gpu';
 import * as webgl_util from './webgl/webgl_util';

--- a/src/math/matmul.ts
+++ b/src/math/matmul.ts
@@ -51,7 +51,7 @@ export function matMul(
           `${b.shape} and orientations ${MatrixOrientation[aOrientation]}` +
           ` and ${MatrixOrientation[bOrientation]} must match.`);
 
-  return ENV.math.engine.executeKernel(
+  return ENV.engine.executeKernel(
       'MatMul', {inputs: {a, b}, args: {aOrientation, bOrientation}},
       (dy: Array2D<'float32'>, y: Array2D) => {
         if (aOrientation === MatrixOrientation.TRANSPOSED ||

--- a/src/math/matmul.ts
+++ b/src/math/matmul.ts
@@ -61,9 +61,11 @@ export function matMul(
         }
         return {
           a: () => matMul(
-              dy, b, MatrixOrientation.REGULAR, MatrixOrientation.TRANSPOSED),
+                       dy, b, MatrixOrientation.REGULAR,
+                       MatrixOrientation.TRANSPOSED) as Array2D<'float32'>,
           b: () => matMul(
-              a, dy, MatrixOrientation.TRANSPOSED, MatrixOrientation.REGULAR)
+                       a, dy, MatrixOrientation.TRANSPOSED,
+                       MatrixOrientation.REGULAR) as Array2D<'float32'>
         };
       });
 }

--- a/src/math/matmul.ts
+++ b/src/math/matmul.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {ENV} from '../environment';
+import * as util from '../util';
+import {MatrixOrientation} from './backends/types/matmul';
+import {Array2D} from './ndarray';
+
+/**
+ * Computes the dot product of two matrices, A * B. These must be matrices,
+ * use matrixTimesVector and vectorTimesMatrix, dotProduct, and outerProduct
+ * in other cases.
+ * @param a First matrix in dot product operation.
+ * @param b Second matrix in dot product operation.
+ * @param aOrientation The MatrixOrientation of A. If using TRANSPOSED, will
+ * compute A^T * B.
+ * @param bOrientation The MatrixOrientation of B. If using TRANSPOSED, will
+ * compute A * B^T.
+ */
+export function matMul(
+    a: Array2D, b: Array2D, aOrientation = MatrixOrientation.REGULAR,
+    bOrientation = MatrixOrientation.REGULAR): Array2D {
+  const innerShapeA =
+      (aOrientation === MatrixOrientation.REGULAR) ? a.shape[1] : a.shape[0];
+  const innerShapeB =
+      (bOrientation === MatrixOrientation.REGULAR) ? b.shape[0] : b.shape[1];
+
+  util.assert(
+      a.rank === 2 && b.rank === 2,
+      `Error in matMul: inputs must be rank 2, got ranks ${a.rank}` +
+          ` and ${b.rank}.`);
+
+  util.assert(
+      innerShapeA === innerShapeB,
+      `Error in matMul: inner shapes (${innerShapeA}) and (` +
+          `${innerShapeB}) of NDArrays with shapes ${a.shape} and ` +
+          `${b.shape} and orientations ${MatrixOrientation[aOrientation]}` +
+          ` and ${MatrixOrientation[bOrientation]} must match.`);
+
+  return ENV.engine.executeKernel(
+      'MatMul', {inputs: {a, b}, args: {aOrientation, bOrientation}},
+      (dy: Array2D<'float32'>, y: Array2D) => {
+        if (aOrientation === MatrixOrientation.TRANSPOSED ||
+            bOrientation === MatrixOrientation.TRANSPOSED) {
+          throw new Error(
+              `Backprop for transposed MatMul not yet implemented.`);
+        }
+        return {
+          a: () => matMul(
+              dy, b, MatrixOrientation.REGULAR, MatrixOrientation.TRANSPOSED),
+          b: () => matMul(
+              a, dy, MatrixOrientation.TRANSPOSED, MatrixOrientation.REGULAR)
+        };
+      });
+}

--- a/src/math/matmul.ts
+++ b/src/math/matmul.ts
@@ -51,7 +51,7 @@ export function matMul(
           `${b.shape} and orientations ${MatrixOrientation[aOrientation]}` +
           ` and ${MatrixOrientation[bOrientation]} must match.`);
 
-  return ENV.engine.executeKernel(
+  return ENV.math.engine.executeKernel(
       'MatMul', {inputs: {a, b}, args: {aOrientation, bOrientation}},
       (dy: Array2D<'float32'>, y: Array2D) => {
         if (aOrientation === MatrixOrientation.TRANSPOSED ||

--- a/src/test_util.ts
+++ b/src/test_util.ts
@@ -380,8 +380,8 @@ function executeTests(
     beforeEach(() => {
       if (features != null) {
         ENV.setFeatures(features);
-        ENV.registerBackend('webgl', () => new MathBackendWebGL());
-        ENV.registerBackend('cpu', () => new MathBackendCPU());
+        ENV.addCustomBackend('webgl', () => new MathBackendWebGL());
+        ENV.addCustomBackend('cpu', () => new MathBackendCPU());
       }
 
       if (customBeforeEach != null) {


### PR DESCRIPTION
This PR is the first of a chain of PRs that export ops to the global `dl` namespace. It starts by moving `matMul` outside of NDArrayMath and exporting it to the `dl` namespace. Standalone `matMul` now uses `ENV.math.engine` to execute a kernel.

Details:
- We are staying backwards compatible.
- The signature and the jsdoc of `matMul` lives in only one place (`matmul.ts`)
- This allows breakdown of ops in different files, which will significantly reduce `math.ts` (3180 lines).
- Removed `NDArray.math`. All `NDArray`s now use `ENV.math` (users shouldn't make ndarrays with custom maths, thus foresee no problems with breaking existing users)
- Renamed `math.backendEngine` to `math.engine`. This makes `ENV.math.engine` shorter, which will be used by almost all standalone ops.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/572)
<!-- Reviewable:end -->
