### PR TITLE
Add @operation decorator and migrate more math ops

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -364,18 +364,4 @@ function getOrMakeEnvironment(): Environment {
   return ns.ENV;
 }
 
-/**
- * Decorator for wrapping functions that perform math operations on
- * NDArrays. The function will be wrapped in a named scope that cleans all
- * memory usage after the function is done.
- */
-export function operation(
-    target: {}, name: string, descriptor: PropertyDescriptor) {
-  const fn = descriptor.value;
-  // tslint:disable-next-line:no-any
-  descriptor.value = (...args: any[]) =>
-      ENV.math.scope(name, () => fn(...args));
-  return descriptor;
-}
-
 export let ENV = getOrMakeEnvironment();

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -364,4 +364,18 @@ function getOrMakeEnvironment(): Environment {
   return ns.ENV;
 }
 
+/**
+ * Decorator for wrapping functions that perform math operations on
+ * NDArrays. The function will be wrapped in a named scope that cleans all
+ * memory usage after the function is done.
+ */
+export function operation(
+    target: {}, name: string, descriptor: PropertyDescriptor) {
+  const fn = descriptor.value;
+  // tslint:disable-next-line:no-any
+  descriptor.value = (...args: any[]) =>
+      ENV.math.scope(name, () => fn(...args));
+  return descriptor;
+}
+
 export let ENV = getOrMakeEnvironment();

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,16 +21,15 @@ import * as gpgpu_util from './math/backends/webgl/gpgpu_util';
 // tslint:disable-next-line:max-line-length
 import * as render_ndarray_gpu_util from './math/backends/webgl/render_ndarray_gpu_util';
 import * as webgl_util from './math/backends/webgl/webgl_util';
-// tslint:disable-next-line:max-line-length
-import {batchNormalization2D, batchNormalization3D, batchNormalization4D} from './math/batchnorm';
-import {concat1D, concat2D, concat3D, concat4D} from './math/concat';
-import {conv1d, conv2d, conv2dTranspose, depthwiseConv2D} from './math/conv';
+import * as batchnorm from './math/batchnorm';
+import * as concat from './math/concat';
+import * as conv from './math/conv';
 import * as conv_util from './math/conv_util';
 // tslint:disable-next-line:max-line-length
-import {dotProduct, matMul, matrixTimesVector, outerProduct, vectorTimesMatrix} from './math/matmul';
-import {avgPool, maxPool, minPool} from './math/pool';
-import {reverse1D, reverse2D, reverse3D, reverse4D} from './math/reverse';
-import {slice1D, slice2D, slice3D, slice4D} from './math/slice';
+import * as matmul from './math/matmul';
+import * as pool from './math/pool';
+import * as reverse from './math/reverse';
+import * as slice from './math/slice';
 import * as test_util from './test_util';
 import * as util from './util';
 import {version} from './version';
@@ -78,32 +77,36 @@ export {
 };
 
 // Math methods.
-export {
-  avgPool,
-  batchNormalization2D,
-  batchNormalization3D,
-  batchNormalization4D,
-  concat1D,
-  concat2D,
-  concat3D,
-  concat4D,
-  conv1d,
-  conv2d,
-  conv2dTranspose,
-  depthwiseConv2D,
-  dotProduct,
-  matMul,
-  matrixTimesVector,
-  maxPool,
-  minPool,
-  outerProduct,
-  reverse1D,
-  reverse2D,
-  reverse3D,
-  reverse4D,
-  slice1D,
-  slice2D,
-  slice3D,
-  slice4D,
-  vectorTimesMatrix
-};
+export const batchNormalization2D = batchnorm.Ops.batchNormalization2D;
+export const batchNormalization3D = batchnorm.Ops.batchNormalization3D;
+export const batchNormalization4D = batchnorm.Ops.batchNormalization4D;
+
+export const concat1D = concat.Ops.concat1D;
+export const concat2D = concat.Ops.concat2D;
+export const concat3D = concat.Ops.concat3D;
+export const concat4D = concat.Ops.concat4D;
+
+export const conv1d = conv.Ops.conv1d;
+export const conv2d = conv.Ops.conv2d;
+export const conv2dTranspose = conv.Ops.conv2dTranspose;
+export const depthwiseConv2D = conv.Ops.depthwiseConv2D;
+
+export const dotProduct = matmul.Ops.dotProduct;
+export const matMul = matmul.Ops.matMul;
+export const matrixTimesVector = matmul.Ops.matrixTimesVector;
+export const outerProduct = matmul.Ops.outerProduct;
+export const vectorTimesMatrix = matmul.Ops.vectorTimesMatrix;
+
+export const avgPool = pool.Ops.avgPool;
+export const maxPool = pool.Ops.maxPool;
+export const minPool = pool.Ops.minPool;
+
+export const reverse1D = reverse.Ops.reverse1D;
+export const reverse2D = reverse.Ops.reverse2D;
+export const reverse3D = reverse.Ops.reverse3D;
+export const reverse4D = reverse.Ops.reverse4D;
+
+export const slice1D = slice.Ops.slice1D;
+export const slice2D = slice.Ops.slice2D;
+export const slice3D = slice.Ops.slice3D;
+export const slice4D = slice.Ops.slice4D;

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,14 +22,17 @@ import * as gpgpu_util from './math/backends/webgl/gpgpu_util';
 import * as render_ndarray_gpu_util from './math/backends/webgl/render_ndarray_gpu_util';
 import * as webgl_util from './math/backends/webgl/webgl_util';
 import * as batchnorm from './math/batchnorm';
+import * as compare from './math/compare';
 import * as concat from './math/concat';
 import * as conv from './math/conv';
 import * as conv_util from './math/conv_util';
 // tslint:disable-next-line:max-line-length
 import * as matmul from './math/matmul';
+import * as minmax from './math/minmax';
 import * as pool from './math/pool';
 import * as reverse from './math/reverse';
 import * as slice from './math/slice';
+import * as transpose from './math/transpose';
 import * as test_util from './test_util';
 import * as util from './util';
 import {version} from './version';
@@ -63,7 +66,6 @@ export {Optimizer} from './math/optimizers/optimizer';
 export {SGDOptimizer} from './math/optimizers/sgd_optimizer';
 export {Model} from './model';
 export {version};
-
 // Second level exports.
 export {
   conv_util,
@@ -101,6 +103,8 @@ export const avgPool = pool.Ops.avgPool;
 export const maxPool = pool.Ops.maxPool;
 export const minPool = pool.Ops.minPool;
 
+export const transpose = transpose.Ops.transpose;
+
 export const reverse1D = reverse.Ops.reverse1D;
 export const reverse2D = reverse.Ops.reverse2D;
 export const reverse3D = reverse.Ops.reverse3D;
@@ -110,3 +114,20 @@ export const slice1D = slice.Ops.slice1D;
 export const slice2D = slice.Ops.slice2D;
 export const slice3D = slice.Ops.slice3D;
 export const slice4D = slice.Ops.slice4D;
+
+export const min = minmax.Ops.min;
+export const max = minmax.Ops.max;
+export const minimum = minmax.Ops.minimum;
+export const maximum = minmax.Ops.maximum;
+export const argMax = minmax.Ops.argMax;
+export const argMin = minmax.Ops.argMin;
+export const argMaxEquals = minmax.Ops.argMaxEquals;
+
+export const equal = compare.Ops.equal;
+export const equalStrict = compare.Ops.equalStrict;
+export const greater = compare.Ops.greater;
+export const greaterEqual = compare.Ops.greaterEqual;
+export const less = compare.Ops.less;
+export const lessEqual = compare.Ops.lessEqual;
+export const notEqual = compare.Ops.notEqual;
+export const notEqualStrict = compare.Ops.notEqualStrict;

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ import * as minmax from './math/minmax';
 import * as pool from './math/pool';
 import * as reverse from './math/reverse';
 import * as slice from './math/slice';
-import * as transpose from './math/transpose';
+import {Ops as TranposeOps} from './math/transpose';
 import * as test_util from './test_util';
 import * as util from './util';
 import {version} from './version';
@@ -103,7 +103,7 @@ export const avgPool = pool.Ops.avgPool;
 export const maxPool = pool.Ops.maxPool;
 export const minPool = pool.Ops.minPool;
 
-export const transpose = transpose.Ops.transpose;
+export const transpose = TranposeOps.transpose;
 
 export const reverse1D = reverse.Ops.reverse1D;
 export const reverse2D = reverse.Ops.reverse2D;

--- a/src/math/batchnorm.ts
+++ b/src/math/batchnorm.ts
@@ -15,27 +15,28 @@
  * =============================================================================
  */
 
-import {ENV} from '../environment';
+import {ENV, operation} from '../environment';
 import * as util from '../util';
 import {Array1D, Array2D, Array3D, Array4D} from './ndarray';
 
-/**
- * Batch normalization 2D. Mean, variance, scale, and offset can be of two
- * shapes: 1) The same shape as the input: an Array2D. 2) In the common
- * case, the depth dimension is the last dimension of x, so the values would
- * be an Array1D of shape [depth].
- * @param x The input NDArray.
- * @param mean A mean NDArray.
- * @param variance A variance NDArray.
- * @param varianceEpsilon A small float number to avoid dividing by 0.
- * @param scale A scale NDArray.
- * @param offset An offset NDArray.
- */
-export function batchNormalization2D(
-    x: Array2D, mean: Array2D|Array1D, variance: Array2D|Array1D,
-    varianceEpsilon = .001, scale?: Array2D|Array1D,
-    offset?: Array2D|Array1D): Array2D {
-  return ENV.math.scope('batchNorm2D', () => {
+export class Ops {
+  /**
+   * Batch normalization 2D. Mean, variance, scale, and offset can be of two
+   * shapes: 1) The same shape as the input: an Array2D. 2) In the common
+   * case, the depth dimension is the last dimension of x, so the values would
+   * be an Array1D of shape [depth].
+   * @param x The input NDArray.
+   * @param mean A mean NDArray.
+   * @param variance A variance NDArray.
+   * @param varianceEpsilon A small float number to avoid dividing by 0.
+   * @param scale A scale NDArray.
+   * @param offset An offset NDArray.
+   */
+  @operation
+  static batchNormalization2D(
+      x: Array2D, mean: Array2D|Array1D, variance: Array2D|Array1D,
+      varianceEpsilon = .001, scale?: Array2D|Array1D,
+      offset?: Array2D|Array1D): Array2D {
     util.assert(
         x.rank === 2,
         `Error in batchNormalization3D: x must be rank 3 but got rank ` +
@@ -64,26 +65,25 @@ export function batchNormalization2D(
     return ENV.engine.executeKernel(
         'BatchNorm2D',
         {inputs: {x, mean, variance, scale, offset}, args: {varianceEpsilon}});
-  });
-}
+  }
 
-/**
- * Batch normalization 3D. Mean, variance, scale, and offset can be of two
- * shapes: 1) The same shape as the input: an Array3D. 2) In the common
- * case, the depth dimension is the last dimension of x, so the values would
- * be an Array1D of shape [depth].
- * @param x The input NDArray.
- * @param mean A mean NDArray.
- * @param variance A variance NDArray.
- * @param varianceEpsilon A small float number to avoid dividing by 0.
- * @param scale A scale NDArray.
- * @param offset An offset NDArray.
- */
-export function batchNormalization3D(
-    x: Array3D, mean: Array3D|Array1D, variance: Array3D|Array1D,
-    varianceEpsilon = .001, scale?: Array3D|Array1D,
-    offset?: Array3D|Array1D): Array3D {
-  return ENV.math.scope('batchNorm3D', () => {
+  /**
+   * Batch normalization 3D. Mean, variance, scale, and offset can be of two
+   * shapes: 1) The same shape as the input: an Array3D. 2) In the common
+   * case, the depth dimension is the last dimension of x, so the values would
+   * be an Array1D of shape [depth].
+   * @param x The input NDArray.
+   * @param mean A mean NDArray.
+   * @param variance A variance NDArray.
+   * @param varianceEpsilon A small float number to avoid dividing by 0.
+   * @param scale A scale NDArray.
+   * @param offset An offset NDArray.
+   */
+  @operation
+  static batchNormalization3D(
+      x: Array3D, mean: Array3D|Array1D, variance: Array3D|Array1D,
+      varianceEpsilon = .001, scale?: Array3D|Array1D,
+      offset?: Array3D|Array1D): Array3D {
     util.assert(
         x.rank === 3,
         `Error in batchNormalization3D: x must be rank 3 but got rank ` +
@@ -112,26 +112,25 @@ export function batchNormalization3D(
     return ENV.engine.executeKernel(
         'BatchNorm3D',
         {inputs: {x, mean, variance, scale, offset}, args: {varianceEpsilon}});
-  });
-}
+  }
 
-/**
- * Batch normalization 4D. Mean, variance, scale, and offset can be of two
- * shapes: 1) The same shape as the input: an Array4D. 2) In the common
- * case, the depth dimension is the last dimension of x, so the values would
- * be an Array1D of shape [depth].
- * @param x The input NDArray.
- * @param mean A mean NDArray.
- * @param variance A variance NDArray.
- * @param varianceEpsilon A small float number to avoid dividing by 0.
- * @param scale A scale NDArray.
- * @param offset An offset NDArray.
- */
-export function batchNormalization4D(
-    x: Array4D, mean: Array4D|Array1D, variance: Array4D|Array1D,
-    varianceEpsilon = .001, scale?: Array4D|Array1D,
-    offset?: Array4D|Array1D): Array4D {
-  return ENV.math.scope('batchNorm4D', () => {
+  /**
+   * Batch normalization 4D. Mean, variance, scale, and offset can be of two
+   * shapes: 1) The same shape as the input: an Array4D. 2) In the common
+   * case, the depth dimension is the last dimension of x, so the values would
+   * be an Array1D of shape [depth].
+   * @param x The input NDArray.
+   * @param mean A mean NDArray.
+   * @param variance A variance NDArray.
+   * @param varianceEpsilon A small float number to avoid dividing by 0.
+   * @param scale A scale NDArray.
+   * @param offset An offset NDArray.
+   */
+  @operation
+  static batchNormalization4D(
+      x: Array4D, mean: Array4D|Array1D, variance: Array4D|Array1D,
+      varianceEpsilon = .001, scale?: Array4D|Array1D,
+      offset?: Array4D|Array1D): Array4D {
     util.assert(
         x.rank === 4,
         `Error in batchNormalization4D: x must be rank 4 but got rank ` +
@@ -160,5 +159,5 @@ export function batchNormalization4D(
     return ENV.engine.executeKernel(
         'BatchNorm4D',
         {inputs: {x, mean, variance, scale, offset}, args: {varianceEpsilon}});
-  });
+  }
 }

--- a/src/math/batchnorm.ts
+++ b/src/math/batchnorm.ts
@@ -15,8 +15,9 @@
  * =============================================================================
  */
 
-import {ENV, operation} from '../environment';
+import {ENV} from '../environment';
 import * as util from '../util';
+import {operation} from './decorators';
 import {Array1D, Array2D, Array3D, Array4D} from './ndarray';
 
 export class Ops {

--- a/src/math/compare.ts
+++ b/src/math/compare.ts
@@ -15,9 +15,10 @@
  * =============================================================================
  */
 
-import {ENV, operation} from '../environment';
+import {ENV} from '../environment';
 import * as util from '../util';
 import * as broadcast_util from './broadcast_util';
+import {operation} from './decorators';
 import {DataType, NDArray, Rank, RankMap} from './ndarray';
 
 export class Ops {

--- a/src/math/compare.ts
+++ b/src/math/compare.ts
@@ -1,0 +1,122 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {ENV, operation} from '../environment';
+import * as util from '../util';
+import * as broadcast_util from './broadcast_util';
+import {DataType, NDArray, Rank, RankMap} from './ndarray';
+
+export class Ops {
+  /**
+   * Returns the truth value of (a != b) element-wise. Supports broadcasting.
+   * For a stricter version without broadcasting use math.notEqualStrict().
+   *
+   * @param a The first input `NDArray`.
+   * @param b The second input `NDArray`. Must have the same dtype as `a`.
+   */
+  @operation
+  static notEqual<D1 extends DataType, D2 extends D1, T extends
+                      NDArray<'bool'>>(a: NDArray<D1>, b: NDArray<D2>): T {
+    util.assertTypesMatch(a, b);
+    broadcast_util.assertAndGetBroadcastShape(a.shape, b.shape);
+    return ENV.engine.executeKernel('NotEqual', {inputs: {a, b}}) as T;
+  }
+
+  @operation
+  static notEqualStrict<R extends Rank, D1 extends DataType, D2 extends D1>(
+      a: NDArray<D1, R>, b: NDArray<D2, R>): RankMap<'bool'>[R] {
+    util.assertShapesMatch(a.shape, b.shape, 'Error in notEqualStrict: ');
+    return this.notEqual(a, b);
+  }
+
+  /**
+   * Returns the truth value of (a < b) element-wise. Supports broadcasting.
+   *
+   * @param a The first input `NDArray`.
+   * @param b The second input `NDArray`. Must have the same dtype as `a`.
+   */
+  @operation
+  static less<D1 extends DataType, D2 extends D1, T extends NDArray<'bool'>>(
+      a: NDArray<D1>, b: NDArray<D2>): T {
+    util.assertTypesMatch(a, b);
+    broadcast_util.assertAndGetBroadcastShape(a.shape, b.shape);
+    return ENV.engine.executeKernel('Less', {inputs: {a, b}}) as T;
+  }
+
+  /**
+   * Returns the truth value of (a == b) element-wise. Supports broadcasting.
+   * For a stricter version without broadcasting use math.equalStrict().
+   *
+   * @param a The first input `NDArray`.
+   * @param b The second input `NDArray`. Must have the same dtype as `a`.
+   */
+  @operation
+  static equal<D1 extends DataType, D2 extends D1, T extends NDArray<'bool'>>(
+      a: NDArray<D1>, b: NDArray<D2>): T {
+    util.assertTypesMatch(a, b);
+    broadcast_util.assertAndGetBroadcastShape(a.shape, b.shape);
+    return ENV.engine.executeKernel('Equal', {inputs: {a, b}}) as T;
+  }
+
+  @operation
+  static equalStrict<T extends NDArray>(a: T, b: T): NDArray<'bool'> {
+    util.assertShapesMatch(a.shape, b.shape, 'Error in equalStrict: ');
+    return this.equal(a, b);
+  }
+
+  /**
+   * Returns the truth value of (a <= b) element-wise. Supports broadcasting.
+   *
+   * @param a The first input `NDArray`.
+   * @param b The second input `NDArray`. Must have the same dtype as `a`.
+   */
+  @operation
+  static lessEqual<D1 extends DataType, D2 extends D1, T extends
+                       NDArray<'bool'>>(a: NDArray<D1>, b: NDArray<D2>): T {
+    util.assertTypesMatch(a, b);
+    broadcast_util.assertAndGetBroadcastShape(a.shape, b.shape);
+    return ENV.engine.executeKernel('LessEqual', {inputs: {a, b}}) as T;
+  }
+
+  /**
+   * Returns the truth value of (a > b) element-wise. Supports broadcasting.
+   *
+   * @param a The first input `NDArray`.
+   * @param b The second input `NDArray`. Must have the same dtype as `a`.
+   */
+  @operation
+  static greater<D1 extends DataType, D2 extends D1, T extends NDArray<'bool'>>(
+      a: NDArray<D1>, b: NDArray<D2>): T {
+    util.assertTypesMatch(a, b);
+    broadcast_util.assertAndGetBroadcastShape(a.shape, b.shape);
+    return ENV.engine.executeKernel('Greater', {inputs: {a, b}}) as T;
+  }
+
+  /**
+   * Returns the truth value of (a >= b) element-wise. Supports broadcasting.
+   *
+   * @param a The first input `NDArray`.
+   * @param b The second input `NDArray`. Must have the same dtype as `a`.
+   */
+  @operation
+  static greaterEqual<D1 extends DataType, D2 extends D1, T extends
+                          NDArray<'bool'>>(a: NDArray<D1>, b: NDArray<D2>): T {
+    util.assertTypesMatch(a, b);
+    broadcast_util.assertAndGetBroadcastShape(a.shape, b.shape);
+    return ENV.engine.executeKernel('GreaterEqual', {inputs: {a, b}}) as T;
+  }
+}

--- a/src/math/compare.ts
+++ b/src/math/compare.ts
@@ -41,7 +41,7 @@ export class Ops {
   static notEqualStrict<R extends Rank, D1 extends DataType, D2 extends D1>(
       a: NDArray<D1, R>, b: NDArray<D2, R>): RankMap<'bool'>[R] {
     util.assertShapesMatch(a.shape, b.shape, 'Error in notEqualStrict: ');
-    return this.notEqual(a, b);
+    return Ops.notEqual(a, b);
   }
 
   /**
@@ -76,7 +76,7 @@ export class Ops {
   @operation
   static equalStrict<T extends NDArray>(a: T, b: T): NDArray<'bool'> {
     util.assertShapesMatch(a.shape, b.shape, 'Error in equalStrict: ');
-    return this.equal(a, b);
+    return Ops.equal(a, b);
   }
 
   /**

--- a/src/math/concat.ts
+++ b/src/math/concat.ts
@@ -15,8 +15,9 @@
  * =============================================================================
  */
 
-import {ENV, operation} from '../environment';
+import {ENV} from '../environment';
 import * as concat_util from './concat_util';
+import {operation} from './decorators';
 import {Array1D, Array2D, Array3D, Array4D} from './ndarray';
 import * as slice from './slice';
 

--- a/src/math/concat.ts
+++ b/src/math/concat.ts
@@ -15,126 +15,124 @@
  * =============================================================================
  */
 
-import {ENV} from '../environment';
+import {ENV, operation} from '../environment';
 import * as concat_util from './concat_util';
 import {Array1D, Array2D, Array3D, Array4D} from './ndarray';
 import * as slice from './slice';
 
-/**
- * Concatenates two 1D arrays.
- *
- * For example, if:
- * A: shape(3) = |r1, g1, b1|
- * B: shape(2) = |r2, g2|
- * C = concat1D(A, B) == |r1, g1, b1, r2, g2|
- *
- * @param a The first array.
- * @param b The second array.
- * @return The concatenated array.
- */
-export function concat1D(a: Array1D, b: Array1D): Array1D {
-  return ENV.math.scope('concat1D', () => {
+export class Ops {
+  /**
+   * Concatenates two 1D arrays.
+   *
+   * For example, if:
+   * A: shape(3) = |r1, g1, b1|
+   * B: shape(2) = |r2, g2|
+   * C = concat1D(A, B) == |r1, g1, b1, r2, g2|
+   *
+   * @param a The first array.
+   * @param b The second array.
+   * @return The concatenated array.
+   */
+  @operation
+  static concat1D(a: Array1D, b: Array1D): Array1D {
     concat_util.assertParams(a.shape, b.shape, 0);
     return ENV.engine.executeKernel('Concat1D', {inputs: {a, b}});
-  });
-}
+  }
 
-/**
- * Concatenates two 2D arrays along a given axis.
- *
- * For example, if:
- * A: shape(2, 3) = | r1, g1, b1 |
- *                  | r2, g2, b2 |
- *
- * B: shape(2, 3) = | r3, g3, b3 |
- *                  | r4, g4, b4 |
- *
- * C = concat2D(A, B, axis)
- *
- * if axis = 0:
- * C: shape(4, 3) = | r1, g1, b1 |
- *                  | r2, g2, b2 |
- *                  | r3, g3, b3 |
- *                  | r4, g4, b4 |
- *
- * if axis = 1:
- * C = shape(2, 6) = | r1, g1, b1, r3, g3, b3 |
- *                   | r2, g2, b2, r4, g4, b4 |
- *
- *
- * @param a The first array.
- * @param b The second array.
- * @param axis The axis to concatenate along.
- * @return The concatenated array.
- */
-export function concat2D(a: Array2D, b: Array2D, axis: number): Array2D {
-  return ENV.math.scope('concat2D', () => {
+  /**
+   * Concatenates two 2D arrays along a given axis.
+   *
+   * For example, if:
+   * A: shape(2, 3) = | r1, g1, b1 |
+   *                  | r2, g2, b2 |
+   *
+   * B: shape(2, 3) = | r3, g3, b3 |
+   *                  | r4, g4, b4 |
+   *
+   * C = concat2D(A, B, axis)
+   *
+   * if axis = 0:
+   * C: shape(4, 3) = | r1, g1, b1 |
+   *                  | r2, g2, b2 |
+   *                  | r3, g3, b3 |
+   *                  | r4, g4, b4 |
+   *
+   * if axis = 1:
+   * C = shape(2, 6) = | r1, g1, b1, r3, g3, b3 |
+   *                   | r2, g2, b2, r4, g4, b4 |
+   *
+   *
+   * @param a The first array.
+   * @param b The second array.
+   * @param axis The axis to concatenate along.
+   * @return The concatenated array.
+   */
+  @operation
+  static concat2D(a: Array2D, b: Array2D, axis: number): Array2D {
     concat_util.assertParams(a.shape, b.shape, axis);
     return ENV.engine.executeKernel('Concat2D', {inputs: {a, b}, args: {axis}});
-  });
-}
+  }
 
-/**
- * Concatenates two 3D ndarrays along a given axis.
- *
- * For example, if:
- * A: shape(2, 1, 3) = | r1, g1, b1 |
- *                     | r2, g2, b2 |
- *
- * B: shape(2, 1, 3) = | r3, g3, b3 |
- *                     | r4, g4, b4 |
- *
- * C = concat3D(A, B, axis)
- *
- * if axis = 0:
- * C: shape(4, 1, 3) = | r1, g1, b1 |
- *                     | r2, g2, b2 |
- *                     | r3, g3, b3 |
- *                     | r4, g4, b4 |
- *
- * if axis = 1:
- * C: shape(2, 2, 3) = | r1, g1, b1, r3, g3, b3 |
- *                     | r2, g2, b2, r4, g4, b4 |
- *
- * if axis = 2:
- * C = shape(2, 1, 6) = | r1, g1, b1, r3, g3, b3 |
- *                      | r2, g2, b2, r4, g4, b4 |
- *
- * @param a The first array to concat.
- * @param b The second array to conat.
- * @param axis The axis to concate along.
- * @return The concatenated array.
- */
-export function concat3D(a: Array3D, b: Array3D, axis: number): Array3D {
-  return ENV.math.scope('concat3D', () => {
+  /**
+   * Concatenates two 3D ndarrays along a given axis.
+   *
+   * For example, if:
+   * A: shape(2, 1, 3) = | r1, g1, b1 |
+   *                     | r2, g2, b2 |
+   *
+   * B: shape(2, 1, 3) = | r3, g3, b3 |
+   *                     | r4, g4, b4 |
+   *
+   * C = concat3D(A, B, axis)
+   *
+   * if axis = 0:
+   * C: shape(4, 1, 3) = | r1, g1, b1 |
+   *                     | r2, g2, b2 |
+   *                     | r3, g3, b3 |
+   *                     | r4, g4, b4 |
+   *
+   * if axis = 1:
+   * C: shape(2, 2, 3) = | r1, g1, b1, r3, g3, b3 |
+   *                     | r2, g2, b2, r4, g4, b4 |
+   *
+   * if axis = 2:
+   * C = shape(2, 1, 6) = | r1, g1, b1, r3, g3, b3 |
+   *                      | r2, g2, b2, r4, g4, b4 |
+   *
+   * @param a The first array to concat.
+   * @param b The second array to conat.
+   * @param axis The axis to concate along.
+   * @return The concatenated array.
+   */
+  @operation
+  static concat3D(a: Array3D, b: Array3D, axis: number): Array3D {
     concat_util.assertParams(a.shape, b.shape, axis);
 
     const gradients = (dy: Array3D<'float32'>, y: Array3D) => {
       const {x1Begin, x1Size, x2Begin, x2Size} =
           concat_util.computeGradientSliceShapes3D(a.shape, y.shape, axis);
       return {
-        a: () => slice.slice3D(dy, x1Begin, x1Size),
-        b: () => slice.slice3D(dy, x2Begin, x2Size)
+        a: () => slice.Ops.slice3D(dy, x1Begin, x1Size),
+        b: () => slice.Ops.slice3D(dy, x2Begin, x2Size)
       };
     };
 
     return ENV.engine.executeKernel(
         'Concat3D', {inputs: {a, b}, args: {axis}}, gradients);
-  });
-}
+  }
 
-/**
- * Concatenates two 4D ndarrays along a given axis. See math.concat2D() for
- * documentation.
- *
- * @param a The first array to concat.
- * @param b The second array to conat.
- * @param axis The axis to concate along.
- * @return The concatenated array.
- */
-export function concat4D(a: Array4D, b: Array4D, axis: number): Array4D {
-  return ENV.math.scope('concat4D', () => {
+  /**
+   * Concatenates two 4D ndarrays along a given axis. See math.concat2D() for
+   * documentation.
+   *
+   * @param a The first array to concat.
+   * @param b The second array to conat.
+   * @param axis The axis to concate along.
+   * @return The concatenated array.
+   */
+  @operation
+  static concat4D(a: Array4D, b: Array4D, axis: number): Array4D {
     concat_util.assertParams(a.shape, b.shape, axis);
     return ENV.engine.executeKernel('Concat4D', {inputs: {a, b}, args: {axis}});
-  });
+  }
 }

--- a/src/math/conv.ts
+++ b/src/math/conv.ts
@@ -87,7 +87,7 @@ export class Ops {
     const strides: [number, number] = [1, stride];
 
     const res =
-        this.conv2d(input4D, filter4D, bias, strides, pad, dimRoundingMode);
+        Ops.conv2d(input4D, filter4D, bias, strides, pad, dimRoundingMode);
     if (reshapedTo3D) {
       return res.as2D(res.shape[2], res.shape[3]) as T;
     }
@@ -158,9 +158,9 @@ export class Ops {
 
     const gradients = (dy: Array4D<'float32'>, y: Array4D) => {
       return {
-        x: () => this.conv2dDerInput(x4D.shape, dy, filter, strides, pad),
-        filter: () => this.conv2dDerFilter(x4D, dy, filter.shape, strides, pad),
-        bias: () => this.conv2dDerBias(dy)
+        x: () => Ops.conv2dDerInput(x4D.shape, dy, filter, strides, pad),
+        filter: () => Ops.conv2dDerFilter(x4D, dy, filter.shape, strides, pad),
+        bias: () => Ops.conv2dDerBias(dy)
       };
     };
 
@@ -359,7 +359,7 @@ export class Ops {
       outputShape: [number, number, number, number]|[number, number, number],
       strides: [number, number]|number, pad: 'valid'|'same'|number,
       dimRoundingMode?: 'floor'|'round'|'ceil'): RankMap<'float32'>[R] {
-    return this.conv2dDerInput(
+    return Ops.conv2dDerInput(
         outputShape, x, filter, strides, pad, dimRoundingMode);
   }
 

--- a/src/math/conv.ts
+++ b/src/math/conv.ts
@@ -15,9 +15,10 @@
  * =============================================================================
  */
 
-import {ENV, operation} from '../environment';
+import {ENV} from '../environment';
 import * as util from '../util';
 import * as conv_util from './conv_util';
+import {operation} from './decorators';
 // tslint:disable-next-line:max-line-length
 import {Array1D, Array3D, Array4D, DataType, NDArray, Rank, RankMap} from './ndarray';
 

--- a/src/math/conv.ts
+++ b/src/math/conv.ts
@@ -15,37 +15,38 @@
  * =============================================================================
  */
 
-import {ENV} from '../environment';
+import {ENV, operation} from '../environment';
 import * as util from '../util';
 import * as conv_util from './conv_util';
 // tslint:disable-next-line:max-line-length
 import {Array1D, Array3D, Array4D, DataType, NDArray, Rank, RankMap} from './ndarray';
 
-/**
- * Computes a 1D convolution over the input x.
- * @param input The input ndarray, of rank 3 or rank 2, of shape
- *     `[batch, width, inChannels]`. If rank 2, batch of 1 is assumed.
- * @param filter The filter, rank 3, of shape
- *     [filterWidth, inDepth, outDepth].
- * @param bias Optional bias, rank 1 of shape [outDepth].
- * @param stride The number of entries by which the filter is moved right at
- *     each step.
- * @param pad A string from: 'same', 'valid'. The type of padding algorithm.
- *    - 'same' pad and stride 1: output will be of same size as input,
- *       regardless of filter size.
- *    - 'valid' pad: output will be smaller than input if filter is larger
- *       than 1x1.
- *   - For more info, see this guide:
- *     https://www.tensorflow.org/api_guides/python/nn#Convolution
- * @param dimRoundingMode A string from: 'ceil', 'round', 'floor'. The
- *     rounding mode used when computing output dimensions if pad is a
- *     number. If none is provided, it will not round and error if the output
- *     is of fractional size.
- */
-export function conv1d<T extends NDArray>(
-    input: T, filter: Array3D, bias: Array1D|null, stride: number,
-    pad: 'valid'|'same'|number, dimRoundingMode?: 'floor'|'round'|'ceil'): T {
-  return ENV.math.scope('Conv1D', () => {
+export class Ops {
+  /**
+   * Computes a 1D convolution over the input x.
+   * @param input The input ndarray, of rank 3 or rank 2, of shape
+   *     `[batch, width, inChannels]`. If rank 2, batch of 1 is assumed.
+   * @param filter The filter, rank 3, of shape
+   *     [filterWidth, inDepth, outDepth].
+   * @param bias Optional bias, rank 1 of shape [outDepth].
+   * @param stride The number of entries by which the filter is moved right at
+   *     each step.
+   * @param pad A string from: 'same', 'valid'. The type of padding algorithm.
+   *    - 'same' pad and stride 1: output will be of same size as input,
+   *       regardless of filter size.
+   *    - 'valid' pad: output will be smaller than input if filter is larger
+   *       than 1x1.
+   *   - For more info, see this guide:
+   *     https://www.tensorflow.org/api_guides/python/nn#Convolution
+   * @param dimRoundingMode A string from: 'ceil', 'round', 'floor'. The
+   *     rounding mode used when computing output dimensions if pad is a
+   *     number. If none is provided, it will not round and error if the output
+   *     is of fractional size.
+   */
+  @operation
+  static conv1d<T extends NDArray>(
+      input: T, filter: Array3D, bias: Array1D|null, stride: number,
+      pad: 'valid'|'same'|number, dimRoundingMode?: 'floor'|'round'|'ceil'): T {
     let input3D = input as Array3D;
     let reshapedTo3D = false;
     if (input.rank === 2) {
@@ -84,41 +85,42 @@ export function conv1d<T extends NDArray>(
         input3D.as4D(input3D.shape[0], 1, input3D.shape[1], input3D.shape[2]);
     const strides: [number, number] = [1, stride];
 
-    const res = conv2d(input4D, filter4D, bias, strides, pad, dimRoundingMode);
+    const res =
+        this.conv2d(input4D, filter4D, bias, strides, pad, dimRoundingMode);
     if (reshapedTo3D) {
       return res.as2D(res.shape[2], res.shape[3]) as T;
     }
     return res.as3D(res.shape[0], res.shape[2], res.shape[3]) as T;
-  });
-}
+  }
 
-/**
- * Computes a 2D convolution over the input x.
- *
- * @param x The input ndarray, of rank 4 or rank 3, of shape
- *     `[batch, height, width, inChannels]`. If rank 3, batch of 1 is
- * assumed.
- * @param filter The filter, rank 4, of shape
- *     [filterHeight, filterWidth, inDepth, outDepth].
- * @param bias Optional bias, rank 1 of shape [outDepth].
- * @param strides The strides of the convolution: [strideHeight,
- * strideWidth].
- * @param pad A string from: 'same', 'valid'. The type of padding algorithm.
- *    - 'same' pad and stride 1: output will be of same size as input,
- *       regardless of filter size.
- *    - 'valid' pad: output will be smaller than input if filter is larger
- *       than 1x1.
- *   - For more info, see this guide:
- *     https://www.tensorflow.org/api_guides/python/nn#Convolution
- * @param dimRoundingMode A string from: 'ceil', 'round', 'floor'. The
- *     rounding mode used when computing output dimensions if pad is a
- *     number. If none is provided, it will not round and error if the output
- *     is of fractional size.
- */
-export function conv2d<T extends Array3D|Array4D>(
-    x: T, filter: Array4D, bias: Array1D|null, strides: [number, number]|number,
-    pad: 'valid'|'same'|number, dimRoundingMode?: 'floor'|'round'|'ceil'): T {
-  return ENV.math.scope('Conv2D', () => {
+  /**
+   * Computes a 2D convolution over the input x.
+   *
+   * @param x The input ndarray, of rank 4 or rank 3, of shape
+   *     `[batch, height, width, inChannels]`. If rank 3, batch of 1 is
+   * assumed.
+   * @param filter The filter, rank 4, of shape
+   *     [filterHeight, filterWidth, inDepth, outDepth].
+   * @param bias Optional bias, rank 1 of shape [outDepth].
+   * @param strides The strides of the convolution: [strideHeight,
+   * strideWidth].
+   * @param pad A string from: 'same', 'valid'. The type of padding algorithm.
+   *    - 'same' pad and stride 1: output will be of same size as input,
+   *       regardless of filter size.
+   *    - 'valid' pad: output will be smaller than input if filter is larger
+   *       than 1x1.
+   *   - For more info, see this guide:
+   *     https://www.tensorflow.org/api_guides/python/nn#Convolution
+   * @param dimRoundingMode A string from: 'ceil', 'round', 'floor'. The
+   *     rounding mode used when computing output dimensions if pad is a
+   *     number. If none is provided, it will not round and error if the output
+   *     is of fractional size.
+   */
+  @operation
+  static conv2d<T extends Array3D|Array4D>(
+      x: T, filter: Array4D, bias: Array1D|null,
+      strides: [number, number]|number, pad: 'valid'|'same'|number,
+      dimRoundingMode?: 'floor'|'round'|'ceil'): T {
     let x4D = x as Array4D;
     let reshapedTo4D = false;
     if (x.rank === 3) {
@@ -155,9 +157,9 @@ export function conv2d<T extends Array3D|Array4D>(
 
     const gradients = (dy: Array4D<'float32'>, y: Array4D) => {
       return {
-        x: () => conv2dDerInput(x4D.shape, dy, filter, strides, pad),
-        filter: () => conv2dDerFilter(x4D, dy, filter.shape, strides, pad),
-        bias: () => conv2dDerBias(dy)
+        x: () => this.conv2dDerInput(x4D.shape, dy, filter, strides, pad),
+        filter: () => this.conv2dDerFilter(x4D, dy, filter.shape, strides, pad),
+        bias: () => this.conv2dDerBias(dy)
       };
     };
 
@@ -168,34 +170,33 @@ export function conv2d<T extends Array3D|Array4D>(
       return res.as3D(res.shape[1], res.shape[2], res.shape[3]) as T;
     }
     return res as T;
-  });
-}
+  }
 
-/**
- * Computes the derivative of the input of a 2D convolution.
- *
- * @param xShape The shape of the input: [batch, height, width, inDepth].
- * If length of 3, batch of 1 is assumed.
- * @param dy The derivative of the output, of rank 4 or rank 3 of shape
- *   [batch, outHeight, outWidth, outDepth]. If rank 3, batch of 1 is
- * assumed.
- * @param filter The filter, rank 4, of shape
- *     [filterHeight, filterWidth, inDepth, outDepth].
- * @param strides The strides of the convolution: [strideHeight,
- * strideWidth].
- * @param pad A string from: 'same', 'valid'. The type of padding algorithm
- *     used in the forward prop of the op.
- * @param dimRoundingMode A string from: 'ceil', 'round', 'floor'. The
- *     rounding mode used when computing output dimensions if pad is a
- *     number. If none is provided, it will not round and error if the output
- *     is of fractional size.
- */
-export function conv2dDerInput<R extends Rank, T extends RankMap<'float32'>[R]>(
-    xShape: [number, number, number, number]|[number, number, number],
-    dy: NDArray<'float32', R>, filter: Array4D,
-    strides: [number, number]|number, pad: 'valid'|'same'|number,
-    dimRoundingMode?: 'floor'|'round'|'ceil'): T {
-  return ENV.math.scope('conv2dDerInput', () => {
+  /**
+   * Computes the derivative of the input of a 2D convolution.
+   *
+   * @param xShape The shape of the input: [batch, height, width, inDepth].
+   * If length of 3, batch of 1 is assumed.
+   * @param dy The derivative of the output, of rank 4 or rank 3 of shape
+   *   [batch, outHeight, outWidth, outDepth]. If rank 3, batch of 1 is
+   * assumed.
+   * @param filter The filter, rank 4, of shape
+   *     [filterHeight, filterWidth, inDepth, outDepth].
+   * @param strides The strides of the convolution: [strideHeight,
+   * strideWidth].
+   * @param pad A string from: 'same', 'valid'. The type of padding algorithm
+   *     used in the forward prop of the op.
+   * @param dimRoundingMode A string from: 'ceil', 'round', 'floor'. The
+   *     rounding mode used when computing output dimensions if pad is a
+   *     number. If none is provided, it will not round and error if the output
+   *     is of fractional size.
+   */
+  @operation
+  static conv2dDerInput<R extends Rank, T extends RankMap<'float32'>[R]>(
+      xShape: [number, number, number, number]|[number, number, number],
+      dy: NDArray<'float32', R>, filter: Array4D,
+      strides: [number, number]|number, pad: 'valid'|'same'|number,
+      dimRoundingMode?: 'floor'|'round'|'ceil'): T {
     util.assert(
         xShape.length === dy.rank,
         `Length of inShape ` +
@@ -247,51 +248,49 @@ export function conv2dDerInput<R extends Rank, T extends RankMap<'float32'>[R]>(
       return res.as3D(res.shape[1], res.shape[2], res.shape[3]) as T;
     }
     return res as T;
-  });
-}
+  }
 
-/**
- * Computes the derivative of the bias of a 2D convolution.
- *
- * @param dy The gradient for the output of this op, of rank 4 or rank 3 of
- *   shape [batch, height, width, outDepth]. If rank 3, batch of 1 is
- * assumed.
- */
-export function conv2dDerBias(dy: Array3D<'float32'>|
-                              Array4D<'float32'>): Array1D<'float32'> {
-  return ENV.math.scope('conv2dDerBias', () => {
+  /**
+   * Computes the derivative of the bias of a 2D convolution.
+   *
+   * @param dy The gradient for the output of this op, of rank 4 or rank 3 of
+   *   shape [batch, height, width, outDepth]. If rank 3, batch of 1 is
+   * assumed.
+   */
+  @operation
+  static conv2dDerBias(dy: Array3D<'float32'>|Array4D<'float32'>):
+      Array1D<'float32'> {
     let dy4D = dy as Array4D;
     if (dy.rank === 3) {
       dy4D = dy.as4D(1, dy.shape[0], dy.shape[1], dy.shape[2]);
     }
     return ENV.engine.executeKernel('Conv2DDerBias', {inputs: {dy: dy4D}});
-  });
-}
+  }
 
-/**
- * Computes the derivative of the filter of a 2D convolution.
- *
- * @param x The input ndarray, of rank 4 or rank 3 of shape
- *     [batch, height, width, inChannels]. If rank 3, batch of 1 is assumed.
- * @param dy The dy image, of rank 4 or rank 3, of shape
- *     [batch, height, width, outDepth]. If rank 3, batch of 1 is assumed.
- * @param filterShape The shape of the filter, length 4,
- *     [filterHeight, filterWidth, inDepth, outDepth].
- * @param strides The strides of the convolution: [strideHeight,
- * strideWidth].
- * @param pad A string from: 'same', 'valid'. The type of padding algorithm
- *     used in the forward prop of the op.
- * @param dimRoundingMode A string from: 'ceil', 'round', 'floor'. The
- *     rounding mode used when computing output dimensions if pad is a
- *     number. If none is provided, it will not round and error if the output
- *     is of fractional size.
- */
-export function conv2dDerFilter<R extends '3'|'4'>(
-    x: NDArray<DataType, R>, dy: NDArray<'float32', R>,
-    filterShape: [number, number, number, number],
-    strides: [number, number]|number, pad: 'valid'|'same'|number,
-    dimRoundingMode?: 'floor'|'round'|'ceil'): Array4D<'float32'> {
-  return ENV.math.scope('conv2dDerFilter', () => {
+  /**
+   * Computes the derivative of the filter of a 2D convolution.
+   *
+   * @param x The input ndarray, of rank 4 or rank 3 of shape
+   *     [batch, height, width, inChannels]. If rank 3, batch of 1 is assumed.
+   * @param dy The dy image, of rank 4 or rank 3, of shape
+   *     [batch, height, width, outDepth]. If rank 3, batch of 1 is assumed.
+   * @param filterShape The shape of the filter, length 4,
+   *     [filterHeight, filterWidth, inDepth, outDepth].
+   * @param strides The strides of the convolution: [strideHeight,
+   * strideWidth].
+   * @param pad A string from: 'same', 'valid'. The type of padding algorithm
+   *     used in the forward prop of the op.
+   * @param dimRoundingMode A string from: 'ceil', 'round', 'floor'. The
+   *     rounding mode used when computing output dimensions if pad is a
+   *     number. If none is provided, it will not round and error if the output
+   *     is of fractional size.
+   */
+  @operation
+  static conv2dDerFilter<R extends '3'|'4'>(
+      x: NDArray<DataType, R>, dy: NDArray<'float32', R>,
+      filterShape: [number, number, number, number],
+      strides: [number, number]|number, pad: 'valid'|'same'|number,
+      dimRoundingMode?: 'floor'|'round'|'ceil'): Array4D<'float32'> {
     let x4D = x as Array4D;
     if (x.rank === 3) {
       x4D = x.as4D(1, x.shape[0], x.shape[1], x.shape[2]);
@@ -331,80 +330,81 @@ export function conv2dDerFilter<R extends '3'|'4'>(
         x4D.shape, filterShape, strides, pad, dimRoundingMode);
     return ENV.engine.executeKernel(
         'Conv2DDerFilter', {inputs: {x: x4D, dy: dy4D}, args: {convInfo}});
-  });
-}
+  }
 
-/**
- * Computes the transposed 2D convolution of an image, also known as a
- * deconvolution.
- *
- * @param x The input image, of rank 4 or rank 3, of shape
- *   [batch, height, width, inDepth]. If rank 3, batch of 1 is assumed.
- * @param filter The filter, rank 4, of shape
- *     `[filterHeight, filterWidth, outDepth, inDepth]`.
- *     `inDepth` must match `inDepth` in `x`.
- * @param outputShape Output shape, of rank 4 or rank 3:
- *     [batch, height, width, outDepth]. If rank 3, batch of 1 is assumed.
- * @param strides The strides of the original convolution:
- *     `[strideHeight, strideWidth]`.
- * @param pad A string from: 'same', 'valid'. The type of padding algorithm
- *     used in the non-transpose version of the op.
- * @param dimRoundingMode A string from: 'ceil', 'round', 'floor'. The
- *     rounding mode used when computing output dimensions if pad is a
- *     number. If none is provided, it will not round and error if the output
- *     is of fractional size.
- */
-export function conv2dTranspose<R extends Rank>(
-    x: NDArray<'float32', R>, filter: Array4D,
-    outputShape: [number, number, number, number]|[number, number, number],
-    strides: [number, number]|number, pad: 'valid'|'same'|number,
-    dimRoundingMode?: 'floor'|'round'|'ceil'): RankMap<'float32'>[R] {
-  return conv2dDerInput(outputShape, x, filter, strides, pad, dimRoundingMode);
-}
+  /**
+   * Computes the transposed 2D convolution of an image, also known as a
+   * deconvolution.
+   *
+   * @param x The input image, of rank 4 or rank 3, of shape
+   *   [batch, height, width, inDepth]. If rank 3, batch of 1 is assumed.
+   * @param filter The filter, rank 4, of shape
+   *     `[filterHeight, filterWidth, outDepth, inDepth]`.
+   *     `inDepth` must match `inDepth` in `x`.
+   * @param outputShape Output shape, of rank 4 or rank 3:
+   *     [batch, height, width, outDepth]. If rank 3, batch of 1 is assumed.
+   * @param strides The strides of the original convolution:
+   *     `[strideHeight, strideWidth]`.
+   * @param pad A string from: 'same', 'valid'. The type of padding algorithm
+   *     used in the non-transpose version of the op.
+   * @param dimRoundingMode A string from: 'ceil', 'round', 'floor'. The
+   *     rounding mode used when computing output dimensions if pad is a
+   *     number. If none is provided, it will not round and error if the output
+   *     is of fractional size.
+   */
+  @operation
+  static conv2dTranspose<R extends Rank>(
+      x: NDArray<'float32', R>, filter: Array4D,
+      outputShape: [number, number, number, number]|[number, number, number],
+      strides: [number, number]|number, pad: 'valid'|'same'|number,
+      dimRoundingMode?: 'floor'|'round'|'ceil'): RankMap<'float32'>[R] {
+    return this.conv2dDerInput(
+        outputShape, x, filter, strides, pad, dimRoundingMode);
+  }
 
-/**
- * Depthwise 2D convolution.
- *
- * Given a 4D `input` array and a `filter` array of shape
- * `[filterHeight, filterWidth, inChannels, channelMultiplier]` containing
- * `inChannels` convolutional filters of depth 1, this op applies a
- * different filter to each input channel (expanding from 1 channel to
- * `channelMultiplier` channels for each), then concatenates the results
- * together. The output has `inChannels * channelMultiplier` channels.
- *
- * See https://www.tensorflow.org/api_docs/python/tf/nn/depthwise_conv2d for
- * more details.
- *
- * @param input The input ndarray, of rank 4 or rank 3, of shape
- *     `[batch, height, width, inChannels]`. If rank 3, batch of 1 is
- * assumed.
- * @param filter The filter ndarray, rank 4, of shape
- *     `[filterHeight, filterWidth, inChannels, channelMultiplier]`.
- * @param strides The strides of the convolution: [strideHeight,
- * strideWidth]. If strides is a single number, then `strideHeight ==
- * strideWidth`.
- * @param pad A string from: 'same', 'valid'. The type of padding algorithm.
- *   - 'same' pad and stride 1: output will be of same size as input,
- *       regardless of filter size.
- *   - 'valid' pad: output will be smaller than input if filter is larger
- *       than 1x1.
- *   - For more info, see this guide:
- *     https://www.tensorflow.org/api_guides/python/nn#Convolution
- * @param rates The dilation rates: `[rateHeight, rateWidth]` in which we
- *     sample input values across the height and width dimensions in atrous
- *     convolution. Defaults to `[1, 1]`. If `rate` is a single number, then
- *     `rateHeight == rateWidth`. If it is greater than 1, then all values
- * of `strides` must be 1.
- * @param dimRoundingMode A string from: 'ceil', 'round', 'floor'. The
- *     rounding mode used when computing output dimensions if pad is a
- *     number. If none is provided, it will not round and error if the output
- *     is of fractional size.
- */
-export function depthwiseConv2D<T extends NDArray>(
-    input: T, filter: Array4D, strides: [number, number]|number,
-    pad: 'valid'|'same'|number, rates: [number, number]|number = [1, 1],
-    dimRoundingMode?: 'floor'|'round'|'ceil'): T {
-  return ENV.math.scope('depthwiseConv2D', () => {
+  /**
+   * Depthwise 2D convolution.
+   *
+   * Given a 4D `input` array and a `filter` array of shape
+   * `[filterHeight, filterWidth, inChannels, channelMultiplier]` containing
+   * `inChannels` convolutional filters of depth 1, this op applies a
+   * different filter to each input channel (expanding from 1 channel to
+   * `channelMultiplier` channels for each), then concatenates the results
+   * together. The output has `inChannels * channelMultiplier` channels.
+   *
+   * See https://www.tensorflow.org/api_docs/python/tf/nn/depthwise_conv2d for
+   * more details.
+   *
+   * @param input The input ndarray, of rank 4 or rank 3, of shape
+   *     `[batch, height, width, inChannels]`. If rank 3, batch of 1 is
+   * assumed.
+   * @param filter The filter ndarray, rank 4, of shape
+   *     `[filterHeight, filterWidth, inChannels, channelMultiplier]`.
+   * @param strides The strides of the convolution: [strideHeight,
+   * strideWidth]. If strides is a single number, then `strideHeight ==
+   * strideWidth`.
+   * @param pad A string from: 'same', 'valid'. The type of padding algorithm.
+   *   - 'same' pad and stride 1: output will be of same size as input,
+   *       regardless of filter size.
+   *   - 'valid' pad: output will be smaller than input if filter is larger
+   *       than 1x1.
+   *   - For more info, see this guide:
+   *     https://www.tensorflow.org/api_guides/python/nn#Convolution
+   * @param rates The dilation rates: `[rateHeight, rateWidth]` in which we
+   *     sample input values across the height and width dimensions in atrous
+   *     convolution. Defaults to `[1, 1]`. If `rate` is a single number, then
+   *     `rateHeight == rateWidth`. If it is greater than 1, then all values
+   * of `strides` must be 1.
+   * @param dimRoundingMode A string from: 'ceil', 'round', 'floor'. The
+   *     rounding mode used when computing output dimensions if pad is a
+   *     number. If none is provided, it will not round and error if the output
+   *     is of fractional size.
+   */
+  @operation
+  static depthwiseConv2D<T extends NDArray>(
+      input: T, filter: Array4D, strides: [number, number]|number,
+      pad: 'valid'|'same'|number, rates: [number, number]|number = [1, 1],
+      dimRoundingMode?: 'floor'|'round'|'ceil'): T {
     let input4D = input as Array4D;
     let reshapedTo4D = false;
     if (input.rank === 3) {
@@ -446,7 +446,7 @@ export function depthwiseConv2D<T extends NDArray>(
       return res.as3D(res.shape[1], res.shape[2], res.shape[3]) as T;
     }
     return res as T;
-  });
+  }
 }
 
 function parseTupleParam(param: number|[number, number]): [number, number] {

--- a/src/math/decorators.ts
+++ b/src/math/decorators.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {ENV} from '../environment';
+
+/**
+ * Decorator for wrapping functions that perform math operations on
+ * NDArrays. The function will be wrapped in a named scope that cleans all
+ * memory usage after the function is done.
+ */
+export function operation(
+    target: {}, name: string, descriptor: PropertyDescriptor) {
+  const fn = descriptor.value;
+  // tslint:disable-next-line:no-any
+  descriptor.value = (...args: any[]) => {
+    return ENV.math.scope(name, () => fn(...args));
+  };
+  return descriptor;
+}

--- a/src/math/matmul.ts
+++ b/src/math/matmul.ts
@@ -15,9 +15,10 @@
  * =============================================================================
  */
 
-import {ENV, operation} from '../environment';
+import {ENV} from '../environment';
 import * as util from '../util';
 import {MatrixOrientation} from './backends/types/matmul';
+import {operation} from './decorators';
 import {Array1D, Array2D, Scalar} from './ndarray';
 
 export class Ops {

--- a/src/math/matmul.ts
+++ b/src/math/matmul.ts
@@ -63,10 +63,10 @@ export class Ops {
                 `Backprop for transposed MatMul not yet implemented.`);
           }
           return {
-            a: () => this.matMul(
+            a: () => Ops.matMul(
                          dy, b, MatrixOrientation.REGULAR,
                          MatrixOrientation.TRANSPOSED) as Array2D<'float32'>,
-            b: () => this.matMul(
+            b: () => Ops.matMul(
                          a, dy, MatrixOrientation.TRANSPOSED,
                          MatrixOrientation.REGULAR) as Array2D<'float32'>
           };
@@ -92,7 +92,7 @@ export class Ops {
         v.size === matrix.shape[0],
         `Error in vectorTimesMatrix: size of vector (${v.size}) ` +
             `must match first dimension of matrix (${matrix.shape[0]})`);
-    return this.matMul(v.as2D(1, -1), matrix).as1D();
+    return Ops.matMul(v.as2D(1, -1), matrix).as1D();
   }
 
   /**
@@ -116,7 +116,7 @@ export class Ops {
             `must match inner dimension of second rank 2 input, but got ` +
             `shape ${matrix.shape}.`);
 
-    return this.matMul(matrix, v.as2D(-1, 1)).as1D();
+    return Ops.matMul(matrix, v.as2D(-1, 1)).as1D();
   }
 
   /**
@@ -134,7 +134,7 @@ export class Ops {
         v1.size === v2.size,
         `Error in dotProduct: size of inputs (${v1.size}) and (` +
             `${v2.size}) must match.`);
-    return this.matMul(v1.as2D(1, -1), v2.as2D(-1, 1)).asScalar();
+    return Ops.matMul(v1.as2D(1, -1), v2.as2D(-1, 1)).asScalar();
   }
 
   /**
@@ -149,6 +149,6 @@ export class Ops {
         `Error in outerProduct: inputs must be rank 1, but got ranks ` +
             `${v1.rank} and ${v2.rank}.`);
 
-    return this.matMul(v1.as2D(-1, 1), v2.as2D(1, -1));
+    return Ops.matMul(v1.as2D(-1, 1), v2.as2D(1, -1));
   }
 }

--- a/src/math/matmul.ts
+++ b/src/math/matmul.ts
@@ -15,26 +15,27 @@
  * =============================================================================
  */
 
-import {ENV} from '../environment';
+import {ENV, operation} from '../environment';
 import * as util from '../util';
 import {MatrixOrientation} from './backends/types/matmul';
 import {Array1D, Array2D, Scalar} from './ndarray';
 
-/**
- * Computes the dot product of two matrices, A * B. These must be matrices,
- * use matrixTimesVector and vectorTimesMatrix, dotProduct, and outerProduct
- * in other cases.
- * @param a First matrix in dot product operation.
- * @param b Second matrix in dot product operation.
- * @param aOrientation The MatrixOrientation of A. If using TRANSPOSED, will
- * compute A^T * B.
- * @param bOrientation The MatrixOrientation of B. If using TRANSPOSED, will
- * compute A * B^T.
- */
-export function matMul(
-    a: Array2D, b: Array2D, aOrientation = MatrixOrientation.REGULAR,
-    bOrientation = MatrixOrientation.REGULAR): Array2D {
-  return ENV.math.scope('matMul', () => {
+export class Ops {
+  /**
+   * Computes the dot product of two matrices, A * B. These must be matrices,
+   * use matrixTimesVector and vectorTimesMatrix, dotProduct, and outerProduct
+   * in other cases.
+   * @param a First matrix in dot product operation.
+   * @param b Second matrix in dot product operation.
+   * @param aOrientation The MatrixOrientation of A. If using TRANSPOSED, will
+   * compute A^T * B.
+   * @param bOrientation The MatrixOrientation of B. If using TRANSPOSED, will
+   * compute A * B^T.
+   */
+  @operation
+  static matMul(
+      a: Array2D, b: Array2D, aOrientation = MatrixOrientation.REGULAR,
+      bOrientation = MatrixOrientation.REGULAR): Array2D {
     const innerShapeA =
         (aOrientation === MatrixOrientation.REGULAR) ? a.shape[1] : a.shape[0];
     const innerShapeB =
@@ -61,24 +62,23 @@ export function matMul(
                 `Backprop for transposed MatMul not yet implemented.`);
           }
           return {
-            a: () => matMul(
+            a: () => this.matMul(
                          dy, b, MatrixOrientation.REGULAR,
                          MatrixOrientation.TRANSPOSED) as Array2D<'float32'>,
-            b: () => matMul(
+            b: () => this.matMul(
                          a, dy, MatrixOrientation.TRANSPOSED,
                          MatrixOrientation.REGULAR) as Array2D<'float32'>
           };
         });
-  });
-}
+  }
 
-/**
- * Computes the dot product of a vector and a matrix, v * B.
- * @param v The vector in dot product operation.
- * @param matrix The matrix in dot product operation.
- */
-export function vectorTimesMatrix(v: Array1D, matrix: Array2D): Array1D {
-  return ENV.math.scope('vectorTimesMatrix', () => {
+  /**
+   * Computes the dot product of a vector and a matrix, v * B.
+   * @param v The vector in dot product operation.
+   * @param matrix The matrix in dot product operation.
+   */
+  @operation
+  static vectorTimesMatrix(v: Array1D, matrix: Array2D): Array1D {
     util.assert(
         v.rank === 1,
         `Error in vectorTimesMatrix: first input must be rank 1, but got ` +
@@ -91,17 +91,16 @@ export function vectorTimesMatrix(v: Array1D, matrix: Array2D): Array1D {
         v.size === matrix.shape[0],
         `Error in vectorTimesMatrix: size of vector (${v.size}) ` +
             `must match first dimension of matrix (${matrix.shape[0]})`);
-    return matMul(v.as2D(1, -1), matrix).as1D();
-  });
-}
+    return this.matMul(v.as2D(1, -1), matrix).as1D();
+  }
 
-/**
- * Computes the dot product of a matrix and vector, A * v.
- * @param matrix The matrix in dot product operation.
- * @param v The vector in dot product operation.
- */
-export function matrixTimesVector(matrix: Array2D, v: Array1D): Array1D {
-  return ENV.math.scope('matrixTimesVector', () => {
+  /**
+   * Computes the dot product of a matrix and vector, A * v.
+   * @param matrix The matrix in dot product operation.
+   * @param v The vector in dot product operation.
+   */
+  @operation
+  static matrixTimesVector(matrix: Array2D, v: Array1D): Array1D {
     util.assert(
         v.rank === 1,
         `Error in matrixTimesVector: second input must rank 1, but got ` +
@@ -117,16 +116,15 @@ export function matrixTimesVector(matrix: Array2D, v: Array1D): Array1D {
             `shape ${matrix.shape}.`);
 
     return matMul(matrix, v.as2D(-1, 1)).as1D();
-  });
-}
+  }
 
-/**
- * Computes the dot product of two vectors, v1 * v2.
- * @param v1 The first vector in the dot product operation.
- * @param v2 The second vector in the dot product operation.
- */
-export function dotProduct(v1: Array1D, v2: Array1D): Scalar {
-  return ENV.math.scope('dotProduct', () => {
+  /**
+   * Computes the dot product of two vectors, v1 * v2.
+   * @param v1 The first vector in the dot product operation.
+   * @param v2 The second vector in the dot product operation.
+   */
+  @operation
+  static dotProduct(v1: Array1D, v2: Array1D): Scalar {
     util.assert(
         v1.rank === 1 && v2.rank === 1,
         `Error in dotProduct: inputs must be rank 1, but got ranks ` +
@@ -135,22 +133,21 @@ export function dotProduct(v1: Array1D, v2: Array1D): Scalar {
         v1.size === v2.size,
         `Error in dotProduct: size of inputs (${v1.size}) and (` +
             `${v2.size}) must match.`);
-    return matMul(v1.as2D(1, -1), v2.as2D(-1, 1)).asScalar();
-  });
-}
+    return this.matMul(v1.as2D(1, -1), v2.as2D(-1, 1)).asScalar();
+  }
 
-/**
- * Computes the outer product of two vectors, v1 and v2.
- * @param v1 The first vector in the outer product operation.
- * @param v2 The second vector in the dot product operation.
- */
-export function outerProduct(v1: Array1D, v2: Array1D): Array2D {
-  return ENV.math.scope('outerProduct', () => {
+  /**
+   * Computes the outer product of two vectors, v1 and v2.
+   * @param v1 The first vector in the outer product operation.
+   * @param v2 The second vector in the dot product operation.
+   */
+  @operation
+  static outerProduct(v1: Array1D, v2: Array1D): Array2D {
     util.assert(
         v1.rank === 1 && v2.rank === 1,
         `Error in outerProduct: inputs must be rank 1, but got ranks ` +
             `${v1.rank} and ${v2.rank}.`);
 
-    return matMul(v1.as2D(-1, 1), v2.as2D(1, -1));
-  });
+    return this.matMul(v1.as2D(-1, 1), v2.as2D(1, -1));
+  }
 }

--- a/src/math/matmul.ts
+++ b/src/math/matmul.ts
@@ -115,7 +115,7 @@ export class Ops {
             `must match inner dimension of second rank 2 input, but got ` +
             `shape ${matrix.shape}.`);
 
-    return matMul(matrix, v.as2D(-1, 1)).as1D();
+    return this.matMul(matrix, v.as2D(-1, 1)).as1D();
   }
 
   /**

--- a/src/math/minmax.ts
+++ b/src/math/minmax.ts
@@ -171,6 +171,6 @@ export class Ops {
   @operation
   static argMaxEquals(x1: NDArray, x2: NDArray): Scalar<'bool'> {
     util.assertShapesMatch(x1.shape, x2.shape, 'Error in argMaxEquals: ');
-    return compare.Ops.equal(this.argMax(x1), this.argMax(x2));
+    return compare.Ops.equal(Ops.argMax(x1), Ops.argMax(x2));
   }
 }

--- a/src/math/minmax.ts
+++ b/src/math/minmax.ts
@@ -15,11 +15,12 @@
  * =============================================================================
  */
 
-import {ENV, operation} from '../environment';
+import {ENV} from '../environment';
 import * as util from '../util';
 import * as axis_util from './axis_util';
 import * as broadcast_util from './broadcast_util';
 import * as compare from './compare';
+import {operation} from './decorators';
 import {DataType, NDArray, Scalar} from './ndarray';
 import * as transpose from './transpose';
 

--- a/src/math/minmax.ts
+++ b/src/math/minmax.ts
@@ -1,0 +1,175 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {ENV, operation} from '../environment';
+import * as util from '../util';
+import * as axis_util from './axis_util';
+import * as broadcast_util from './broadcast_util';
+import * as compare from './compare';
+import {DataType, NDArray, Scalar} from './ndarray';
+import * as transpose from './transpose';
+
+export class Ops {
+  /**
+   * Computes the minimum value from the input.
+   *
+   * Reduces the input along the dimensions given in `axes`. Unless `keepDims`
+   * is true, the rank of the array is reduced by 1 for each entry in `axes`.
+   * If `keepDims` is true, the reduced dimensions are retained with length 1.
+   * If `axes` has no entries, all dimensions are reduced, and an array with a
+   * single element is returned.
+   *
+   * @param x The input NDArray.
+   * @param axis Optional. The dimension(s) to reduce. By default it reduces
+   *     all dimensions.
+   * @param keepDims Optional. If true, retains reduced dimensions with size 1.
+   */
+  @operation
+  static min<D extends DataType, T extends NDArray<D>>(
+      x: NDArray<D>, axis: number|number[] = null, keepDims = false): T {
+    const origAxes = axis_util.parseAxisParam(axis, x.shape);
+    let axes = origAxes;
+    const permutedAxes = axis_util.getAxesPermutation(axes, x.rank);
+    if (permutedAxes != null) {
+      x = transpose.transpose(x, permutedAxes);
+      axes = axis_util.getInnerMostAxes(axes.length, x.rank);
+    }
+    const res = ENV.engine.executeKernel('Min', {inputs: {x}, args: {axes}}) as
+        NDArray<D>;
+    if (keepDims) {
+      const newShape = axis_util.expandShapeToKeepDim(res.shape, origAxes);
+      return res.reshape(newShape) as T;
+    }
+    return res as T;
+  }
+
+  /**
+   * Returns the min of a and b (`a < b ? a : b`) element-wise.
+   * Supports broadcasting.
+   *
+   * @param a The first ndarray.
+   * @param b The second ndarray. Must have the same type as `a`.
+   */
+  @operation
+  static minimum<D1 extends DataType, D2 extends D1, T extends NDArray<D1>>(
+      a: NDArray<D1>, b: NDArray<D2>): T {
+    util.assertTypesMatch(a, b);
+    broadcast_util.assertAndGetBroadcastShape(a.shape, b.shape);
+    return ENV.engine.executeKernel('Minimum', {inputs: {a, b}}) as T;
+  }
+
+  /**
+   * Computes the maximum of elements across dimensions of an array.
+   *
+   * Reduces the input along the dimensions given in `axes`. Unless `keepDims`
+   * is true, the rank of the array is reduced by 1 for each entry in `axes`.
+   * If `keepDims` is true, the reduced dimensions are retained with length 1.
+   * If `axes` has no entries, all dimensions are reduced, and an array with a
+   * single element is returned.
+   *
+   * @param x The input array.
+   * @param axis Optional. The dimension(s) to reduce. By default it reduces
+   *     all dimensions.
+   * @param keepDims Optional. If true, retains reduced dimensions with size 1.
+   */
+  @operation
+  static max<D extends DataType, T extends NDArray<D>>(
+      x: NDArray<D>, axis: number|number[] = null, keepDims = false): T {
+    const origAxes = axis_util.parseAxisParam(axis, x.shape);
+    let axes = origAxes;
+    const permutedAxes = axis_util.getAxesPermutation(axes, x.rank);
+    if (permutedAxes != null) {
+      x = transpose.transpose(x, permutedAxes);
+      axes = axis_util.getInnerMostAxes(axes.length, x.rank);
+    }
+    const res = ENV.engine.executeKernel('Max', {inputs: {x}, args: {axes}}) as
+        NDArray<D>;
+    if (keepDims) {
+      const newShape = axis_util.expandShapeToKeepDim(res.shape, origAxes);
+      return res.reshape(newShape) as T;
+    }
+    return res as T;
+  }
+
+  /**
+   * Returns the max of a and b (`a > b ? a : b`) element-wise.
+   * Supports broadcasting.
+   *
+   * @param a The first ndarray.
+   * @param b The second ndarray. Must have the same type as `a`.
+   */
+  @operation
+  static maximum<D1 extends DataType, D2 extends D1, T extends NDArray<D1>>(
+      a: NDArray<D1>, b: NDArray<D2>): T {
+    util.assertTypesMatch(a, b);
+    broadcast_util.assertAndGetBroadcastShape(a.shape, b.shape);
+    return ENV.engine.executeKernel('Maximum', {inputs: {a, b}}) as T;
+  }
+
+  /**
+   * Returns the indices of the minimum values along an `axis`. The result has
+   * the same shape as `input` with the dimension along `axis` removed.
+   *
+   * @param x The input array.
+   * @param axis Optional. The dimension to reduce. By default it reduces
+   * across all axes and returns the flat index.
+   *
+   */
+  @operation
+  static argMin<T extends NDArray<'int32'>>(x: NDArray, axis: number = null):
+      T {
+    let axes = axis_util.parseAxisParam(axis, x.shape);
+    const permutedAxes = axis_util.getAxesPermutation(axes, x.rank);
+    if (permutedAxes != null) {
+      x = transpose.transpose(x, permutedAxes);
+      axes = axis_util.getInnerMostAxes(axes.length, x.rank);
+    }
+    return ENV.engine.executeKernel('ArgMin', {inputs: {x}, args: {axes}}) as T;
+  }
+
+  /**
+   * Returns the indices of the maximum values along an `axis`. The result has
+   * the same shape as `input` with the dimension along `axis` removed.
+   *
+   * @param x The input array.
+   * @param axis Optional. The dimension to reduce. By default it reduces
+   *     across all axes and returns the flat index
+   */
+  @operation
+  static argMax<T extends NDArray<'int32'>>(x: NDArray, axis: number = null):
+      T {
+    let axes = axis_util.parseAxisParam(axis, x.shape);
+    const permutedAxes = axis_util.getAxesPermutation(axes, x.rank);
+    if (permutedAxes != null) {
+      x = transpose.transpose(x, permutedAxes);
+      axes = axis_util.getInnerMostAxes(axes.length, x.rank);
+    }
+
+    return ENV.engine.executeKernel('ArgMax', {inputs: {x}, args: {axes}}) as T;
+  }
+
+  /**
+   * Returns a 1 if the argMax of x1 and x2 are the same, otherwise 0.
+   * @param x1 The first input NDArray.
+   * @param x2 The second input NDArray.
+   */
+  @operation
+  static argMaxEquals(x1: NDArray, x2: NDArray): Scalar<'bool'> {
+    util.assertShapesMatch(x1.shape, x2.shape, 'Error in argMaxEquals: ');
+    return compare.Ops.equal(this.argMax(x1), this.argMax(x2));
+  }
+}

--- a/src/math/minmax.ts
+++ b/src/math/minmax.ts
@@ -45,7 +45,7 @@ export class Ops {
     let axes = origAxes;
     const permutedAxes = axis_util.getAxesPermutation(axes, x.rank);
     if (permutedAxes != null) {
-      x = transpose.transpose(x, permutedAxes);
+      x = transpose.Ops.transpose(x, permutedAxes);
       axes = axis_util.getInnerMostAxes(axes.length, x.rank);
     }
     const res = ENV.engine.executeKernel('Min', {inputs: {x}, args: {axes}}) as
@@ -93,7 +93,7 @@ export class Ops {
     let axes = origAxes;
     const permutedAxes = axis_util.getAxesPermutation(axes, x.rank);
     if (permutedAxes != null) {
-      x = transpose.transpose(x, permutedAxes);
+      x = transpose.Ops.transpose(x, permutedAxes);
       axes = axis_util.getInnerMostAxes(axes.length, x.rank);
     }
     const res = ENV.engine.executeKernel('Max', {inputs: {x}, args: {axes}}) as
@@ -135,7 +135,7 @@ export class Ops {
     let axes = axis_util.parseAxisParam(axis, x.shape);
     const permutedAxes = axis_util.getAxesPermutation(axes, x.rank);
     if (permutedAxes != null) {
-      x = transpose.transpose(x, permutedAxes);
+      x = transpose.Ops.transpose(x, permutedAxes);
       axes = axis_util.getInnerMostAxes(axes.length, x.rank);
     }
     return ENV.engine.executeKernel('ArgMin', {inputs: {x}, args: {axes}}) as T;
@@ -155,7 +155,7 @@ export class Ops {
     let axes = axis_util.parseAxisParam(axis, x.shape);
     const permutedAxes = axis_util.getAxesPermutation(axes, x.rank);
     if (permutedAxes != null) {
-      x = transpose.transpose(x, permutedAxes);
+      x = transpose.Ops.transpose(x, permutedAxes);
       axes = axis_util.getInnerMostAxes(axes.length, x.rank);
     }
 

--- a/src/math/pool.ts
+++ b/src/math/pool.ts
@@ -15,10 +15,10 @@
  * =============================================================================
  */
 
-import {ENV, operation} from '../environment';
+import {ENV} from '../environment';
 import * as util from '../util';
 import * as conv_util from './conv_util';
-// tslint:disable-next-line:max-line-length
+import {operation} from './decorators';
 import {Array4D, DataType, NDArray, Rank, RankMap} from './ndarray';
 
 export class Ops {
@@ -65,7 +65,7 @@ export class Ops {
         x4D.shape, filterSize, strides, pad, dimRoundingMode);
 
     const gradients = (dy: Array4D<'float32'>, y: Array4D) => {
-      return {x: () => this.maxPoolBackprop(dy, x4D, filterSize, strides, pad)};
+      return {x: () => Ops.maxPoolBackprop(dy, x4D, filterSize, strides, pad)};
     };
     const res = ENV.engine.executeKernel(
         'MaxPool', {inputs: {x: x4D}, args: {convInfo}}, gradients);
@@ -230,7 +230,7 @@ export class Ops {
         conv_util.computePool2DInfo(x4D.shape, filterSize, strides, pad);
 
     const gradients = (dy: Array4D<'float32'>, y: Array4D) => {
-      return {x: () => this.avgPoolBackprop(dy, x4D, filterSize, strides, pad)};
+      return {x: () => Ops.avgPoolBackprop(dy, x4D, filterSize, strides, pad)};
     };
     const res = ENV.engine.executeKernel(
         'AvgPool', {inputs: {x: x4D}, args: {convInfo}}, gradients);

--- a/src/math/pool.ts
+++ b/src/math/pool.ts
@@ -15,35 +15,37 @@
  * =============================================================================
  */
 
-import {ENV} from '../environment';
+import {ENV, operation} from '../environment';
 import * as util from '../util';
 import * as conv_util from './conv_util';
 // tslint:disable-next-line:max-line-length
 import {Array4D, DataType, NDArray, Rank, RankMap} from './ndarray';
 
-/**
- * Computes the 2D max pooling of an image.
- *
- * @param x The input ndarray, of rank 4 or rank 3 of shape
- *     [batch, height, width, inChannels]. If rank 3, batch of 1 is assumed.
- * @param filterSize The filter size, a tuple [filterHeight, filterWidth].
- * @param strides The strides of the pooling: [strideHeight, strideWidth].
- * @param pad A string from: 'same', 'valid'. The type of padding algorithm.
- *    - 'same' pad and stride 1: output will be of same size as input,
- *       regardless of filter size.
- *    - 'valid' pad: output will be smaller than input if filter is larger
- *       than 1x1.
- *   - For more info, see this guide:
- *     https://www.tensorflow.org/api_guides/python/nn#Convolution
- * @param dimRoundingMode A string from: 'ceil', 'round', 'floor'. The
- *     rounding mode used when computing output dimensions if pad is a
- *     number. If none is provided, it will not round and error if the output
- *     is of fractional size.
- */
-export function maxPool<T extends NDArray>(
-    x: T, filterSize: [number, number]|number, strides: [number, number]|number,
-    pad: 'valid'|'same'|number, dimRoundingMode?: 'floor'|'round'|'ceil'): T {
-  return ENV.math.scope('maxPool', () => {
+export class Ops {
+  /**
+   * Computes the 2D max pooling of an image.
+   *
+   * @param x The input ndarray, of rank 4 or rank 3 of shape
+   *     [batch, height, width, inChannels]. If rank 3, batch of 1 is assumed.
+   * @param filterSize The filter size, a tuple [filterHeight, filterWidth].
+   * @param strides The strides of the pooling: [strideHeight, strideWidth].
+   * @param pad A string from: 'same', 'valid'. The type of padding algorithm.
+   *    - 'same' pad and stride 1: output will be of same size as input,
+   *       regardless of filter size.
+   *    - 'valid' pad: output will be smaller than input if filter is larger
+   *       than 1x1.
+   *   - For more info, see this guide:
+   *     https://www.tensorflow.org/api_guides/python/nn#Convolution
+   * @param dimRoundingMode A string from: 'ceil', 'round', 'floor'. The
+   *     rounding mode used when computing output dimensions if pad is a
+   *     number. If none is provided, it will not round and error if the output
+   *     is of fractional size.
+   */
+  @operation
+  static maxPool<T extends NDArray>(
+      x: T, filterSize: [number, number]|number,
+      strides: [number, number]|number, pad: 'valid'|'same'|number,
+      dimRoundingMode?: 'floor'|'round'|'ceil'): T {
     let x4D = x as Array4D;
     let reshapedTo4D = false;
     if (x.rank === 3) {
@@ -63,7 +65,7 @@ export function maxPool<T extends NDArray>(
         x4D.shape, filterSize, strides, pad, dimRoundingMode);
 
     const gradients = (dy: Array4D<'float32'>, y: Array4D) => {
-      return {x: () => maxPoolBackprop(dy, x4D, filterSize, strides, pad)};
+      return {x: () => this.maxPoolBackprop(dy, x4D, filterSize, strides, pad)};
     };
     const res = ENV.engine.executeKernel(
         'MaxPool', {inputs: {x: x4D}, args: {convInfo}}, gradients);
@@ -71,33 +73,32 @@ export function maxPool<T extends NDArray>(
       return res.as3D(res.shape[1], res.shape[2], res.shape[3]) as T;
     }
     return res as T;
-  });
-}
+  }
 
-/**
- * Computes the backprop of a max pool.
- *
- * @param dy The dy error, of rank 4 or rank 3 of shape
- *     [batchSize, height, width, channels]. If rank 3, batch of 1 is
- * assumed.
- * @param input The input image, of rank 4 or rank 3 of shape
- *     [batchSize, height, width, channels]. If rank 3, batch of 1 is
- * assumed.
- * @param filterSize The filter size, a tuple [filterHeight, filterWidth].
- * @param strides The strides of the pooling: [strideHeight, strideWidth].
- * @param pad A string from: 'same', 'valid'. The type of padding algorithm
- *     used in the forward prop of the op.
- * @param dimRoundingMode A string from: 'ceil', 'round', 'floor'. The
- *     rounding mode used when computing output dimensions if pad is a
- *     number. If none is provided, it will not round and error if the output
- *     is of fractional size.
- */
-export function maxPoolBackprop<
-    D extends DataType, R extends Rank, T extends RankMap<'float32'>[R]>(
-    dy: NDArray<'float32', R>, input: NDArray<D, R>,
-    filterSize: [number, number]|number, strides: [number, number]|number,
-    pad: 'valid'|'same'|number, dimRoundingMode?: 'floor'|'round'|'ceil'): T {
-  return ENV.math.scope('maxPoolBackprop', () => {
+  /**
+   * Computes the backprop of a max pool.
+   *
+   * @param dy The dy error, of rank 4 or rank 3 of shape
+   *     [batchSize, height, width, channels]. If rank 3, batch of 1 is
+   * assumed.
+   * @param input The input image, of rank 4 or rank 3 of shape
+   *     [batchSize, height, width, channels]. If rank 3, batch of 1 is
+   * assumed.
+   * @param filterSize The filter size, a tuple [filterHeight, filterWidth].
+   * @param strides The strides of the pooling: [strideHeight, strideWidth].
+   * @param pad A string from: 'same', 'valid'. The type of padding algorithm
+   *     used in the forward prop of the op.
+   * @param dimRoundingMode A string from: 'ceil', 'round', 'floor'. The
+   *     rounding mode used when computing output dimensions if pad is a
+   *     number. If none is provided, it will not round and error if the output
+   *     is of fractional size.
+   */
+  @operation
+  static maxPoolBackprop<
+      D extends DataType, R extends Rank, T extends RankMap<'float32'>[R]>(
+      dy: NDArray<'float32', R>, input: NDArray<D, R>,
+      filterSize: [number, number]|number, strides: [number, number]|number,
+      pad: 'valid'|'same'|number, dimRoundingMode?: 'floor'|'round'|'ceil'): T {
     util.assert(
         input.rank === dy.rank,
         `Rank of input (${input.rank}) does not match rank of dy (${dy.rank})`);
@@ -134,33 +135,32 @@ export function maxPoolBackprop<
       return res.as3D(res.shape[1], res.shape[2], res.shape[3]) as T;
     }
     return res as T;
-  });
-}
+  }
 
-/**
- * Computes the 2D min pooling of an image.
- *
- * @param input The input ndarray, of rank 4 or rank 3 of shape
- *     [batch, height, width, inChannels]. If rank 3, batch of 1 is assumed.
- * @param filterSize The filter size, a tuple [filterHeight, filterWidth].
- * @param strides The strides of the pooling: [strideHeight, strideWidth].
- * @param pad A string from: 'same', 'valid'. The type of padding algorithm.
- *    - 'same' pad and stride 1: output will be of same size as input,
- *       regardless of filter size.
- *    - 'valid' pad: output will be smaller than input if filter is larger
- *       than 1x1.
- *   - For more info, see this guide:
- *     https://www.tensorflow.org/api_guides/python/nn#Convolution
- * @param dimRoundingMode A string from: 'ceil', 'round', 'floor'. The
- *     rounding mode used when computing output dimensions if pad is a
- *     number. If none is provided, it will not round and error if the output
- *     is of fractional size.
- */
-export function minPool<T extends NDArray>(
-    input: T, filterSize: [number, number]|number,
-    strides: [number, number]|number, pad: 'valid'|'same'|number,
-    dimRoundingMode?: 'floor'|'round'|'ceil'): T {
-  return ENV.math.scope('minPool', () => {
+  /**
+   * Computes the 2D min pooling of an image.
+   *
+   * @param input The input ndarray, of rank 4 or rank 3 of shape
+   *     [batch, height, width, inChannels]. If rank 3, batch of 1 is assumed.
+   * @param filterSize The filter size, a tuple [filterHeight, filterWidth].
+   * @param strides The strides of the pooling: [strideHeight, strideWidth].
+   * @param pad A string from: 'same', 'valid'. The type of padding algorithm.
+   *    - 'same' pad and stride 1: output will be of same size as input,
+   *       regardless of filter size.
+   *    - 'valid' pad: output will be smaller than input if filter is larger
+   *       than 1x1.
+   *   - For more info, see this guide:
+   *     https://www.tensorflow.org/api_guides/python/nn#Convolution
+   * @param dimRoundingMode A string from: 'ceil', 'round', 'floor'. The
+   *     rounding mode used when computing output dimensions if pad is a
+   *     number. If none is provided, it will not round and error if the output
+   *     is of fractional size.
+   */
+  @operation
+  static minPool<T extends NDArray>(
+      input: T, filterSize: [number, number]|number,
+      strides: [number, number]|number, pad: 'valid'|'same'|number,
+      dimRoundingMode?: 'floor'|'round'|'ceil'): T {
     let input4D = input as Array4D;
     let reshapedTo4D = false;
     if (input.rank === 3) {
@@ -184,33 +184,32 @@ export function minPool<T extends NDArray>(
       return res.as3D(res.shape[1], res.shape[2], res.shape[3]) as T;
     }
     return res as T;
-  });
-}
+  }
 
-/**
- * Computes the 2D average pooling of an image.
- *
- * @param x The input ndarray, of rank 4 or rank 3 of shape
- *     [batch, height, width, inChannels]. If rank 3, batch of 1 is assumed.
- * @param filterSize The filter size, a tuple [filterHeight, filterWidth].
- * @param strides The strides of the pooling: [strideHeight, strideWidth].
- * @param pad A string from: 'same', 'valid'. The type of padding algorithm.
- *    - 'same' pad and stride 1: output will be of same size as input,
- *       regardless of filter size.
- *    - 'valid' pad: output will be smaller than input if filter is larger
- *       than 1x1.
- *   - For more info, see this guide:
- *     https://www.tensorflow.org/api_guides/python/nn#Convolution
- * @param dimRoundingMode A string from: 'ceil', 'round', 'floor'. The
- *     rounding mode used when computing output dimensions if pad is a
- *     number. If none is provided, it will not round and error if the output
- *     is of fractional size.
- */
-export function avgPool<R extends '3'|'4'>(
-    x: NDArray<'int32'|'float32', R>, filterSize: [number, number]|number,
-    strides: [number, number]|number, pad: 'valid'|'same'|number,
-    dimRoundingMode?: 'floor'|'round'|'ceil'): RankMap<'float32'>[R] {
-  return ENV.math.scope('avgPool', () => {
+  /**
+   * Computes the 2D average pooling of an image.
+   *
+   * @param x The input ndarray, of rank 4 or rank 3 of shape
+   *     [batch, height, width, inChannels]. If rank 3, batch of 1 is assumed.
+   * @param filterSize The filter size, a tuple [filterHeight, filterWidth].
+   * @param strides The strides of the pooling: [strideHeight, strideWidth].
+   * @param pad A string from: 'same', 'valid'. The type of padding algorithm.
+   *    - 'same' pad and stride 1: output will be of same size as input,
+   *       regardless of filter size.
+   *    - 'valid' pad: output will be smaller than input if filter is larger
+   *       than 1x1.
+   *   - For more info, see this guide:
+   *     https://www.tensorflow.org/api_guides/python/nn#Convolution
+   * @param dimRoundingMode A string from: 'ceil', 'round', 'floor'. The
+   *     rounding mode used when computing output dimensions if pad is a
+   *     number. If none is provided, it will not round and error if the output
+   *     is of fractional size.
+   */
+  @operation
+  static avgPool<R extends '3'|'4'>(
+      x: NDArray<'int32'|'float32', R>, filterSize: [number, number]|number,
+      strides: [number, number]|number, pad: 'valid'|'same'|number,
+      dimRoundingMode?: 'floor'|'round'|'ceil'): RankMap<'float32'>[R] {
     let x4D = x as Array4D;
     let reshapedTo4D = false;
     if (x.rank === 3) {
@@ -231,7 +230,7 @@ export function avgPool<R extends '3'|'4'>(
         conv_util.computePool2DInfo(x4D.shape, filterSize, strides, pad);
 
     const gradients = (dy: Array4D<'float32'>, y: Array4D) => {
-      return {x: () => avgPoolBackprop(dy, x4D, filterSize, strides, pad)};
+      return {x: () => this.avgPoolBackprop(dy, x4D, filterSize, strides, pad)};
     };
     const res = ENV.engine.executeKernel(
         'AvgPool', {inputs: {x: x4D}, args: {convInfo}}, gradients);
@@ -240,29 +239,28 @@ export function avgPool<R extends '3'|'4'>(
           RankMap<'float32'>[R];
     }
     return res as RankMap<'float32'>[R];
-  });
-}
+  }
 
-/**
- * Computes the backprop of an avg pool.
- *
- * @param dy The dy error, of rank 4 or rank 3 of shape
- *     [batchSize, height, width, channels]. If rank 3, batch of 1 is
- * assumed.
- * @param input The input image, of rank 4 or rank 3 of shape
- *     [batchSize, height, width, channels]. If rank 3, batch of 1 is
- * assumed.
- * @param filterSize The filter size, a tuple [filterHeight, filterWidth].
- * @param strides The strides of the pooling: [strideHeight, strideWidth].
- * @param pad A string from: 'same', 'valid'. The type of padding algorithm
- *     used in the forward prop of the op.
- */
-function avgPoolBackprop<D extends DataType, R extends
+  /**
+   * Computes the backprop of an avg pool.
+   *
+   * @param dy The dy error, of rank 4 or rank 3 of shape
+   *     [batchSize, height, width, channels]. If rank 3, batch of 1 is
+   * assumed.
+   * @param input The input image, of rank 4 or rank 3 of shape
+   *     [batchSize, height, width, channels]. If rank 3, batch of 1 is
+   * assumed.
+   * @param filterSize The filter size, a tuple [filterHeight, filterWidth].
+   * @param strides The strides of the pooling: [strideHeight, strideWidth].
+   * @param pad A string from: 'same', 'valid'. The type of padding algorithm
+   *     used in the forward prop of the op.
+   */
+  @operation
+  static avgPoolBackprop<D extends DataType, R extends
                          '3'|'4', T extends RankMap<'float32'>[R]>(
-    dy: NDArray<'float32', R>, input: NDArray<D, R>,
-    filterSize: [number, number]|number, strides: [number, number]|number,
-    pad: 'valid'|'same'|number): T {
-  return ENV.math.scope('avgPoolBackprop', () => {
+      dy: NDArray<'float32', R>, input: NDArray<D, R>,
+      filterSize: [number, number]|number, strides: [number, number]|number,
+      pad: 'valid'|'same'|number): T {
     util.assert(
         input.rank === dy.rank,
         `Rank of input (${input.rank}) does not match rank of dy (${dy.rank})`);
@@ -293,5 +291,5 @@ function avgPoolBackprop<D extends DataType, R extends
       return res.as3D(res.shape[1], res.shape[2], res.shape[3]) as T;
     }
     return res as T;
-  });
+  }
 }

--- a/src/math/reverse.ts
+++ b/src/math/reverse.ts
@@ -31,7 +31,7 @@ export class Ops {
     util.assert(x.rank === 1, `Error in reverse1D: x must be rank 1 but got
              rank ${x.rank}.`);
     const input4D = x.as4D(1, 1, 1, x.shape[0]);
-    const res = this.reverse4D(input4D, [3]);
+    const res = Ops.reverse4D(input4D, [3]);
     return res.as1D();
   }
 
@@ -47,7 +47,7 @@ export class Ops {
              rank ${x.rank}.`);
     const axisCleaned = axis_util.parseAxisParam(axis, x.shape).map(a => a + 2);
     const input4D = x.as4D(1, 1, x.shape[0], x.shape[1]);
-    const res = this.reverse4D(input4D, axisCleaned);
+    const res = Ops.reverse4D(input4D, axisCleaned);
     return res.as2D(res.shape[2], res.shape[3]);
   }
 
@@ -63,7 +63,7 @@ export class Ops {
              rank ${x.rank}.`);
     const axisCleaned = axis_util.parseAxisParam(axis, x.shape).map(a => a + 1);
     const input4D = x.as4D(1, x.shape[0], x.shape[1], x.shape[2]);
-    const res = this.reverse4D(input4D, axisCleaned);
+    const res = Ops.reverse4D(input4D, axisCleaned);
     return res.as3D(res.shape[1], res.shape[2], res.shape[3]);
   }
 

--- a/src/math/reverse.ts
+++ b/src/math/reverse.ts
@@ -15,9 +15,10 @@
  * =============================================================================
  */
 
-import {ENV, operation} from '../environment';
+import {ENV} from '../environment';
 import * as util from '../util';
 import * as axis_util from './axis_util';
+import {operation} from './decorators';
 import {Array1D, Array2D, Array3D, Array4D} from './ndarray';
 
 export class Ops {

--- a/src/math/reverse.ts
+++ b/src/math/reverse.ts
@@ -15,71 +15,69 @@
  * =============================================================================
  */
 
-import {ENV} from '../environment';
+import {ENV, operation} from '../environment';
 import * as util from '../util';
 import * as axis_util from './axis_util';
 import {Array1D, Array2D, Array3D, Array4D} from './ndarray';
 
-/**
- * Reverses a 1D array
- * @param x The input array.
- */
-export function reverse1D(x: Array1D): Array1D {
-  return ENV.math.scope('reverse1D', () => {
+export class Ops {
+  /**
+   * Reverses a 1D array
+   * @param x The input array.
+   */
+  @operation
+  static reverse1D(x: Array1D): Array1D {
     util.assert(x.rank === 1, `Error in reverse1D: x must be rank 1 but got
              rank ${x.rank}.`);
     const input4D = x.as4D(1, 1, 1, x.shape[0]);
-    const res = reverse4D(input4D, [3]);
+    const res = this.reverse4D(input4D, [3]);
     return res.as1D();
-  });
-}
+  }
 
-/**
- * Reverses a 2D array along a specified axis
- * @param x The input array.
- * @param axis The set of dimensions to reverse. Must be in the
- *     range [-rank(x), rank(x)).
- */
-export function reverse2D(x: Array2D, axis: number|number[]): Array2D {
-  return ENV.math.scope('reverse2D', () => {
+  /**
+   * Reverses a 2D array along a specified axis
+   * @param x The input array.
+   * @param axis The set of dimensions to reverse. Must be in the
+   *     range [-rank(x), rank(x)).
+   */
+  @operation
+  static reverse2D(x: Array2D, axis: number|number[]): Array2D {
     util.assert(x.rank === 2, `Error in reverse2D: x must be rank 2 but got
              rank ${x.rank}.`);
     const axisCleaned = axis_util.parseAxisParam(axis, x.shape).map(a => a + 2);
     const input4D = x.as4D(1, 1, x.shape[0], x.shape[1]);
-    const res = reverse4D(input4D, axisCleaned);
+    const res = this.reverse4D(input4D, axisCleaned);
     return res.as2D(res.shape[2], res.shape[3]);
-  });
-}
+  }
 
-/**
- * Reverses a 3D array along a specified axis
- * @param x The input array.
- * @param axis The set of dimensions to reverse. Must be in the
- *     range [-rank(x), rank(x)).
- */
-export function reverse3D(x: Array3D, axis: number|number[]): Array3D {
-  return ENV.math.scope('reverse3D', () => {
+  /**
+   * Reverses a 3D array along a specified axis
+   * @param x The input array.
+   * @param axis The set of dimensions to reverse. Must be in the
+   *     range [-rank(x), rank(x)).
+   */
+  @operation
+  static reverse3D(x: Array3D, axis: number|number[]): Array3D {
     util.assert(x.rank === 3, `Error in reverse3D: x must be rank 3 but got
              rank ${x.rank}.`);
     const axisCleaned = axis_util.parseAxisParam(axis, x.shape).map(a => a + 1);
     const input4D = x.as4D(1, x.shape[0], x.shape[1], x.shape[2]);
-    const res = reverse4D(input4D, axisCleaned);
+    const res = this.reverse4D(input4D, axisCleaned);
     return res.as3D(res.shape[1], res.shape[2], res.shape[3]);
-  });
-}
+  }
 
-/**
- * Reverses a 4D array along a specified axis
- * @param x The input array.
- * @param axis The set of dimensions to reverse. Must be in the
- *     range [-rank(x), rank(x)).
- */
-export function reverse4D(x: Array4D, axis: number|number[]): Array4D {
-  return ENV.math.scope('reverse4D', () => {
+  /**
+   * Reverses a 4D array along a specified axis
+   * @param x The input array.
+   * @param axis The set of dimensions to reverse. Must be in the
+   *     range [-rank(x), rank(x)).
+   */
+  @operation
+  static reverse4D(x: Array4D, axis: number|number[]): Array4D {
     util.assert(x.rank === 4, `Error in reverse4D: x must be rank 4 but got
              rank ${x.rank}.`);
     const axisCleaned = axis_util.parseAxisParam(axis, x.shape);
     return ENV.engine.executeKernel(
         'Reverse4D', {inputs: {x}, args: {axis: axisCleaned}});
-  });
+  }
 }

--- a/src/math/slice.ts
+++ b/src/math/slice.ts
@@ -15,7 +15,8 @@
  * =============================================================================
  */
 
-import {ENV, operation} from '../environment';
+import {ENV} from '../environment';
+import {operation} from './decorators';
 import {Array1D, Array2D, Array3D, Array4D, DataType} from './ndarray';
 import * as slice_util from './slice_util';
 

--- a/src/math/slice.ts
+++ b/src/math/slice.ts
@@ -15,78 +15,76 @@
  * =============================================================================
  */
 
-import {ENV} from '../environment';
+import {ENV, operation} from '../environment';
 import {Array1D, Array2D, Array3D, Array4D, DataType} from './ndarray';
 import * as slice_util from './slice_util';
 
-/**
- * Extracts a 1D slice from 1D array starting at coordinates `begin` and is
- * of length `size`.
- *
- * @param x The input array to slice from.
- * @param begin The offset to start the slice from.
- * @param size The size of the slice.
- */
-export function slice1D<D extends DataType>(
-    x: Array1D<D>, begin: number, size: number): Array1D<D> {
-  return ENV.math.scope('slice1D', () => {
+export class Ops {
+  /**
+   * Extracts a 1D slice from 1D array starting at coordinates `begin` and is
+   * of length `size`.
+   *
+   * @param x The input array to slice from.
+   * @param begin The offset to start the slice from.
+   * @param size The size of the slice.
+   */
+  @operation
+  static slice1D<D extends DataType>(
+      x: Array1D<D>, begin: number, size: number): Array1D<D> {
     slice_util.assertParamsValid(x, [begin], [size]);
     return ENV.engine.executeKernel(
                'Slice1D', {inputs: {x}, args: {begin, size}}) as Array1D<D>;
-  });
-}
+  }
 
-/**
- * Extracts a 2D slice from a 2D array starting at coordinates `begin` and
- * is of size `size`.
- *
- * @param x The input array to slice from.
- * @param begin The [row, col] 2d coordinates to start the slice from.
- * @param size The size of the slice.
- */
-export function slice2D<D extends DataType>(
-    x: Array2D<D>, begin: [number, number],
-    size: [number, number]): Array2D<D> {
-  return ENV.math.scope('slice2D', () => {
+  /**
+   * Extracts a 2D slice from a 2D array starting at coordinates `begin` and
+   * is of size `size`.
+   *
+   * @param x The input array to slice from.
+   * @param begin The [row, col] 2d coordinates to start the slice from.
+   * @param size The size of the slice.
+   */
+  @operation
+  static slice2D<D extends DataType>(
+      x: Array2D<D>, begin: [number, number], size: [number, number]):
+      Array2D<D> {
     slice_util.assertParamsValid(x, begin, size);
     return ENV.engine.executeKernel(
                'Slice2D', {inputs: {x}, args: {begin, size}}) as Array2D<D>;
-  });
-}
+  }
 
-/**
- * Extracts a 3D slice from a 3D array starting at coordinates `begin` and
- * is of size `size`.
- *
- * @param x The input array to slice from.
- * @param begin The [row, col, depth] 3d coordinates to start the slice from.
- * @param size The size of the slice.
- */
-export function slice3D<D extends DataType>(
-    x: Array3D<D>, begin: [number, number, number],
-    size: [number, number, number]): Array3D<D> {
-  return ENV.math.scope('slice3D', () => {
+  /**
+   * Extracts a 3D slice from a 3D array starting at coordinates `begin` and
+   * is of size `size`.
+   *
+   * @param x The input array to slice from.
+   * @param begin The [row, col, depth] 3d coordinates to start the slice from.
+   * @param size The size of the slice.
+   */
+  @operation
+  static slice3D<D extends DataType>(
+      x: Array3D<D>, begin: [number, number, number],
+      size: [number, number, number]): Array3D<D> {
     slice_util.assertParamsValid(x, begin, size);
     return ENV.engine.executeKernel(
                'Slice3D', {inputs: {x}, args: {begin, size}}) as Array3D<D>;
-  });
-}
+  }
 
-/**
- * Extracts a 4D slice from a 4D array starting at coordinates `begin` and
- * is of size `size`.
- *
- * @param x The input array to slice from.
- * @param begin The [row, col, depth, depth2] 4d coordinates to start the
- *              slice from.
- * @param size The size of the slice.
- */
-export function slice4D<D extends DataType>(
-    x: Array4D<D>, begin: [number, number, number, number],
-    size: [number, number, number, number]): Array4D<D> {
-  return ENV.math.scope('slice4D', () => {
+  /**
+   * Extracts a 4D slice from a 4D array starting at coordinates `begin` and
+   * is of size `size`.
+   *
+   * @param x The input array to slice from.
+   * @param begin The [row, col, depth, depth2] 4d coordinates to start the
+   *              slice from.
+   * @param size The size of the slice.
+   */
+  @operation
+  static slice4D<D extends DataType>(
+      x: Array4D<D>, begin: [number, number, number, number],
+      size: [number, number, number, number]): Array4D<D> {
     slice_util.assertParamsValid(x, begin, size);
     return ENV.engine.executeKernel(
                'Slice4D', {inputs: {x}, args: {begin, size}}) as Array4D<D>;
-  });
+  }
 }

--- a/src/math/transpose.ts
+++ b/src/math/transpose.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {ENV, operation} from '../environment';
+import * as util from '../util';
+import * as axis_util from './axis_util';
+import {NDArray} from './ndarray';
+
+export class Ops {
+  /**
+   * Transposes the array. Permutes the dimensions according to `perm`.
+   *
+   * The returned array's dimension `i` will correspond to the input dimension
+   * `perm[i]`. If `perm` is not given, it is set to `[n-1...0]`, where `n` is
+   * the rank of the input array. Hence by default, this operation performs a
+   * regular matrix transpose on 2-D input arrays.
+   *
+   * @param x The array to transpose.
+   * @param perm Optional. The permutation of the dimensions of a.
+   */
+  @operation
+  static transpose<T extends NDArray>(x: T, perm?: number[]): T {
+    if (perm == null) {
+      perm = x.shape.map((s, i) => i).reverse();
+    }
+    const der = (dy: NDArray<'float32'>) => {
+      const undoPerm = axis_util.getUndoAxesPermutation(perm);
+      const derX = () => this.transpose(dy, undoPerm);
+      return {x: derX};
+    };
+    util.assert(
+        x.rank === perm.length,
+        `Error in transpose: rank of input ${x.rank} ` +
+            `must match length of perm ${perm}.`);
+    return ENV.engine.executeKernel(
+               'Transpose', {inputs: {x}, args: {perm}}, der) as T;
+  }
+}

--- a/src/math/transpose.ts
+++ b/src/math/transpose.ts
@@ -15,9 +15,10 @@
  * =============================================================================
  */
 
-import {ENV, operation} from '../environment';
+import {ENV} from '../environment';
 import * as util from '../util';
 import * as axis_util from './axis_util';
+import {operation} from './decorators';
 import {NDArray} from './ndarray';
 
 export class Ops {

--- a/src/math/transpose.ts
+++ b/src/math/transpose.ts
@@ -40,7 +40,7 @@ export class Ops {
     }
     const der = (dy: NDArray<'float32'>) => {
       const undoPerm = axis_util.getUndoAxesPermutation(perm);
-      const derX = () => this.transpose(dy, undoPerm);
+      const derX = () => Ops.transpose(dy, undoPerm);
       return {x: derX};
     };
     util.assert(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "noUnusedParameters": false,
     "pretty": true,
     "noFallthroughCasesInSwitch": true,
-    "allowUnreachableCode": false
+    "allowUnreachableCode": false,
+    "experimentalDecorators": true
   },
   "include": [
     "src/"


### PR DESCRIPTION
Add `@operation` decorator that wraps the method in a math.scope(methodName, () => {}). This helps annotate all ops, track them (in debug mode) and significantly reduce chances of memory leaks.

Also migrate more math ops to global namespace:
 - compare (less, greater, equal etc)
 - min/max/minimum/maximum/argMin/argMax/argMaxEquals
 - transpose

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/577)
<!-- Reviewable:end -->
