### PR TITLE
Replace undefined Error object

### DIFF
--- a/scripts/dump_checkpoints/dump_checkpoint_vars.py
+++ b/scripts/dump_checkpoints/dump_checkpoint_vars.py
@@ -57,7 +57,7 @@ def get_checkpoint_dumper(model_type, checkpoint_file, output_dir, remove_variab
     return PytorchCheckpointDumper(
       checkpoint_file, output_dir, remove_variables_regex)
   else:
-    raise Error('Currently, "%s" models are not supported'.format(model_type))
+    raise ValueError('Currently, "{}" models are not supported'.format(model_type))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In `scripts/dump_checkpoints/dump_checkpoint_vars.py` `Error` object is raised, but it doesn't exist in Python. So, I replaced `Error` with [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError). 
I also found invalid use of `format` method. As you know, `%s` is not treated by `format` method. So, I replaced `%s` with `{}`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/579)
<!-- Reviewable:end -->
