### PR TITLE
Make shell scripts work on win64 too.

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "test": "karma start",
     "test-travis": "karma start --browsers='bs_firefox_mac,bs_chrome_mac' --singleRun",
     "lint": "tslint -p . -t verbose",
-    "make-version": "./scripts/make-version"
+    "make-version": "sh -c ./scripts/make-version"
   },
   "dependencies": {
     "seedrandom": "~2.4.3"


### PR DESCRIPTION
Fix #534 - windows needs a 'sh -c' prefix for running npm commands.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/581)
<!-- Reviewable:end -->
