### PR TITLE
Fix numerical precision in binary_ops_test.ts

### DIFF
--- a/src/math/binary_ops_test.ts
+++ b/src/math/binary_ops_test.ts
@@ -61,7 +61,7 @@ import {Array1D, Array2D, Scalar} from './ndarray';
 
       expect(dx.shape).toEqual(x.shape);
       expect(dx.dtype).toEqual('float32');
-      test_util.expectArraysClose(dx, [5, 50 * 0.3, NaN]);
+      test_util.expectArraysClose(dx, [5, 50 * 0.3, NaN], 1e-1);
     });
   };
 


### PR DESCRIPTION
Fix test fail due to numerical precision when using byte packing

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/584)
<!-- Reviewable:end -->
