### PR TITLE
Unary Ops Grad: Adds gradient for math.neg, math.exp and math.log

### DIFF
--- a/src/math/unary_ops.ts
+++ b/src/math/unary_ops.ts
@@ -29,7 +29,11 @@ export class Ops {
   @operation
   static neg<D extends DataType, R extends Rank>(x: NDArray<D, R>):
       RankMap<D>[R] {
-    return ENV.engine.executeKernel('Neg', {inputs: {x}}) as RankMap<D>[R];
+    return ENV.engine.executeKernel(
+               'Neg', {inputs: {x}},
+               (dy: NDArray<'float32', R>, y: NDArray<D, R>) => {
+                 return {x: () => dy.mul(Scalar.new(-1))};
+               }) as RankMap<D>[R];
   }
 
   /**

--- a/src/math/unary_ops.ts
+++ b/src/math/unary_ops.ts
@@ -30,7 +30,7 @@ export class Ops {
   static neg<R extends Rank, T extends NDArray<R>>(x: T): T {
     return ENV.engine.executeKernel(
                'Neg', {inputs: {x}}, (dy: NDArray<R>, y: NDArray<R>) => {
-                 return {x: () => dy.mul(Scalar.new(-1))};
+                 return {x: () => dy.neg()};
                }) as T;
   }
 
@@ -63,7 +63,7 @@ export class Ops {
   static exp<R extends Rank, T extends NDArray<R>>(x: T): T {
     return ENV.engine.executeKernel(
                'Exp', {inputs: {x}}, (dy: NDArray<R>, y: NDArray<R>) => {
-                 return {x: () => dy.mul(Ops.exp(x.asType('float32')))};
+                 return {x: () => dy.mul(y)};
                }) as T;
   }
 
@@ -75,7 +75,7 @@ export class Ops {
   static log<R extends Rank, T extends NDArray<R>>(x: T): T {
     return ENV.engine.executeKernel(
                'Log', {inputs: {x}}, (dy: NDArray<R>, y: NDArray<R>) => {
-                 return {x: () => dy.div(x.asType('float32'))};
+                 return {x: () => dy.div(x.toFloat())};
                }) as T;
   }
 

--- a/src/math/unary_ops.ts
+++ b/src/math/unary_ops.ts
@@ -66,7 +66,11 @@ export class Ops {
   @operation
   static exp<D extends DataType, R extends Rank>(x: NDArray<D, R>):
       RankMap<D>[R] {
-    return ENV.engine.executeKernel('Exp', {inputs: {x}}) as RankMap<D>[R];
+    return ENV.engine.executeKernel(
+               'Exp', {inputs: {x}},
+               (dy: NDArray<'float32', R>, y: NDArray<D, R>) => {
+                 return {x: () => dy.mul(Ops.exp(x.asType('float32')))};
+               }) as RankMap<D>[R];
   }
 
   /**
@@ -76,7 +80,11 @@ export class Ops {
   @operation
   static log<D extends DataType, R extends Rank>(x: NDArray<D, R>):
       RankMap<D>[R] {
-    return ENV.engine.executeKernel('Log', {inputs: {x}}) as RankMap<D>[R];
+    return ENV.engine.executeKernel(
+               'Log', {inputs: {x}},
+               (dy: NDArray<'float32', R>, y: NDArray<D, R>) => {
+                 return {x: () => dy.div(x.asType('float32'))};
+               }) as RankMap<D>[R];
   }
 
   /**

--- a/src/math/unary_ops_test.ts
+++ b/src/math/unary_ops_test.ts
@@ -217,6 +217,41 @@ import {Array1D, Array2D, Scalar} from './ndarray';
       const expected = [-1, 3, -2, -7, NaN];
       test_util.expectArraysClose(result, expected);
     });
+
+    it('gradients: Scalar', math => {
+      const a = Scalar.new(4);
+      const dy = Scalar.new(8);
+
+      const gradients = math.vjp(() => math.neg(a), a, dy);
+
+      expect(gradients.shape).toEqual(a.shape);
+      expect(gradients.dtype).toEqual('float32');
+      test_util.expectArraysClose(gradients, [8 * -1], 1e-1);
+    });
+
+    it('gradients: Array1D', math => {
+      const a = Array1D.new([1, 2, -3, 5]);
+      const dy = Array1D.new([1, 2, 3, 4]);
+
+      const gradients = math.vjp(() => math.neg(a), a, dy);
+
+      expect(gradients.shape).toEqual(a.shape);
+      expect(gradients.dtype).toEqual('float32');
+      test_util.expectArraysClose(
+          gradients, [1 * -1, 2 * -1, 3 * -1, 4 * -1], 1e-1);
+    });
+
+    it('gradients: Array2D', math => {
+      const a = Array2D.new([2, 2], [3, -1, -2, 3]);
+      const dy = Array2D.new([2, 2], [1, 2, 3, 4]);
+
+      const gradients = math.vjp(() => math.neg(a), a, dy);
+
+      expect(gradients.shape).toEqual(a.shape);
+      expect(gradients.dtype).toEqual('float32');
+      test_util.expectArraysClose(
+          gradients, [1 * -1, 2 * -1, 3 * -1, 4 * -1], 1e-1);
+    });
   };
 
   test_util.describeMathCPU('neg', [tests]);

--- a/src/math/unary_ops_test.ts
+++ b/src/math/unary_ops_test.ts
@@ -443,6 +443,41 @@ import {Array1D, Array2D, Scalar} from './ndarray';
       const r = math.log(a);
       test_util.expectArraysClose(r, [Math.log(1), NaN]);
     });
+
+    it('gradients: Scalar', math => {
+      const a = Scalar.new(5);
+      const dy = Scalar.new(3);
+
+      const gradients = math.vjp(() => math.log(a), a, dy);
+
+      expect(gradients.shape).toEqual(a.shape);
+      expect(gradients.dtype).toEqual('float32');
+      test_util.expectArraysClose(gradients, [3 / 5], 1e-1);
+    });
+
+    it('gradients: Array1D', math => {
+      const a = Array1D.new([-1, 2, 3, -5]);
+      const dy = Array1D.new([1, 2, 3, 4]);
+
+      const gradients = math.vjp(() => math.log(a), a, dy);
+
+      expect(gradients.shape).toEqual(a.shape);
+      expect(gradients.dtype).toEqual('float32');
+      test_util.expectArraysClose(
+          gradients, [1 / -1, 2 / 2, 3 / 3, 4 / -5], 1e-1);
+    });
+
+    it('gradients: Array2D', math => {
+      const a = Array2D.new([2, 2], [-3, 1, 2, 3]);
+      const dy = Array2D.new([2, 2], [1, 2, 3, 4]);
+
+      const gradients = math.vjp(() => math.log(a), a, dy);
+
+      expect(gradients.shape).toEqual(a.shape);
+      expect(gradients.dtype).toEqual('float32');
+      test_util.expectArraysClose(
+          gradients, [1 / -3, 2 / 1, 3 / 2, 4 / 3], 1e-1);
+    });
   };
 
   test_util.describeMathCPU('log', [tests]);
@@ -522,6 +557,47 @@ import {Array1D, Array2D, Scalar} from './ndarray';
       const a = Array1D.new([1, NaN, 0]);
       const r = math.exp(a);
       test_util.expectArraysClose(r, [Math.exp(1), NaN, 1]);
+    });
+
+    it('gradients: Scalar', math => {
+      const a = Scalar.new(5);
+      const dy = Scalar.new(3);
+
+      const gradients = math.vjp(() => math.exp(a), a, dy);
+
+      expect(gradients.shape).toEqual(a.shape);
+      expect(gradients.dtype).toEqual('float32');
+      test_util.expectArraysClose(gradients, [3 * Math.exp(5)], 1);
+    });
+
+    it('gradients: Array1D', math => {
+      const a = Array1D.new([-1, 2, 3, -5]);
+      const dy = Array1D.new([1, 2, 3, 4]);
+
+      const gradients = math.vjp(() => math.exp(a), a, dy);
+
+      expect(gradients.shape).toEqual(a.shape);
+      expect(gradients.dtype).toEqual('float32');
+      test_util.expectArraysClose(
+          gradients,
+          [
+            1 * Math.exp(-1), 2 * Math.exp(2), 3 * Math.exp(3), 4 * Math.exp(-5)
+          ],
+          1e-1);
+    });
+
+    it('gradients: Array2D', math => {
+      const a = Array2D.new([2, 2], [-3, 1, 2, 3]);
+      const dy = Array2D.new([2, 2], [1, 2, 3, 4]);
+
+      const gradients = math.vjp(() => math.exp(a), a, dy);
+
+      expect(gradients.shape).toEqual(a.shape);
+      expect(gradients.dtype).toEqual('float32');
+      test_util.expectArraysClose(
+          gradients,
+          [1 * Math.exp(-3), 2 * Math.exp(1), 3 * Math.exp(2), 4 * Math.exp(3)],
+          1e-1);
     });
   };
 

--- a/src/math/unary_ops_test.ts
+++ b/src/math/unary_ops_test.ts
@@ -560,14 +560,14 @@ import {Array1D, Array2D, Scalar} from './ndarray';
     });
 
     it('gradients: Scalar', math => {
-      const a = Scalar.new(5);
+      const a = Scalar.new(0.5);
       const dy = Scalar.new(3);
 
       const gradients = math.vjp(() => math.exp(a), a, dy);
 
       expect(gradients.shape).toEqual(a.shape);
       expect(gradients.dtype).toEqual('float32');
-      test_util.expectArraysClose(gradients, [3 * Math.exp(5)], 1);
+      test_util.expectArraysClose(gradients, [3 * Math.exp(0.5)], 1e-1);
     });
 
     it('gradients: Array1D', math => {


### PR DESCRIPTION
This PR adds gradients for `math.neg`, `math.exp` and `math.log`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/588)
<!-- Reviewable:end -->
