### PR TITLE
Remove dtype from generics

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,16 +1,25 @@
 {
     "version": "2.0.0",
     "tasks": [
-        {
-            "command": "yarn",
-            "label": "lint",
-            "type": "shell",
-            "args": ["lint"],
-            "problemMatcher": {
-                "base": "$tslint5",
-                "owner": "tslint-type-checked",
-                "fileLocation": "absolute"
-            }
+      {
+        "command": "yarn",
+        "label": "lint",
+        "type": "shell",
+        "args": [
+          "lint"
+        ],
+        "problemMatcher": {
+          "base": "$tslint5",
+          "owner": "tslint-type-checked",
+          "fileLocation": "absolute"
         }
+      },
+      {
+        "type": "npm",
+        "script": "build",
+        "problemMatcher": [
+          "$tsc"
+        ]
+      }
     ]
-}
+  }

--- a/src/data/dataset_test.ts
+++ b/src/data/dataset_test.ts
@@ -15,6 +15,7 @@
  * =============================================================================
  */
 
+import * as dl from '../index';
 import {Array2D, NDArray} from '../math/ndarray';
 import * as test_util from '../test_util';
 
@@ -41,8 +42,8 @@ describe('Dataset', () => {
         Array2D.new([2, 3], [4, 5, 40, -4, 4, 1])
       ],
       [
-        NDArray.randNormal([1]), NDArray.randNormal([1]),
-        NDArray.randNormal([1]), NDArray.randNormal([1])
+        dl.randNormal([1]), dl.randNormal([1]), dl.randNormal([1]),
+        dl.randNormal([1])
       ]
     ];
     const dataset = new StubDataset(data);

--- a/src/data/dataset_test.ts
+++ b/src/data/dataset_test.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {Array1D, Array2D, NDArray} from '../math/ndarray';
+import {Array2D, NDArray} from '../math/ndarray';
 import * as test_util from '../test_util';
 
 import {InMemoryDataset} from './dataset';
@@ -41,8 +41,8 @@ describe('Dataset', () => {
         Array2D.new([2, 3], [4, 5, 40, -4, 4, 1])
       ],
       [
-        Array1D.randNormal([1]), Array1D.randNormal([1]),
-        Array1D.randNormal([1]), Array1D.randNormal([1])
+        NDArray.randNormal([1]), NDArray.randNormal([1]),
+        NDArray.randNormal([1]), NDArray.randNormal([1])
       ]
     ];
     const dataset = new StubDataset(data);

--- a/src/data/input_provider.ts
+++ b/src/data/input_provider.ts
@@ -134,7 +134,7 @@ export abstract class InMemoryShuffledInputProviderBuilder implements
  */
 export class InCPUMemoryShuffledInputProviderBuilder extends
     InMemoryShuffledInputProviderBuilder {
-  getInputProvider(inputId: number) {
+  getInputProvider(inputId: number): InputProvider {
     const shuffledInputProvider = this;
 
     return {
@@ -156,7 +156,7 @@ export class InCPUMemoryShuffledInputProviderBuilder extends
  */
 export class InGPUMemoryShuffledInputProviderBuilder extends
     InMemoryShuffledInputProviderBuilder {
-  getInputProvider(inputId: number) {
+  getInputProvider(inputId: number): InputProvider {
     const shuffledInputProvider = this;
 
     return {

--- a/src/graph/activation_functions.ts
+++ b/src/graph/activation_functions.ts
@@ -36,7 +36,7 @@ export class TanHFunc implements ActivationFunction {
     return math.scope(() => {
       const ySquared = math.multiplyStrict(y, y);
       // 1 - y^2.
-      return math.subtract(this.one, ySquared as NDArray<'float32'>) as T;
+      return math.subtract(this.one, ySquared as NDArray) as T;
     });
   }
 
@@ -100,7 +100,7 @@ export class SquareFunc implements ActivationFunction {
 
   der<T extends NDArray>(math: NDArrayMath, x: T, y: T) {
     // dy/dx = 2*x.
-    return math.multiply(this.two, x as NDArray<'float32'>) as T;
+    return math.multiply(this.two, x as NDArray) as T;
   }
 
   dispose() {

--- a/src/graph/graph_runner.ts
+++ b/src/graph/graph_runner.ts
@@ -83,7 +83,7 @@ export class GraphRunner {
   private lastCostTimestamp = 0;
   private lastEvalTimestamp = 0;
 
-  private zeroScalar: Scalar<'float32'>;
+  private zeroScalar: Scalar;
   private metricBatchSizeScalar: Scalar;
 
   constructor(
@@ -299,7 +299,7 @@ export class GraphRunner {
     return this.isInferring;
   }
 
-  computeMetric(): Scalar<'float32'> {
+  computeMetric(): Scalar {
     if (this.metricFeedEntries == null) {
       throw new Error('Cannot compute metric, no metric FeedEntries provided.');
     }
@@ -310,7 +310,7 @@ export class GraphRunner {
       for (let i = 0; i < this.metricBatchSize; i++) {
         const metricValue =
             this.session.eval(this.metricTensor, this.metricFeedEntries) as
-            NDArray<'float32'>;
+            NDArray;
 
         metric = this.math.add(metric, metricValue.asType('float32'));
       }

--- a/src/graph/graph_test.ts
+++ b/src/graph/graph_test.ts
@@ -15,9 +15,8 @@
  * =============================================================================
  */
 
+import * as dl from '../index';
 import * as conv_util from '../math/conv_util';
-import {NDArray} from '../math/ndarray';
-
 import {ConstantNode, Graph, Node, Tensor, VariableNode} from './graph';
 import {FeedDictionary} from './session';
 import * as session_util from './session_util';
@@ -40,39 +39,39 @@ describe('Graph', () => {
   });
 
   it('variable creates a node in the graph', () => {
-    const v = g.variable('', NDArray.zeros([1]));
+    const v = g.variable('', dl.zeros([1]));
     expect(v.node.graph).toEqual(g);
   });
 
   it('variable creates a VariableNode in the graph', () => {
-    const v = g.variable('', NDArray.zeros([1]));
+    const v = g.variable('', dl.zeros([1]));
     expect(v.node instanceof VariableNode).toEqual(true);
   });
 
   it('variable passes name to graph node', () => {
-    const v = g.variable('hello', NDArray.zeros([1]));
+    const v = g.variable('hello', dl.zeros([1]));
     expect(v.node.name).toEqual('hello');
   });
 
   it('mnist fully-connected', () => {
     const input = g.placeholder('input', [28 * 28]);
-    const fc0W = g.variable('fc0W', NDArray.zeros([32, 28 * 28]));
-    const fc0B = g.variable('fc0B', NDArray.zeros([32]));
+    const fc0W = g.variable('fc0W', dl.zeros([32, 28 * 28]));
+    const fc0B = g.variable('fc0B', dl.zeros([32]));
     const fc0 = g.add(g.matmul(fc0W, input), fc0B);
     const relu0 = g.relu(fc0);
-    const fc1W = g.variable('fc1W', NDArray.zeros([32, 32]));
-    const fc1B = g.variable('fc1B', NDArray.zeros([32]));
+    const fc1W = g.variable('fc1W', dl.zeros([32, 32]));
+    const fc1B = g.variable('fc1B', dl.zeros([32]));
     const fc1 = g.add(g.matmul(fc1W, relu0), fc1B);
     const relu1 = g.relu(fc1);
-    const fc2W = g.variable('fc2W', NDArray.zeros([32, 32]));
-    const fc2B = g.variable('fc2B', NDArray.zeros([32]));
+    const fc2W = g.variable('fc2W', dl.zeros([32, 32]));
+    const fc2B = g.variable('fc2B', dl.zeros([32]));
     const fc2 = g.add(g.matmul(fc2W, relu1), fc2B);
     const relu2 = g.relu(fc2);
-    const fc3W = g.variable('fc3W', NDArray.zeros([10, 32]));
-    const fc3B = g.variable('fc3B', NDArray.zeros([10]));
+    const fc3W = g.variable('fc3W', dl.zeros([10, 32]));
+    const fc3B = g.variable('fc3B', dl.zeros([10]));
     const fc3 = g.add(g.matmul(fc3W, relu2), fc3B);
 
-    const fd = new FeedDictionary([{tensor: input, data: NDArray.zeros([1])}]);
+    const fd = new FeedDictionary([{tensor: input, data: dl.zeros([1])}]);
     const orderedEvaluationSet =
         session_util.getOrderedEvaluationSetFromEvalTensor([fc3], fd);
     expect(orderedEvaluationSet.length).toBeGreaterThan(1);
@@ -91,7 +90,7 @@ describe('Variable validation', () => {
   });
 
   it('non null data does not throw', () => {
-    g.variable('test', NDArray.zeros([5]));
+    g.variable('test', dl.zeros([5]));
   });
 });
 
@@ -119,7 +118,7 @@ describe('Constant', () => {
   });
 
   it('non null data does not throw', () => {
-    expect(g.constant(NDArray.zeros([5])).shape).toEqual([5]);
+    expect(g.constant(dl.zeros([5])).shape).toEqual([5]);
   });
 
   it('from a single value', () => {
@@ -330,8 +329,7 @@ describe('Concat1d validation', () => {
   });
 
   it('Axis=0 shapes the same does not throw', () => {
-    expect(g.concat1d(new Tensor([5]), new Tensor([1])).shape)
-        .toEqual([6]);
+    expect(g.concat1d(new Tensor([5]), new Tensor([1])).shape).toEqual([6]);
   });
 });
 
@@ -439,43 +437,51 @@ describe('Concat4d validation', () => {
   });
 
   it('Axis=0 different shapes throws', () => {
-    expect(() => g.concat4d(new Tensor([5, 4, 1, 1]),
-      new Tensor([1, 2, 1, 1]), 0)).toThrowError();
+    expect(
+        () => g.concat4d(new Tensor([5, 4, 1, 1]), new Tensor([1, 2, 1, 1]), 0))
+        .toThrowError();
   });
 
   it('Axis=1 different shapes throws', () => {
-    expect(() => g.concat4d(new Tensor([5, 4, 1, 1]),
-      new Tensor([1, 2, 1, 1]), 1)).toThrowError();
+    expect(
+        () => g.concat4d(new Tensor([5, 4, 1, 1]), new Tensor([1, 2, 1, 1]), 1))
+        .toThrowError();
   });
 
   it('Axis=2 different shapes throws', () => {
-    expect(() => g.concat4d(new Tensor([5, 4, 1, 1]),
-      new Tensor([1, 2, 1, 1]), 2)).toThrowError();
+    expect(
+        () => g.concat4d(new Tensor([5, 4, 1, 1]), new Tensor([1, 2, 1, 1]), 2))
+        .toThrowError();
   });
 
   it('Axis=3 different shapes throws', () => {
-    expect(() => g.concat4d(new Tensor([5, 4, 1, 1]),
-      new Tensor([1, 2, 1, 1]), 3)).toThrowError();
+    expect(
+        () => g.concat4d(new Tensor([5, 4, 1, 1]), new Tensor([1, 2, 1, 1]), 3))
+        .toThrowError();
   });
 
   it('Axis=0 shapes the same does not throw', () => {
-    expect(g.concat4d(new Tensor([5, 4, 3, 1]),
-      new Tensor([1, 4, 3, 1]), 0).shape).toEqual([6, 4, 3, 1]);
+    expect(
+        g.concat4d(new Tensor([5, 4, 3, 1]), new Tensor([1, 4, 3, 1]), 0).shape)
+        .toEqual([6, 4, 3, 1]);
   });
 
   it('Axis=1 shapes the same does not throw', () => {
-    expect(g.concat4d(new Tensor([5, 3, 3, 1]),
-      new Tensor([5, 4, 3, 1]), 1).shape).toEqual([5, 7, 3, 1]);
+    expect(
+        g.concat4d(new Tensor([5, 3, 3, 1]), new Tensor([5, 4, 3, 1]), 1).shape)
+        .toEqual([5, 7, 3, 1]);
   });
 
   it('Axis=2 shapes the same does not throw', () => {
-    expect(g.concat4d(new Tensor([5, 4, 3, 1]),
-      new Tensor([5, 4, 1, 1]), 2).shape).toEqual([5, 4, 4, 1]);
+    expect(
+        g.concat4d(new Tensor([5, 4, 3, 1]), new Tensor([5, 4, 1, 1]), 2).shape)
+        .toEqual([5, 4, 4, 1]);
   });
 
   it('Axis=3 shapes the same does not throw', () => {
-    expect(g.concat4d(new Tensor([5, 4, 3, 1]), 
-      new Tensor([5, 4, 3, 2]), 3).shape).toEqual([5, 4, 3, 3]);
+    expect(
+        g.concat4d(new Tensor([5, 4, 3, 1]), new Tensor([5, 4, 3, 2]), 3).shape)
+        .toEqual([5, 4, 3, 3]);
   });
 });
 

--- a/src/graph/graph_util_test.ts
+++ b/src/graph/graph_util_test.ts
@@ -15,6 +15,7 @@
  * =============================================================================
  */
 
+import * as dl from '../index';
 // tslint:disable-next-line:max-line-length
 import {NDArray, Scalar} from '../math/ndarray';
 // tslint:disable-next-line:max-line-length
@@ -169,7 +170,7 @@ describe('graph_util.isInputNode', () => {
 
   beforeEach(() => {
     g = new Graph();
-    nda = NDArray.zeros([1]);
+    nda = dl.zeros([1]);
   });
 
   it('returns true for VariableNode', () => {
@@ -182,7 +183,7 @@ describe('graph_util.isInputNode', () => {
   });
 
   it('returns true for ConstantNode', () => {
-    expect(graph_util.isInputNode(new ConstantNode(g, NDArray.zeros([1]))))
+    expect(graph_util.isInputNode(new ConstantNode(g, dl.zeros([1]))))
         .toEqual(true);
   });
 

--- a/src/graph/ops/convolution.ts
+++ b/src/graph/ops/convolution.ts
@@ -78,7 +78,7 @@ export class Convolution2D extends Operation {
       gradientArrays: SummedTensorArrayMap) {
     const filter = inferenceArrays.get(this.wTensor) as Array4D;
     const x = inferenceArrays.get(this.xTensor) as Array3D;
-    const dy = gradientArrays.get(this.yTensor) as Array3D<'float32'>;
+    const dy = gradientArrays.get(this.yTensor) as Array3D;
 
     math.scope(() => {
       const dw =

--- a/src/graph/ops/convolution_test.ts
+++ b/src/graph/ops/convolution_test.ts
@@ -17,7 +17,7 @@
 
 import {ENV} from '../../environment';
 import * as conv_util from '../../math/conv_util';
-import {Array1D, Array2D, Array3D, Array4D, NDArray} from '../../math/ndarray';
+import {Array1D, Array2D, NDArray} from '../../math/ndarray';
 import * as test_util from '../../test_util';
 import {Tensor} from '../graph';
 import {SummedTensorArrayMap, TensorArrayMap} from '../tensor_array_map';
@@ -107,9 +107,9 @@ describe('Convolution', () => {
     const fSize = 3;
     const stride = 1;
 
-    const weights = Array4D.randNormal([fSize, fSize, inputDepth, outputDepth]);
-    const biases = Array1D.randNormal([outputDepth]);
-    const x = Array3D.randNormal([5, 5, inputDepth]);
+    const weights = NDArray.randNormal([fSize, fSize, inputDepth, outputDepth]);
+    const biases = NDArray.randNormal([outputDepth]);
+    const x = NDArray.randNormal<'float32', '3'>([5, 5, inputDepth]);
 
     wTensor = new Tensor(weights.shape);
     xTensor = new Tensor(x.shape);
@@ -137,9 +137,9 @@ describe('Convolution', () => {
     const fSize = 2;
     const stride = 1;
 
-    const weights = Array4D.randNormal([fSize, fSize, inputDepth, outputDepth]);
-    const biases = Array1D.randNormal([outputDepth]);
-    const x = Array3D.randNormal([5, 5, inputDepth]);
+    const weights = NDArray.randNormal([fSize, fSize, inputDepth, outputDepth]);
+    const biases = NDArray.randNormal([outputDepth]);
+    const x = NDArray.randNormal<'float32', '3'>([5, 5, inputDepth]);
 
     wTensor = new Tensor(weights.shape);
     xTensor = new Tensor(x.shape);
@@ -168,9 +168,9 @@ describe('Convolution', () => {
     const stride = 1;
     const zeroPad = 1;
 
-    const weights = Array4D.randNormal([fSize, fSize, inputDepth, outputDepth]);
-    const biases = Array1D.randNormal([outputDepth]);
-    const x = Array3D.randNormal([30, 30, inputDepth]);
+    const weights = NDArray.randNormal([fSize, fSize, inputDepth, outputDepth]);
+    const biases = NDArray.randNormal([outputDepth]);
+    const x = NDArray.randNormal<'float32', '3'>([30, 30, inputDepth]);
 
     wTensor = new Tensor(weights.shape);
     xTensor = new Tensor(x.shape);
@@ -203,10 +203,10 @@ describe('Convolution', () => {
     const stride = 1;
     const zeroPad = 0;
 
-    const x3d = Array3D.randNormal([3, 3, inputDepth]);
+    const x3d = NDArray.randNormal<'float32', '3'>([3, 3, inputDepth]);
     const x = x3d.as2D(3, 3);
-    const weights = Array4D.randNormal([fSize, fSize, inputDepth, outputDepth]);
-    const biases = Array1D.randNormal([outputDepth]);
+    const weights = NDArray.randNormal([fSize, fSize, inputDepth, outputDepth]);
+    const biases = NDArray.randNormal([outputDepth]);
 
     wTensor = new Tensor(weights.shape);
     xTensor = new Tensor(x3d.shape);
@@ -255,7 +255,7 @@ describe('Convolution', () => {
             x.get(2, 1) * weights.get(1, 0, 0, 0) +
             x.get(2, 2) * weights.get(1, 1, 0, 0) + biases.get(0));
 
-    const dy3d = Array3D.randNormal([2, 2, 1]);
+    const dy3d = NDArray.randNormal([2, 2, 1]);
 
     gradients.add(yTensor, dy3d);
 
@@ -313,9 +313,9 @@ describe('Convolution', () => {
     const stride = 1;
     const zeroPad = 1;
 
-    const weights = Array4D.randNormal([fSize, fSize, inputDepth, outputDepth]);
-    const biases = Array1D.randNormal([outputDepth]);
-    const x = Array3D.randNormal([10, 10, inputDepth]);
+    const weights = NDArray.randNormal([fSize, fSize, inputDepth, outputDepth]);
+    const biases = NDArray.randNormal([outputDepth]);
+    const x = NDArray.randNormal<'float32', '3'>([10, 10, inputDepth]);
 
     wTensor = new Tensor(weights.shape);
     xTensor = new Tensor(x.shape);
@@ -337,7 +337,7 @@ describe('Convolution', () => {
 
     assertNoNaNs(result);
 
-    const dy = Array3D.randNormal(result.shape as [number, number, number]);
+    const dy = NDArray.randNormal(result.shape as [number, number, number]);
 
     gradients.add(yTensor, dy);
 

--- a/src/graph/ops/convolution_test.ts
+++ b/src/graph/ops/convolution_test.ts
@@ -16,12 +16,12 @@
  */
 
 import {ENV} from '../../environment';
+import * as dl from '../../index';
 import * as conv_util from '../../math/conv_util';
 import {Array1D, Array2D, NDArray} from '../../math/ndarray';
 import * as test_util from '../../test_util';
 import {Tensor} from '../graph';
 import {SummedTensorArrayMap, TensorArrayMap} from '../tensor_array_map';
-
 import {Convolution2D} from './convolution';
 
 function assertNoNaNs(t: NDArray) {
@@ -107,9 +107,9 @@ describe('Convolution', () => {
     const fSize = 3;
     const stride = 1;
 
-    const weights = NDArray.randNormal([fSize, fSize, inputDepth, outputDepth]);
-    const biases = NDArray.randNormal([outputDepth]);
-    const x = NDArray.randNormal<'3'>([5, 5, inputDepth]);
+    const weights = dl.randNormal([fSize, fSize, inputDepth, outputDepth]);
+    const biases = dl.randNormal([outputDepth]);
+    const x = dl.randNormal<'3'>([5, 5, inputDepth]);
 
     wTensor = new Tensor(weights.shape);
     xTensor = new Tensor(x.shape);
@@ -137,9 +137,9 @@ describe('Convolution', () => {
     const fSize = 2;
     const stride = 1;
 
-    const weights = NDArray.randNormal([fSize, fSize, inputDepth, outputDepth]);
-    const biases = NDArray.randNormal([outputDepth]);
-    const x = NDArray.randNormal<'3'>([5, 5, inputDepth]);
+    const weights = dl.randNormal([fSize, fSize, inputDepth, outputDepth]);
+    const biases = dl.randNormal([outputDepth]);
+    const x = dl.randNormal<'3'>([5, 5, inputDepth]);
 
     wTensor = new Tensor(weights.shape);
     xTensor = new Tensor(x.shape);
@@ -168,9 +168,9 @@ describe('Convolution', () => {
     const stride = 1;
     const zeroPad = 1;
 
-    const weights = NDArray.randNormal([fSize, fSize, inputDepth, outputDepth]);
-    const biases = NDArray.randNormal([outputDepth]);
-    const x = NDArray.randNormal<'3'>([30, 30, inputDepth]);
+    const weights = dl.randNormal([fSize, fSize, inputDepth, outputDepth]);
+    const biases = dl.randNormal([outputDepth]);
+    const x = dl.randNormal<'3'>([30, 30, inputDepth]);
 
     wTensor = new Tensor(weights.shape);
     xTensor = new Tensor(x.shape);
@@ -203,10 +203,10 @@ describe('Convolution', () => {
     const stride = 1;
     const zeroPad = 0;
 
-    const x3d = NDArray.randNormal<'3'>([3, 3, inputDepth]);
+    const x3d = dl.randNormal<'3'>([3, 3, inputDepth]);
     const x = x3d.as2D(3, 3);
-    const weights = NDArray.randNormal([fSize, fSize, inputDepth, outputDepth]);
-    const biases = NDArray.randNormal([outputDepth]);
+    const weights = dl.randNormal([fSize, fSize, inputDepth, outputDepth]);
+    const biases = dl.randNormal([outputDepth]);
 
     wTensor = new Tensor(weights.shape);
     xTensor = new Tensor(x3d.shape);
@@ -255,7 +255,7 @@ describe('Convolution', () => {
             x.get(2, 1) * weights.get(1, 0, 0, 0) +
             x.get(2, 2) * weights.get(1, 1, 0, 0) + biases.get(0));
 
-    const dy3d = NDArray.randNormal([2, 2, 1]);
+    const dy3d = dl.randNormal([2, 2, 1]);
 
     gradients.add(yTensor, dy3d);
 
@@ -313,9 +313,9 @@ describe('Convolution', () => {
     const stride = 1;
     const zeroPad = 1;
 
-    const weights = NDArray.randNormal([fSize, fSize, inputDepth, outputDepth]);
-    const biases = NDArray.randNormal([outputDepth]);
-    const x = NDArray.randNormal<'3'>([10, 10, inputDepth]);
+    const weights = dl.randNormal([fSize, fSize, inputDepth, outputDepth]);
+    const biases = dl.randNormal([outputDepth]);
+    const x = dl.randNormal<'3'>([10, 10, inputDepth]);
 
     wTensor = new Tensor(weights.shape);
     xTensor = new Tensor(x.shape);
@@ -337,7 +337,7 @@ describe('Convolution', () => {
 
     assertNoNaNs(result);
 
-    const dy = NDArray.randNormal(result.shape as [number, number, number]);
+    const dy = dl.randNormal(result.shape as [number, number, number]);
 
     gradients.add(yTensor, dy);
 

--- a/src/graph/ops/convolution_test.ts
+++ b/src/graph/ops/convolution_test.ts
@@ -109,7 +109,7 @@ describe('Convolution', () => {
 
     const weights = NDArray.randNormal([fSize, fSize, inputDepth, outputDepth]);
     const biases = NDArray.randNormal([outputDepth]);
-    const x = NDArray.randNormal<'float32', '3'>([5, 5, inputDepth]);
+    const x = NDArray.randNormal<'3'>([5, 5, inputDepth]);
 
     wTensor = new Tensor(weights.shape);
     xTensor = new Tensor(x.shape);
@@ -139,7 +139,7 @@ describe('Convolution', () => {
 
     const weights = NDArray.randNormal([fSize, fSize, inputDepth, outputDepth]);
     const biases = NDArray.randNormal([outputDepth]);
-    const x = NDArray.randNormal<'float32', '3'>([5, 5, inputDepth]);
+    const x = NDArray.randNormal<'3'>([5, 5, inputDepth]);
 
     wTensor = new Tensor(weights.shape);
     xTensor = new Tensor(x.shape);
@@ -170,7 +170,7 @@ describe('Convolution', () => {
 
     const weights = NDArray.randNormal([fSize, fSize, inputDepth, outputDepth]);
     const biases = NDArray.randNormal([outputDepth]);
-    const x = NDArray.randNormal<'float32', '3'>([30, 30, inputDepth]);
+    const x = NDArray.randNormal<'3'>([30, 30, inputDepth]);
 
     wTensor = new Tensor(weights.shape);
     xTensor = new Tensor(x.shape);
@@ -203,7 +203,7 @@ describe('Convolution', () => {
     const stride = 1;
     const zeroPad = 0;
 
-    const x3d = NDArray.randNormal<'float32', '3'>([3, 3, inputDepth]);
+    const x3d = NDArray.randNormal<'3'>([3, 3, inputDepth]);
     const x = x3d.as2D(3, 3);
     const weights = NDArray.randNormal([fSize, fSize, inputDepth, outputDepth]);
     const biases = NDArray.randNormal([outputDepth]);
@@ -315,7 +315,7 @@ describe('Convolution', () => {
 
     const weights = NDArray.randNormal([fSize, fSize, inputDepth, outputDepth]);
     const biases = NDArray.randNormal([outputDepth]);
-    const x = NDArray.randNormal<'float32', '3'>([10, 10, inputDepth]);
+    const x = NDArray.randNormal<'3'>([10, 10, inputDepth]);
 
     wTensor = new Tensor(weights.shape);
     xTensor = new Tensor(x.shape);

--- a/src/graph/ops/convolution_test.ts
+++ b/src/graph/ops/convolution_test.ts
@@ -19,9 +19,11 @@ import {ENV} from '../../environment';
 import * as dl from '../../index';
 import * as conv_util from '../../math/conv_util';
 import {Array1D, Array2D, NDArray} from '../../math/ndarray';
+import {Rank} from '../../math/types';
 import * as test_util from '../../test_util';
 import {Tensor} from '../graph';
 import {SummedTensorArrayMap, TensorArrayMap} from '../tensor_array_map';
+
 import {Convolution2D} from './convolution';
 
 function assertNoNaNs(t: NDArray) {
@@ -106,10 +108,9 @@ describe('Convolution', () => {
     const outputDepth = 2;
     const fSize = 3;
     const stride = 1;
-
     const weights = dl.randNormal([fSize, fSize, inputDepth, outputDepth]);
     const biases = dl.randNormal([outputDepth]);
-    const x = dl.randNormal<'3'>([5, 5, inputDepth]);
+    const x = dl.randNormal<Rank.R3>([5, 5, inputDepth]);
 
     wTensor = new Tensor(weights.shape);
     xTensor = new Tensor(x.shape);
@@ -139,7 +140,7 @@ describe('Convolution', () => {
 
     const weights = dl.randNormal([fSize, fSize, inputDepth, outputDepth]);
     const biases = dl.randNormal([outputDepth]);
-    const x = dl.randNormal<'3'>([5, 5, inputDepth]);
+    const x = dl.randNormal<Rank.R3>([5, 5, inputDepth]);
 
     wTensor = new Tensor(weights.shape);
     xTensor = new Tensor(x.shape);
@@ -170,7 +171,7 @@ describe('Convolution', () => {
 
     const weights = dl.randNormal([fSize, fSize, inputDepth, outputDepth]);
     const biases = dl.randNormal([outputDepth]);
-    const x = dl.randNormal<'3'>([30, 30, inputDepth]);
+    const x = dl.randNormal<Rank.R3>([30, 30, inputDepth]);
 
     wTensor = new Tensor(weights.shape);
     xTensor = new Tensor(x.shape);
@@ -203,7 +204,7 @@ describe('Convolution', () => {
     const stride = 1;
     const zeroPad = 0;
 
-    const x3d = dl.randNormal<'3'>([3, 3, inputDepth]);
+    const x3d = dl.randNormal<Rank.R3>([3, 3, inputDepth]);
     const x = x3d.as2D(3, 3);
     const weights = dl.randNormal([fSize, fSize, inputDepth, outputDepth]);
     const biases = dl.randNormal([outputDepth]);
@@ -315,7 +316,7 @@ describe('Convolution', () => {
 
     const weights = dl.randNormal([fSize, fSize, inputDepth, outputDepth]);
     const biases = dl.randNormal([outputDepth]);
-    const x = dl.randNormal<'3'>([10, 10, inputDepth]);
+    const x = dl.randNormal<Rank.R3>([10, 10, inputDepth]);
 
     wTensor = new Tensor(weights.shape);
     xTensor = new Tensor(x.shape);

--- a/src/graph/ops/max_pool.ts
+++ b/src/graph/ops/max_pool.ts
@@ -62,7 +62,7 @@ export class MaxPool extends Operation {
       math: NDArrayMath, inferenceArrays: TensorArrayMap,
       gradientArrays: SummedTensorArrayMap) {
     const x = inferenceArrays.get(this.xTensor) as Array3D;
-    const dy = gradientArrays.get(this.yTensor) as Array3D<'float32'>;
+    const dy = gradientArrays.get(this.yTensor) as Array3D;
 
     math.scope(() => {
       gradientArrays.add(

--- a/src/graph/ops/max_pool_test.ts
+++ b/src/graph/ops/max_pool_test.ts
@@ -62,7 +62,7 @@ describe('Max pool', () => {
     op.feedForward(math, activations);
 
     // Feed forward.
-    const y = activations.get(yTensor) as Array3D<'float32'>;
+    const y = activations.get(yTensor) as Array3D;
     const expectedResult = Array3D.new([2, 2, depth], [5, 6, 9, 9]);
     test_util.expectArraysClose(y, expectedResult);
 
@@ -72,7 +72,7 @@ describe('Max pool', () => {
 
     op.backProp(math, activations, gradients);
 
-    const dx = gradients.get(xTensor) as Array3D<'float32'>;
+    const dx = gradients.get(xTensor) as Array3D;
     const expectedBackprop =
         Array3D.new([3, 3, depth], [0, 0, 0, 0, 50, 60, 0, 170, 0]);
     test_util.expectArraysClose(dx, expectedBackprop);
@@ -138,7 +138,7 @@ describe('Max pool', () => {
     const stride = 2;
     const pad = 0;
 
-    const x = NDArray.randNormal<'float32', '3'>([6, 6, 5]);
+    const x = NDArray.randNormal<'3'>([6, 6, 5]);
 
     xTensor = new Tensor(x.shape);
     yTensor = new Tensor(conv_util.computeOutputShape3D(

--- a/src/graph/ops/max_pool_test.ts
+++ b/src/graph/ops/max_pool_test.ts
@@ -16,12 +16,12 @@
  */
 
 import {ENV} from '../../environment';
+import * as dl from '../../index';
 import * as conv_util from '../../math/conv_util';
-import {Array3D, NDArray} from '../../math/ndarray';
+import {Array3D} from '../../math/ndarray';
 import * as test_util from '../../test_util';
 import {Tensor} from '../graph';
 import {SummedTensorArrayMap, TensorArrayMap} from '../tensor_array_map';
-
 import {MaxPool} from './max_pool';
 
 describe('Max pool', () => {
@@ -138,7 +138,7 @@ describe('Max pool', () => {
     const stride = 2;
     const pad = 0;
 
-    const x = NDArray.randNormal<'3'>([6, 6, 5]);
+    const x = dl.randNormal<'3'>([6, 6, 5]);
 
     xTensor = new Tensor(x.shape);
     yTensor = new Tensor(conv_util.computeOutputShape3D(

--- a/src/graph/ops/max_pool_test.ts
+++ b/src/graph/ops/max_pool_test.ts
@@ -19,9 +19,11 @@ import {ENV} from '../../environment';
 import * as dl from '../../index';
 import * as conv_util from '../../math/conv_util';
 import {Array3D} from '../../math/ndarray';
+import {Rank} from '../../math/types';
 import * as test_util from '../../test_util';
 import {Tensor} from '../graph';
 import {SummedTensorArrayMap, TensorArrayMap} from '../tensor_array_map';
+
 import {MaxPool} from './max_pool';
 
 describe('Max pool', () => {
@@ -138,7 +140,7 @@ describe('Max pool', () => {
     const stride = 2;
     const pad = 0;
 
-    const x = dl.randNormal<'3'>([6, 6, 5]);
+    const x = dl.randNormal<Rank.R3>([6, 6, 5]);
 
     xTensor = new Tensor(x.shape);
     yTensor = new Tensor(conv_util.computeOutputShape3D(

--- a/src/graph/ops/max_pool_test.ts
+++ b/src/graph/ops/max_pool_test.ts
@@ -17,10 +17,11 @@
 
 import {ENV} from '../../environment';
 import * as conv_util from '../../math/conv_util';
-import {Array3D} from '../../math/ndarray';
+import {Array3D, NDArray} from '../../math/ndarray';
 import * as test_util from '../../test_util';
 import {Tensor} from '../graph';
 import {SummedTensorArrayMap, TensorArrayMap} from '../tensor_array_map';
+
 import {MaxPool} from './max_pool';
 
 describe('Max pool', () => {
@@ -137,7 +138,7 @@ describe('Max pool', () => {
     const stride = 2;
     const pad = 0;
 
-    const x = Array3D.randNormal([6, 6, 5]);
+    const x = NDArray.randNormal<'float32', '3'>([6, 6, 5]);
 
     xTensor = new Tensor(x.shape);
     yTensor = new Tensor(conv_util.computeOutputShape3D(

--- a/src/graph/ops/softmax.ts
+++ b/src/graph/ops/softmax.ts
@@ -101,7 +101,7 @@ export class SoftmaxCrossEntropyCost extends Operation {
 
 export function crossEntropyCost(
     math: NDArrayMath, y: Array1D, target: Array1D,
-    epsilon: Scalar): Scalar<'float32'> {
+    epsilon: Scalar): Scalar {
   util.assert(
       y.size === target.size, 'The output and target must be the same size');
 

--- a/src/graph/optimizers/adadelta_optimizer.ts
+++ b/src/graph/optimizers/adadelta_optimizer.ts
@@ -18,7 +18,7 @@
 import {NDArrayMath} from '../../math/math';
 import {NDArray, Scalar} from '../../math/ndarray';
 import {Optimizer} from '../../math/optimizers/optimizer';
-import {NamedVariableMap} from '../../util';
+import {NamedVariableMap} from '../../math/types';
 import {Node} from '../graph';
 import {SessionRuntime} from '../session';
 import {SummedTensorArrayMap, TensorArrayMap} from '../tensor_array_map';

--- a/src/graph/optimizers/adadelta_optimizer_test.ts
+++ b/src/graph/optimizers/adadelta_optimizer_test.ts
@@ -16,7 +16,8 @@
  */
 import {InputProvider} from '../../data/input_provider';
 import {ENV} from '../../environment';
-import {Array1D, NDArray} from '../../math/ndarray';
+import * as dl from '../../index';
+import {Array1D} from '../../math/ndarray';
 import * as test_util from '../../test_util';
 import {Graph} from '../graph';
 import {Session} from '../session';
@@ -36,8 +37,8 @@ describe('adadelta optimizer', () => {
     math.scope(() => {
       const g = new Graph();
       const x = g.placeholder('x', [2]);
-      const w = g.variable('w', NDArray.zeros([1, 2]));
-      const b = g.variable('b', NDArray.zeros([1]));
+      const w = g.variable('w', dl.zeros([1, 2]));
+      const b = g.variable('b', dl.zeros([1]));
       const y = g.reduceSum(g.add(g.matmul(w, x), b));
       const session = new Session(g, math);
       const optimizer = new AdadeltaOptimizer(0.1, 0.8);

--- a/src/graph/optimizers/adagrad_optimizer.ts
+++ b/src/graph/optimizers/adagrad_optimizer.ts
@@ -17,7 +17,7 @@
 import {NDArrayMath} from '../../math/math';
 import {NDArray, Scalar} from '../../math/ndarray';
 import {Optimizer} from '../../math/optimizers/optimizer';
-import {NamedVariableMap} from '../../util';
+import {NamedVariableMap} from '../../math/types';
 import {Node} from '../graph';
 import {SessionRuntime} from '../session';
 import {SummedTensorArrayMap, TensorArrayMap} from '../tensor_array_map';

--- a/src/graph/optimizers/adagrad_optimizer_test.ts
+++ b/src/graph/optimizers/adagrad_optimizer_test.ts
@@ -16,11 +16,11 @@
  */
 import {InputProvider} from '../../data/input_provider';
 import {ENV} from '../../environment';
-import {Array1D, NDArray} from '../../math/ndarray';
+import * as dl from '../../index';
+import {Array1D} from '../../math/ndarray';
 import * as test_util from '../../test_util';
 import {Graph} from '../graph';
 import {Session} from '../session';
-
 import {AdagradOptimizer} from './adagrad_optimizer';
 
 describe('adagrad optimizer', () => {
@@ -37,8 +37,8 @@ describe('adagrad optimizer', () => {
     math.scope(() => {
       const g = new Graph();
       const x = g.placeholder('x', [2]);
-      const w = g.variable('w', NDArray.zeros([1, 2]));
-      const b = g.variable('b', NDArray.zeros([1]));
+      const w = g.variable('w', dl.zeros([1, 2]));
+      const b = g.variable('b', dl.zeros([1]));
       const y = g.reduceSum(g.add(g.matmul(w, x), b));
       const optimizer = new AdagradOptimizer(0.1);
       const session = new Session(g, math);

--- a/src/graph/optimizers/adam_optimizer.ts
+++ b/src/graph/optimizers/adam_optimizer.ts
@@ -18,7 +18,7 @@
 import {NDArrayMath} from '../../math/math';
 import {NDArray, Scalar} from '../../math/ndarray';
 import {Optimizer} from '../../math/optimizers/optimizer';
-import {NamedVariableMap} from '../../util';
+import {NamedVariableMap} from '../../math/types';
 import {Node} from '../graph';
 import {SessionRuntime} from '../session';
 import {SummedTensorArrayMap, TensorArrayMap} from '../tensor_array_map';

--- a/src/graph/optimizers/adam_optimizer.ts
+++ b/src/graph/optimizers/adam_optimizer.ts
@@ -134,7 +134,7 @@ export class AdamOptimizer extends Optimizer {
   private firstMoment = new TensorArrayMap();
   // Average of squared gradient
   private secondMoment = new TensorArrayMap();
-  private eps: Scalar<'float32'>;
+  private eps: Scalar;
   private b1: Scalar;
   private b2: Scalar;
   private accB1: Scalar;

--- a/src/graph/optimizers/adam_optimizer_test.ts
+++ b/src/graph/optimizers/adam_optimizer_test.ts
@@ -16,11 +16,11 @@
  */
 import {InputProvider} from '../../data/input_provider';
 import {ENV} from '../../environment';
-import {Array1D, NDArray} from '../../math/ndarray';
+import * as dl from '../../index';
+import {Array1D} from '../../math/ndarray';
 import * as test_util from '../../test_util';
 import {Graph} from '../graph';
 import {Session} from '../session';
-
 import {AdamOptimizer} from './adam_optimizer';
 
 describe('adam optimizer', () => {
@@ -37,8 +37,8 @@ describe('adam optimizer', () => {
     math.scope(() => {
       const g = new Graph();
       const x = g.placeholder('x', [2]);
-      const w = g.variable('w', NDArray.zeros([1, 2]));
-      const b = g.variable('b', NDArray.zeros([1]));
+      const w = g.variable('w', dl.zeros([1, 2]));
+      const b = g.variable('b', dl.zeros([1]));
       const y = g.reduceSum(g.add(g.matmul(w, x), b));
       const optimizer = new AdamOptimizer(0.1, 0.8, 0.9);
       const session = new Session(g, math);

--- a/src/graph/optimizers/adamax_optimizer.ts
+++ b/src/graph/optimizers/adamax_optimizer.ts
@@ -18,7 +18,7 @@
 import {NDArrayMath} from '../../math/math';
 import {NDArray, Scalar} from '../../math/ndarray';
 import {Optimizer} from '../../math/optimizers/optimizer';
-import {NamedVariableMap} from '../../util';
+import {NamedVariableMap} from '../../math/types';
 import {Node} from '../graph';
 import {SessionRuntime} from '../session';
 import {SummedTensorArrayMap, TensorArrayMap} from '../tensor_array_map';

--- a/src/graph/optimizers/adamax_optimizer_test.ts
+++ b/src/graph/optimizers/adamax_optimizer_test.ts
@@ -16,11 +16,11 @@
  */
 import {InputProvider} from '../../data/input_provider';
 import {ENV} from '../../environment';
-import {Array1D, NDArray} from '../../math/ndarray';
+import * as dl from '../../index';
+import {Array1D} from '../../math/ndarray';
 import * as test_util from '../../test_util';
 import {Graph} from '../graph';
 import {Session} from '../session';
-
 import {AdamaxOptimizer} from './adamax_optimizer';
 
 describe('adamax optimizer', () => {
@@ -37,8 +37,8 @@ describe('adamax optimizer', () => {
     math.scope(() => {
       const g = new Graph();
       const x = g.placeholder('x', [2]);
-      const w = g.variable('w', NDArray.zeros([1, 2]));
-      const b = g.variable('b', NDArray.zeros([1]));
+      const w = g.variable('w', dl.zeros([1, 2]));
+      const b = g.variable('b', dl.zeros([1]));
       const y = g.reduceSum(g.add(g.matmul(w, x), b));
       const optimizer = new AdamaxOptimizer(0.1, 0.8, 0.9);
       const session = new Session(g, math);

--- a/src/graph/optimizers/momentum_optimizer.ts
+++ b/src/graph/optimizers/momentum_optimizer.ts
@@ -18,7 +18,7 @@
 import {NDArrayMath} from '../../math/math';
 import {NDArray, Scalar} from '../../math/ndarray';
 import {SGDOptimizer} from '../../math/optimizers/sgd_optimizer';
-import {NamedVariableMap} from '../../util';
+import {NamedVariableMap} from '../../math/types';
 import {Node} from '../graph';
 import {SessionRuntime} from '../session';
 import {SummedTensorArrayMap, TensorArrayMap} from '../tensor_array_map';

--- a/src/graph/optimizers/momentum_optimizer_test.ts
+++ b/src/graph/optimizers/momentum_optimizer_test.ts
@@ -16,10 +16,12 @@
  */
 import {InputProvider} from '../../data/input_provider';
 import {ENV} from '../../environment';
-import {Array1D, NDArray} from '../../math/ndarray';
+import * as dl from '../../index';
+import {Array1D} from '../../math/ndarray';
 import * as test_util from '../../test_util';
 import {Graph} from '../graph';
 import {Session} from '../session';
+
 import {MomentumOptimizer} from './momentum_optimizer';
 
 describe('momentum optimizer', () => {
@@ -36,8 +38,8 @@ describe('momentum optimizer', () => {
     math.scope(() => {
       const g = new Graph();
       const x = g.placeholder('x', [2]);
-      const w = g.variable('w', NDArray.zeros([1, 2]));
-      const b = g.variable('b', NDArray.zeros([1]));
+      const w = g.variable('w', dl.zeros([1, 2]));
+      const b = g.variable('b', dl.zeros([1]));
       const y = g.reduceSum(g.add(g.matmul(w, x), b));
       const optimizer = new MomentumOptimizer(0.1, 0.5);
       const session = new Session(g, math);

--- a/src/graph/optimizers/rmsprop_optimizer.ts
+++ b/src/graph/optimizers/rmsprop_optimizer.ts
@@ -18,7 +18,7 @@
 import {NDArrayMath} from '../../math/math';
 import {NDArray, Scalar} from '../../math/ndarray';
 import {Optimizer} from '../../math/optimizers/optimizer';
-import {NamedVariableMap} from '../../util';
+import {NamedVariableMap} from '../../math/types';
 import {Node} from '../graph';
 import {SessionRuntime} from '../session';
 import {SummedTensorArrayMap, TensorArrayMap} from '../tensor_array_map';

--- a/src/graph/optimizers/rmsprop_optimizer_test.ts
+++ b/src/graph/optimizers/rmsprop_optimizer_test.ts
@@ -16,7 +16,8 @@
  */
 import {InputProvider} from '../../data/input_provider';
 import {ENV} from '../../environment';
-import {Array1D, NDArray} from '../../math/ndarray';
+import * as dl from '../../index';
+import {Array1D} from '../../math/ndarray';
 import * as test_util from '../../test_util';
 import {Graph} from '../graph';
 import {Session} from '../session';
@@ -36,8 +37,8 @@ describe('rmsprop optimizer', () => {
     math.scope(() => {
       const g = new Graph();
       const x = g.placeholder('x', [2]);
-      const w = g.variable('w', NDArray.zeros([1, 2]));
-      const b = g.variable('b', NDArray.zeros([1]));
+      const w = g.variable('w', dl.zeros([1, 2]));
+      const b = g.variable('b', dl.zeros([1]));
       const y = g.reduceSum(g.add(g.matmul(w, x), b));
       const optimizer = new RMSPropOptimizer(0.1, 0.8);
       const session = new Session(g, math);

--- a/src/graph/session.ts
+++ b/src/graph/session.ts
@@ -222,7 +222,7 @@ export class Session {
             feed, activations, this.math);
 
         cost = this.updateCostForExample(
-            cost, activations.get(costTensor) as Scalar<'float32'>,
+            cost, activations.get(costTensor) as Scalar,
             costReduction);
       }
 
@@ -234,8 +234,8 @@ export class Session {
   }
 
   private updateCostForExample(
-      totalCost: Scalar<'float32'>, currCost: Scalar<'float32'>,
-      costReduction: CostReduction): Scalar<'float32'> {
+      totalCost: Scalar, currCost: Scalar,
+      costReduction: CostReduction): Scalar {
     if (costReduction === CostReduction.MEAN ||
         costReduction === CostReduction.SUM) {
       return this.math.add(totalCost, currCost);
@@ -244,8 +244,8 @@ export class Session {
   }
 
   private updateCostForBatch(
-      totalCost: Scalar<'float32'>,
-      costReduction: CostReduction): Scalar<'float32'> {
+      totalCost: Scalar,
+      costReduction: CostReduction): Scalar {
     if (costReduction === CostReduction.MEAN) {
       return this.math.divide(totalCost, this.batchSizeScalar);
     }

--- a/src/graph/session_test.ts
+++ b/src/graph/session_test.ts
@@ -17,11 +17,11 @@
 
 import {InputProvider} from '../data/input_provider';
 import {ENV} from '../environment';
+import * as dl from '../index';
 import {NDArrayMath} from '../math/math';
-import {Array1D, NDArray, Scalar} from '../math/ndarray';
+import {Array1D, Scalar} from '../math/ndarray';
 import {SGDOptimizer} from '../math/optimizers/sgd_optimizer';
 import * as test_util from '../test_util';
-
 import {Graph, Tensor} from './graph';
 import {FeedDictionary, FeedEntry, Session} from './session';
 
@@ -33,7 +33,7 @@ describe('FeedDictionary', () => {
   it('ctor populates dict from only feed entry', () => {
     const math = ENV.math;
     math.scope(() => {
-      const e: FeedEntry = {tensor: new Tensor([]), data: NDArray.zeros([1])};
+      const e: FeedEntry = {tensor: new Tensor([]), data: dl.zeros([1])};
       const d = new FeedDictionary([e]);
       expect(Object.keys(d.dict).length).toEqual(1);
       expect(d.dict[e.tensor.id]).toBe(e);
@@ -42,10 +42,10 @@ describe('FeedDictionary', () => {
 
   it('ctor populates dict from many entries', () => {
     const entries: FeedEntry[] = [
-      {tensor: new Tensor([]), data: NDArray.zeros([1])},
-      {tensor: new Tensor([]), data: NDArray.zeros([1])},
-      {tensor: new Tensor([]), data: NDArray.zeros([1])},
-      {tensor: new Tensor([]), data: NDArray.zeros([1])}
+      {tensor: new Tensor([]), data: dl.zeros([1])},
+      {tensor: new Tensor([]), data: dl.zeros([1])},
+      {tensor: new Tensor([]), data: dl.zeros([1])},
+      {tensor: new Tensor([]), data: dl.zeros([1])}
     ];
     const d = new FeedDictionary(entries);
     expect(Object.keys(d.dict).length).toEqual(entries.length);
@@ -54,7 +54,7 @@ describe('FeedDictionary', () => {
 
   it('add adds entry to map keyed on tensor id', () => {
     const t = new Tensor([]);
-    const nda = NDArray.zeros([1]);
+    const nda = dl.zeros([1]);
     const fd = new FeedDictionary([{tensor: t, data: nda}]);
     expect(fd.dict[t.id].tensor).toBe(t);
     expect(fd.dict[t.id].data).toBe(nda);
@@ -69,24 +69,24 @@ describe('Session', () => {
   it('mnist fc', () => {
     const math = ENV.math;
     const input = g.placeholder('input', [28 * 28]);
-    const fc0W = g.variable('fc0W', NDArray.zeros([32, 28 * 28]));
-    const fc0B = g.variable('fc0B', NDArray.zeros([32]));
+    const fc0W = g.variable('fc0W', dl.zeros([32, 28 * 28]));
+    const fc0B = g.variable('fc0B', dl.zeros([32]));
     const fc0 = g.add(g.matmul(fc0W, input), fc0B);
     const relu0 = g.relu(fc0);
-    const fc1W = g.variable('fc1W', NDArray.zeros([32, 32]));
-    const fc1B = g.variable('fc1B', NDArray.zeros([32]));
+    const fc1W = g.variable('fc1W', dl.zeros([32, 32]));
+    const fc1B = g.variable('fc1B', dl.zeros([32]));
     const fc1 = g.add(g.matmul(fc1W, relu0), fc1B);
     const relu1 = g.relu(fc1);
-    const fc2W = g.variable('fc2W', NDArray.zeros([32, 32]));
-    const fc2B = g.variable('fc2B', NDArray.zeros([32]));
+    const fc2W = g.variable('fc2W', dl.zeros([32, 32]));
+    const fc2B = g.variable('fc2B', dl.zeros([32]));
     const fc2 = g.add(g.matmul(fc2W, relu1), fc2B);
     const relu2 = g.relu(fc2);
-    const fc3W = g.variable('fc3W', NDArray.zeros([10, 32]));
-    const fc3B = g.variable('fc3B', NDArray.zeros([10]));
+    const fc3W = g.variable('fc3W', dl.zeros([10, 32]));
+    const fc3B = g.variable('fc3B', dl.zeros([10]));
     const fc3 = g.add(g.matmul(fc3W, relu2), fc3B);
 
     const session = new Session(g, math);
-    session.eval(fc3, [{tensor: input, data: NDArray.zeros([28 * 28])}]);
+    session.eval(fc3, [{tensor: input, data: dl.zeros([28 * 28])}]);
   });
 
   it('y=x^2 + 3: CPU', () => {
@@ -226,10 +226,10 @@ describe('Session', () => {
   it('Specify which variables to update (var_list)', () => {
     const math = ENV.math;
     const x = g.placeholder('x', [2]);
-    const b0 = g.variable('b0', NDArray.zeros([2]));
+    const b0 = g.variable('b0', dl.zeros([2]));
     const p = g.add(x, b0);
     const q = g.square(p);
-    const b1 = g.variable('b1', NDArray.zeros([2]));
+    const b1 = g.variable('b1', dl.zeros([2]));
     const r = g.add(q, b1);
     const yPrediction = g.reduceSum(r);
     const yTrue = g.constant(1);

--- a/src/graph/session_util_test.ts
+++ b/src/graph/session_util_test.ts
@@ -18,6 +18,7 @@
 // tslint:disable-next-line:max-line-length
 import {InputProvider} from '../data/input_provider';
 import {ENV} from '../environment';
+import * as dl from '../index';
 import {NDArray} from '../math/ndarray';
 // tslint:disable-next-line:max-line-length
 import {ConstantNode, Graph, Node, PlaceholderNode, Tensor, VariableNode} from './graph';
@@ -41,7 +42,7 @@ describe('getTerminatingNodesFromFeedDictionary', () => {
     math.scope(() => {
       const node = new TestNode(new Graph(), '', {}, new Tensor([]));
       const fd =
-          new FeedDictionary([{tensor: node.output, data: NDArray.zeros([1])}]);
+          new FeedDictionary([{tensor: node.output, data: dl.zeros([1])}]);
       expect(session_util.getTerminatingNodesFromFeedDictionary(fd)).toEqual([
         node
       ]);
@@ -57,11 +58,11 @@ describe('getTerminatingNodesFromFeedDictionary', () => {
       const n3 = new TestNode(new Graph(), '', {}, new Tensor([]));
       const n4 = new TestNode(new Graph(), '', {}, new Tensor([]));
       const feeds: FeedEntry[] = [
-        {tensor: n0.output, data: NDArray.zeros([1])},
-        {tensor: n1.output, data: NDArray.zeros([1])},
-        {tensor: n2.output, data: NDArray.zeros([1])},
-        {tensor: n3.output, data: NDArray.zeros([1])},
-        {tensor: n4.output, data: NDArray.zeros([1])}
+        {tensor: n0.output, data: dl.zeros([1])},
+        {tensor: n1.output, data: dl.zeros([1])},
+        {tensor: n2.output, data: dl.zeros([1])},
+        {tensor: n3.output, data: dl.zeros([1])},
+        {tensor: n4.output, data: dl.zeros([1])}
       ];
       const fd = new FeedDictionary(feeds);
       const nodes = session_util.getTerminatingNodesFromFeedDictionary(fd);
@@ -90,13 +91,13 @@ describe('addPersistentArraysToTensorArrayMap', () => {
   });
 
   it('adds the only VariableNode to the map', () => {
-    const v = new VariableNode(g, '', NDArray.zeros([1]));
+    const v = new VariableNode(g, '', dl.zeros([1]));
     session_util.addPersistentArraysToTensorArrayMap([v], map);
     expect(map.get(v.output)).toBe(v.data);
   });
 
   it('adds the only ConstantNode to the map', () => {
-    const c = new ConstantNode(g, NDArray.zeros([1]));
+    const c = new ConstantNode(g, dl.zeros([1]));
     session_util.addPersistentArraysToTensorArrayMap([c], map);
     expect(map.get(c.output)).toBe(c.data);
   });
@@ -110,9 +111,9 @@ describe('addPersistentArraysToTensorArrayMap', () => {
 
   it('adds multiple VariableNodes to the map', () => {
     const nodes = [
-      new VariableNode(g, '', NDArray.zeros([1])),
-      new VariableNode(g, '', NDArray.zeros([1])),
-      new VariableNode(g, '', NDArray.zeros([1]))
+      new VariableNode(g, '', dl.zeros([1])),
+      new VariableNode(g, '', dl.zeros([1])),
+      new VariableNode(g, '', dl.zeros([1]))
     ];
     session_util.addPersistentArraysToTensorArrayMap(nodes, map);
     expect(map.get(nodes[0].output)).toBe(nodes[0].data);
@@ -123,9 +124,8 @@ describe('addPersistentArraysToTensorArrayMap', () => {
   it('adds multiple ConstantNodes to the map', () => {
     math.scope(() => {
       const nodes = [
-        new ConstantNode(g, NDArray.zeros([1])),
-        new ConstantNode(g, NDArray.zeros([1])),
-        new ConstantNode(g, NDArray.zeros([1]))
+        new ConstantNode(g, dl.zeros([1])), new ConstantNode(g, dl.zeros([1])),
+        new ConstantNode(g, dl.zeros([1]))
       ];
       session_util.addPersistentArraysToTensorArrayMap(nodes, map);
       expect(map.get(nodes[0].output)).toBe(nodes[0].data);
@@ -137,11 +137,11 @@ describe('addPersistentArraysToTensorArrayMap', () => {
   it('skips non-VariableNode or ConstantNode entries in the set', () => {
     const nodes: Node[] = [
       new TestNode(g, '', {}, new Tensor([])),
-      new VariableNode(g, '', NDArray.zeros([1])),
+      new VariableNode(g, '', dl.zeros([1])),
       new TestNode(g, '', {}, new Tensor([])),
-      new ConstantNode(g, NDArray.zeros([1])),
+      new ConstantNode(g, dl.zeros([1])),
       new TestNode(g, '', {}, new Tensor([])),
-      new VariableNode(g, '', NDArray.zeros([1]))
+      new VariableNode(g, '', dl.zeros([1]))
     ];
     session_util.addPersistentArraysToTensorArrayMap(nodes, map);
     expect(map.size()).toEqual(3);
@@ -167,7 +167,7 @@ describe('loadInputsFromFeedDictionaryToTensorArrayMap', () => {
 
   it('adds the only NDArray feed dict entry to the map', () => {
     const tensor = new Tensor([1]);
-    const fd = new FeedDictionary([{tensor, data: NDArray.zeros([1])}]);
+    const fd = new FeedDictionary([{tensor, data: dl.zeros([1])}]);
     session_util.loadInputsFromFeedDictionaryToTensorArrayMap(fd, map, math);
     expect(map.size()).toEqual(1);
     expect(map.get(tensor)).toBe(fd.dict[tensor.id].data as NDArray);
@@ -175,7 +175,7 @@ describe('loadInputsFromFeedDictionaryToTensorArrayMap', () => {
 
   it('adds the only provider feed dict entry to the map', () => {
     const tensor = new Tensor([2]);
-    const ndarray = NDArray.zeros([2]);
+    const ndarray = dl.zeros([2]);
     const provider: InputProvider = {
       getNextCopy():
           NDArray {  // Don't return a copy in this case so we can test
@@ -198,7 +198,7 @@ describe('loadInputsFromFeedDictionaryToTensorArrayMap', () => {
       new Tensor([1])
     ];
     const feeds = tensors.map(tensor => {
-      return {tensor, data: NDArray.zeros([1])};
+      return {tensor, data: dl.zeros([1])};
     });
     const fd = new FeedDictionary(feeds);
     session_util.loadInputsFromFeedDictionaryToTensorArrayMap(fd, map, math);
@@ -215,7 +215,7 @@ describe('loadInputsFromFeedDictionaryToTensorArrayMap', () => {
     ];
     const ndarrays: NDArray[] = [];
     for (let i = 0; i < tensors.length; i++) {
-      ndarrays.push(NDArray.zeros([1]));
+      ndarrays.push(dl.zeros([1]));
     }
     let idx = 0;
     const provider: InputProvider = {
@@ -242,7 +242,7 @@ describe('loadInputsFromFeedDictionaryToTensorArrayMap', () => {
 
   it('throws when provides data that does not match tensor shape', () => {
     const tensor = new Tensor([4, 5]);
-    const fd = new FeedDictionary([{tensor, data: NDArray.zeros([2, 3])}]);
+    const fd = new FeedDictionary([{tensor, data: dl.zeros([2, 3])}]);
     expect(
         () => session_util.loadInputsFromFeedDictionaryToTensorArrayMap(
             fd, map, math))
@@ -267,9 +267,8 @@ describe('releaseFeedDictionaryInputsFromTensorArrayMap', () => {
 
   it('doesn\'t remove tensors from map that don\'t exist in feed', () => {
     const fdTensor = new Tensor([]);
-    const nda = NDArray.zeros([1]);
-    const fd =
-        new FeedDictionary([{tensor: fdTensor, data: NDArray.zeros([1])}]);
+    const nda = dl.zeros([1]);
+    const fd = new FeedDictionary([{tensor: fdTensor, data: dl.zeros([1])}]);
     const nonFDTensor = new Tensor([]);
     map.set(nonFDTensor, nda);
     session_util.releaseFeedDictionaryInputsFromTensorArrayMap(fd, map, math);
@@ -279,7 +278,7 @@ describe('releaseFeedDictionaryInputsFromTensorArrayMap', () => {
 
   it('removes only tensor in map and feed dict', () => {
     const tensor = new Tensor([]);
-    const ndarray = NDArray.zeros([1]);
+    const ndarray = dl.zeros([1]);
     const fd = new FeedDictionary([{tensor, data: ndarray}]);
     map.set(tensor, ndarray);
     session_util.releaseFeedDictionaryInputsFromTensorArrayMap(fd, map, math);
@@ -290,7 +289,7 @@ describe('releaseFeedDictionaryInputsFromTensorArrayMap', () => {
     const tensors = [new Tensor([]), new Tensor([]), new Tensor([])];
 
     const feeds = tensors.map(tensor => {
-      return {tensor, data: NDArray.zeros([1])};
+      return {tensor, data: dl.zeros([1])};
     });
     const fd = new FeedDictionary(feeds);
     tensors.forEach(
@@ -315,8 +314,7 @@ describe('disposeAndInitializeOperationOutputs', () => {
 
   it('does nothing to map if set has no input nodes', () => {
     const nodes = [
-      new VariableNode(g, '', NDArray.zeros([1])),
-      new PlaceholderNode(g, '', [1])
+      new VariableNode(g, '', dl.zeros([1])), new PlaceholderNode(g, '', [1])
     ];
     session_util.disposeAndInitializeOperationOutputs(nodes, map);
     expect(map.size()).toEqual(0);
@@ -362,7 +360,7 @@ describe('removeFeedDictionaryNodesFromEvaluationSet', () => {
   it('removes only feed dict node from set', () => {
     set.push(new TestNode(new Graph(), '', {}, new Tensor([])));
     const fd =
-        new FeedDictionary([{tensor: set[0].output, data: NDArray.zeros([1])}]);
+        new FeedDictionary([{tensor: set[0].output, data: dl.zeros([1])}]);
     session_util.removeFeedDictionaryNodesFromEvaluationSet(fd, set);
     expect(set.length).toEqual(0);
   });
@@ -378,10 +376,10 @@ describe('removeFeedDictionaryNodesFromEvaluationSet', () => {
     set.push(remainingNodes[0]);
     set.push(new TestNode(g, '', {}, new Tensor([])));
     const feeds: FeedEntry[] = [];
-    feeds.push({tensor: set[set.length - 1].output, data: NDArray.zeros([1])});
+    feeds.push({tensor: set[set.length - 1].output, data: dl.zeros([1])});
     set.push(remainingNodes[1]);
     set.push(new TestNode(g, '', {}, new Tensor([])));
-    feeds.push({tensor: set[set.length - 1].output, data: NDArray.zeros([1])});
+    feeds.push({tensor: set[set.length - 1].output, data: dl.zeros([1])});
     set.push(remainingNodes[2]);
 
     const fd = new FeedDictionary(feeds);

--- a/src/graph/tensor_array_map_test.ts
+++ b/src/graph/tensor_array_map_test.ts
@@ -16,7 +16,8 @@
  */
 
 import {ENV} from '../environment';
-import {Array1D, NDArray} from '../math/ndarray';
+import * as dl from '../index';
+import {Array1D} from '../math/ndarray';
 import {Tensor} from './graph';
 import {SummedTensorArrayMap, TensorArrayMap} from './tensor_array_map';
 
@@ -27,14 +28,14 @@ describe('TensorArrayMap.size', () => {
 
   it('is 1 after add', () => {
     const map = new TensorArrayMap();
-    map.set(new Tensor([]), NDArray.zeros([1]));
+    map.set(new Tensor([]), dl.zeros([1]));
     expect(map.size()).toEqual(1);
   });
 
   it('increments for every add', () => {
     const map = new TensorArrayMap();
     for (let i = 0; i < 9; ++i) {
-      map.set(new Tensor([]), NDArray.zeros([1]));
+      map.set(new Tensor([]), dl.zeros([1]));
     }
     expect(map.size()).toEqual(9);
   });
@@ -54,7 +55,7 @@ describe('TensorArrayMap.hasNullArray', () => {
   });
 
   it('returns false for non-null NDArray entries', () => {
-    map.set(t, NDArray.zeros([1]));
+    map.set(t, dl.zeros([1]));
     expect(map.hasNullArray(t)).toBe(false);
   });
 
@@ -72,7 +73,7 @@ describe('TensorArrayMap.get', () => {
   });
 
   it('returns the associated NDArray', () => {
-    const nda = NDArray.zeros([1]);
+    const nda = dl.zeros([1]);
     map.set(t, nda);
     expect(map.get(t)).toBe(nda);
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import * as conv_util from './math/conv_util';
 import * as test_util from './test_util';
 import * as util from './util';
 import {version} from './version';
+
 export {CheckpointLoader} from './data/checkpoint_loader';
 export {DataStats, InMemoryDataset} from './data/dataset';
 // tslint:disable-next-line:max-line-length
@@ -52,6 +53,7 @@ export {LSTMCell, NDArrayMath} from './math/math';
 export {Array1D, Array2D, Array3D, Array4D, NDArray, Scalar, variable, Variable} from './math/ndarray';
 export {Optimizer} from './math/optimizers/optimizer';
 export {SGDOptimizer} from './math/optimizers/sgd_optimizer';
+export {Rank} from './math/types';
 export {Model} from './model';
 export {version};
 // Second level exports.
@@ -65,4 +67,5 @@ export {
   webgl_util,
   xhr_dataset
 };
+
 export * from './math/ops';

--- a/src/math/arithmetic_test.ts
+++ b/src/math/arithmetic_test.ts
@@ -287,9 +287,9 @@ import {Array1D, Array2D, Array3D, NDArray, Scalar} from './ndarray';
       const a = Array2D.new([2, 3], [1, 2, -3, -4, 5, 6], 'float32');
       const b = Array2D.new([2, 2], [5, 3, 4, -7], 'int32');
 
-      expect(() => math.multiplyStrict(a, b as Array2D as Array2D<'float32'>))
+      expect(() => math.multiplyStrict(a, b as Array2D as Array2D))
           .toThrowError();
-      expect(() => math.multiplyStrict(b, a as Array2D as Array2D<'int32'>))
+      expect(() => math.multiplyStrict(b, a as Array2D as Array2D))
           .toThrowError();
     });
 

--- a/src/math/arithmetic_test.ts
+++ b/src/math/arithmetic_test.ts
@@ -15,10 +15,10 @@
  * =============================================================================
  */
 
+import * as dl from '../index';
 import * as test_util from '../test_util';
 import {MathTests} from '../test_util';
-
-import {Array1D, Array2D, Array3D, NDArray, Scalar} from './ndarray';
+import {Array1D, Array2D, Array3D, Scalar} from './ndarray';
 
 // divide
 {
@@ -984,7 +984,7 @@ import {Array1D, Array2D, Array3D, NDArray, Scalar} from './ndarray';
       const a = Array2D.new([2, 3], [2, 4, 6, 8, 10, 12]);
       const b = Array2D.new([2, 3], [1, 2, 3, 4, 5, 6]);
       // tslint:disable-next-line:no-any
-      const c1: any = NDArray.randNormal([10]);
+      const c1: any = dl.randNormal([10]);
       const c2 = Scalar.new(2);
 
       expect(() => math.scaledArrayAdd(c1 as Scalar, a, c2, b)).toThrowError();

--- a/src/math/arithmetic_test.ts
+++ b/src/math/arithmetic_test.ts
@@ -17,7 +17,8 @@
 
 import * as test_util from '../test_util';
 import {MathTests} from '../test_util';
-import {Array1D, Array2D, Array3D, Scalar} from './ndarray';
+
+import {Array1D, Array2D, Array3D, NDArray, Scalar} from './ndarray';
 
 // divide
 {
@@ -983,7 +984,7 @@ import {Array1D, Array2D, Array3D, Scalar} from './ndarray';
       const a = Array2D.new([2, 3], [2, 4, 6, 8, 10, 12]);
       const b = Array2D.new([2, 3], [1, 2, 3, 4, 5, 6]);
       // tslint:disable-next-line:no-any
-      const c1: any = Array1D.randNormal([10]);
+      const c1: any = NDArray.randNormal([10]);
       const c2 = Scalar.new(2);
 
       expect(() => math.scaledArrayAdd(c1 as Scalar, a, c2, b)).toThrowError();

--- a/src/math/array_ops.ts
+++ b/src/math/array_ops.ts
@@ -25,16 +25,14 @@ import {DataType, DataTypeMap, Rank} from './types';
 export class Ops {
   /** Creates a ndarray of ones with the specified shape. */
   @operation
-  static ones<D extends DataType = 'float32', R extends Rank = Rank>(
-      shape: number[], dtype?: D): NDArray<D, R> {
+  static ones<R extends Rank>(shape: number[], dtype?: DataType): NDArray<R> {
     const values = makeOnesTypedArray(util.sizeFromShape(shape), dtype);
     return NDArray.make(shape, {values}, dtype);
   }
 
   /** Creates a ndarray of zeros with the specified shape. */
   @operation
-  static zeros<D extends DataType = 'float32', R extends Rank = Rank>(
-      shape: number[], dtype?: D): NDArray<D, R> {
+  static zeros<R extends Rank>(shape: number[], dtype?: DataType): NDArray<R> {
     const values = makeZerosTypedArray(util.sizeFromShape(shape), dtype);
     return NDArray.make(shape, {values}, dtype);
   }
@@ -57,17 +55,16 @@ export class Ops {
 
   /** Creates a ndarray with the same values/shape as the specified ndarray. */
   @operation
-  static clone<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      NDArray<D, R> {
+  static clone<R extends Rank>(x: NDArray<R>): NDArray<R> {
     const newValues = util.copyTypedArray(x.dataSync(), x.dtype);
-    return NDArray.make(x.shape, {values: newValues}, x.dtype) as NDArray<D, R>;
+    return NDArray.make(x.shape, {values: newValues}, x.dtype) as NDArray<R>;
   }
 
   @operation
-  static randNormal<D extends keyof RandNormalDataTypes, R extends Rank>(
-      shape: number[], mean = 0, stdDev = 1, dtype?: D, seed?: number):
-      NDArray<D, R> {
-    if (dtype != null && dtype === 'bool') {
+  static randNormal<R extends Rank>(
+      shape: number[], mean = 0, stdDev = 1, dtype?: keyof RandNormalDataTypes,
+      seed?: number): NDArray<R> {
+    if (dtype != null && (dtype as DataType) === 'bool') {
       throw new Error(`Unsupported data type ${dtype}`);
     }
     const randGauss =
@@ -76,11 +73,10 @@ export class Ops {
   }
 
   @operation
-  static randTruncatedNormal<D extends keyof RandNormalDataTypes,
-                                       R extends Rank>(
-      shape: number[], mean = 0, stdDev = 1, dtype?: D, seed?: number):
-      NDArray<D, R> {
-    if (dtype != null && dtype === 'bool') {
+  static randTruncatedNormal<R extends Rank>(
+      shape: number[], mean = 0, stdDev = 1, dtype?: keyof RandNormalDataTypes,
+      seed?: number): NDArray<R> {
+    if (dtype != null && (dtype as DataType) === 'bool') {
       throw new Error(`Unsupported data type ${dtype}`);
     }
     const randGauss =
@@ -89,14 +85,15 @@ export class Ops {
   }
 
   @operation
-  static randUniform<D extends DataType, R extends Rank>(
-      shape: number[], a: number, b: number, dtype?: D): NDArray<D, R> {
+  static randUniform<R extends Rank>(
+      shape: number[], a: number, b: number, dtype?: DataType): NDArray<R> {
     return NDArray.rand(shape, () => util.randUniform(a, b), dtype);
   }
 
   @operation
-  static rand<D extends DataType, R extends Rank>(
-      shape: number[], randFunction: () => number, dtype?: D): NDArray<D, R> {
+  static rand<R extends Rank>(
+      shape: number[], randFunction: () => number, dtype?: DataType):
+      NDArray<R> {
     const size = util.sizeFromShape(shape);
 
     let values = null;
@@ -119,15 +116,15 @@ export class Ops {
   @operation
   static fromPixels(
       pixels: ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement,
-      numChannels = 3): Array3D<'int32'> {
+      numChannels = 3): Array3D {
     if (numChannels > 4) {
       throw new Error(
           'Cannot construct NDArray with more than 4 channels from pixels.');
     }
-    const ndarrayData: NDArrayData<'int32'> = {};
+    const ndarrayData: NDArrayData = {};
     const shape: [number, number, number] =
         [pixels.height, pixels.width, numChannels];
-    const res = NDArray.make(shape, ndarrayData, 'int32') as Array3D<'int32'>;
+    const res = NDArray.make(shape, ndarrayData, 'int32') as Array3D;
     ENV.math.writePixels(res.dataId, pixels, numChannels);
     return res;
   }

--- a/src/math/array_ops.ts
+++ b/src/math/array_ops.ts
@@ -20,13 +20,13 @@ import * as util from '../util';
 import {operation} from './decorators';
 import {Array3D, NDArray, NDArrayData} from './ndarray';
 import {MPRandGauss, RandNormalDataTypes} from './rand';
-import {DataType, DataTypeMap, Rank, RankMap} from './types';
+import {DataType, DataTypeMap, Rank} from './types';
 
 export class Ops {
   /** Creates a ndarray of ones with the specified shape. */
   @operation
   static ones<D extends DataType = 'float32', R extends Rank = Rank>(
-      shape: number[], dtype?: D): RankMap<D>[R] {
+      shape: number[], dtype?: D): NDArray<D, R> {
     const values = makeOnesTypedArray(util.sizeFromShape(shape), dtype);
     return NDArray.make(shape, {values}, dtype);
   }
@@ -34,7 +34,7 @@ export class Ops {
   /** Creates a ndarray of zeros with the specified shape. */
   @operation
   static zeros<D extends DataType = 'float32', R extends Rank = Rank>(
-      shape: number[], dtype?: D): RankMap<D>[R] {
+      shape: number[], dtype?: D): NDArray<D, R> {
     const values = makeZerosTypedArray(util.sizeFromShape(shape), dtype);
     return NDArray.make(shape, {values}, dtype);
   }
@@ -58,15 +58,15 @@ export class Ops {
   /** Creates a ndarray with the same values/shape as the specified ndarray. */
   @operation
   static clone<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      RankMap<D>[R] {
+      NDArray<D, R> {
     const newValues = util.copyTypedArray(x.dataSync(), x.dtype);
-    return NDArray.make(x.shape, {values: newValues}, x.dtype) as RankMap<D>[R];
+    return NDArray.make(x.shape, {values: newValues}, x.dtype) as NDArray<D, R>;
   }
 
   @operation
   static randNormal<D extends keyof RandNormalDataTypes, R extends Rank>(
       shape: number[], mean = 0, stdDev = 1, dtype?: D, seed?: number):
-      RankMap<D>[R] {
+      NDArray<D, R> {
     if (dtype != null && dtype === 'bool') {
       throw new Error(`Unsupported data type ${dtype}`);
     }
@@ -79,7 +79,7 @@ export class Ops {
   static randTruncatedNormal<D extends keyof RandNormalDataTypes,
                                        R extends Rank>(
       shape: number[], mean = 0, stdDev = 1, dtype?: D, seed?: number):
-      RankMap<D>[R] {
+      NDArray<D, R> {
     if (dtype != null && dtype === 'bool') {
       throw new Error(`Unsupported data type ${dtype}`);
     }
@@ -90,13 +90,13 @@ export class Ops {
 
   @operation
   static randUniform<D extends DataType, R extends Rank>(
-      shape: number[], a: number, b: number, dtype?: D): RankMap<D>[R] {
+      shape: number[], a: number, b: number, dtype?: D): NDArray<D, R> {
     return NDArray.rand(shape, () => util.randUniform(a, b), dtype);
   }
 
   @operation
   static rand<D extends DataType, R extends Rank>(
-      shape: number[], randFunction: () => number, dtype?: D): RankMap<D>[R] {
+      shape: number[], randFunction: () => number, dtype?: D): NDArray<D, R> {
     const size = util.sizeFromShape(shape);
 
     let values = null;

--- a/src/math/array_ops_test.ts
+++ b/src/math/array_ops_test.ts
@@ -955,7 +955,7 @@ const testsFromPixels: MathTests = it => {
     pixels.data[2] = 160;
     pixels.data[3] = 240;
 
-    const array = Array3D.fromPixels(pixels, 3);
+    const array = NDArray.fromPixels(pixels, 3);
 
     test_util.expectArraysEqual(array, [0, 80, 160]);
   });
@@ -967,7 +967,7 @@ const testsFromPixels: MathTests = it => {
     pixels.data[2] = 160;
     pixels.data[3] = 240;
 
-    const array = Array3D.fromPixels(pixels, 4);
+    const array = NDArray.fromPixels(pixels, 4);
 
     test_util.expectArraysEqual(array, [0, 80, 160, 240]);
   });
@@ -982,7 +982,7 @@ const testsFromPixels: MathTests = it => {
       pixels.data[i] = i * 2;
     }
 
-    const array = Array3D.fromPixels(pixels, 3);
+    const array = NDArray.fromPixels(pixels, 3);
 
     test_util.expectArraysEqual(
         array, [0, 2, 4, 8, 10, 12, 16, 18, 20, 24, 26, 28]);
@@ -997,7 +997,7 @@ const testsFromPixels: MathTests = it => {
       pixels.data[i] = i * 2;
     }
 
-    const array = Array3D.fromPixels(pixels, 4);
+    const array = NDArray.fromPixels(pixels, 4);
 
     test_util.expectArraysClose(
         array,

--- a/src/math/array_ops_test.ts
+++ b/src/math/array_ops_test.ts
@@ -20,115 +20,116 @@ import * as test_util from '../test_util';
 import {MathTests} from '../test_util';
 import * as util from '../util';
 import {Array1D, Array2D, Array3D, Array4D, NDArray} from './ndarray';
+import {Rank} from './types';
 
 const testsZeros: MathTests = it => {
   it('1D default dtype', () => {
-    const a = dl.zeros<'1'>([3]);
+    const a = dl.zeros<Rank.R1>([3]);
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([3]);
     test_util.expectArraysClose(a, [0, 0, 0]);
   });
 
   it('1D float32 dtype', () => {
-    const a = dl.zeros<'1'>([3], 'float32');
+    const a = dl.zeros<Rank.R1>([3], 'float32');
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([3]);
     test_util.expectArraysClose(a, [0, 0, 0]);
   });
 
   it('1D int32 dtype', () => {
-    const a = dl.zeros<'1'>([3], 'int32');
+    const a = dl.zeros<Rank.R1>([3], 'int32');
     expect(a.dtype).toBe('int32');
     expect(a.shape).toEqual([3]);
     test_util.expectArraysEqual(a, [0, 0, 0]);
   });
 
   it('1D bool dtype', () => {
-    const a = dl.zeros<'1'>([3], 'bool');
+    const a = dl.zeros<Rank.R1>([3], 'bool');
     expect(a.dtype).toBe('bool');
     expect(a.shape).toEqual([3]);
     test_util.expectArraysEqual(a, [0, 0, 0]);
   });
 
   it('2D default dtype', () => {
-    const a = dl.zeros<'1'>([3, 2]);
+    const a = dl.zeros<Rank.R1>([3, 2]);
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([3, 2]);
     test_util.expectArraysClose(a, [0, 0, 0, 0, 0, 0]);
   });
 
   it('2D float32 dtype', () => {
-    const a = dl.zeros<'1'>([3, 2], 'float32');
+    const a = dl.zeros<Rank.R1>([3, 2], 'float32');
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([3, 2]);
     test_util.expectArraysClose(a, [0, 0, 0, 0, 0, 0]);
   });
 
   it('2D int32 dtype', () => {
-    const a = dl.zeros<'1'>([3, 2], 'int32');
+    const a = dl.zeros<Rank.R1>([3, 2], 'int32');
     expect(a.dtype).toBe('int32');
     expect(a.shape).toEqual([3, 2]);
     test_util.expectArraysEqual(a, [0, 0, 0, 0, 0, 0]);
   });
 
   it('2D bool dtype', () => {
-    const a = dl.zeros<'1'>([3, 2], 'bool');
+    const a = dl.zeros<Rank.R1>([3, 2], 'bool');
     expect(a.dtype).toBe('bool');
     expect(a.shape).toEqual([3, 2]);
     test_util.expectArraysEqual(a, [0, 0, 0, 0, 0, 0]);
   });
 
   it('3D default dtype', () => {
-    const a = dl.zeros<'1'>([2, 2, 2]);
+    const a = dl.zeros<Rank.R1>([2, 2, 2]);
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([2, 2, 2]);
     test_util.expectArraysClose(a, [0, 0, 0, 0, 0, 0, 0, 0]);
   });
 
   it('3D float32 dtype', () => {
-    const a = dl.zeros<'1'>([2, 2, 2], 'float32');
+    const a = dl.zeros<Rank.R1>([2, 2, 2], 'float32');
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([2, 2, 2]);
     test_util.expectArraysClose(a, [0, 0, 0, 0, 0, 0, 0, 0]);
   });
 
   it('3D int32 dtype', () => {
-    const a = dl.zeros<'1'>([2, 2, 2], 'int32');
+    const a = dl.zeros<Rank.R1>([2, 2, 2], 'int32');
     expect(a.dtype).toBe('int32');
     expect(a.shape).toEqual([2, 2, 2]);
     test_util.expectArraysEqual(a, [0, 0, 0, 0, 0, 0, 0, 0]);
   });
 
   it('3D bool dtype', () => {
-    const a = dl.zeros<'1'>([2, 2, 2], 'bool');
+    const a = dl.zeros<Rank.R1>([2, 2, 2], 'bool');
     expect(a.dtype).toBe('bool');
     expect(a.shape).toEqual([2, 2, 2]);
     test_util.expectArraysEqual(a, [0, 0, 0, 0, 0, 0, 0, 0]);
   });
 
   it('4D default dtype', () => {
-    const a = dl.zeros<'1'>([3, 2, 1, 1]);
+    const a = dl.zeros<Rank.R1>([3, 2, 1, 1]);
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([3, 2, 1, 1]);
     test_util.expectArraysClose(a, [0, 0, 0, 0, 0, 0]);
   });
 
   it('4D float32 dtype', () => {
-    const a = dl.zeros<'1'>([3, 2, 1, 1], 'float32');
+    const a = dl.zeros<Rank.R1>([3, 2, 1, 1], 'float32');
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([3, 2, 1, 1]);
     test_util.expectArraysClose(a, [0, 0, 0, 0, 0, 0]);
   });
 
   it('4D int32 dtype', () => {
-    const a = dl.zeros<'1'>([3, 2, 1, 1], 'int32');
+    const a = dl.zeros<Rank.R1>([3, 2, 1, 1], 'int32');
     expect(a.dtype).toBe('int32');
     expect(a.shape).toEqual([3, 2, 1, 1]);
     test_util.expectArraysEqual(a, [0, 0, 0, 0, 0, 0]);
   });
 
   it('4D bool dtype', () => {
-    const a = dl.zeros<'1'>([3, 2, 1, 1], 'bool');
+    const a = dl.zeros<Rank.R1>([3, 2, 1, 1], 'bool');
     expect(a.dtype).toBe('bool');
     expect(a.shape).toEqual([3, 2, 1, 1]);
     test_util.expectArraysEqual(a, [0, 0, 0, 0, 0, 0]);
@@ -136,112 +137,112 @@ const testsZeros: MathTests = it => {
 };
 const testsOnes: MathTests = it => {
   it('1D default dtype', () => {
-    const a = dl.ones<'1'>([3]);
+    const a = dl.ones<Rank.R1>([3]);
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([3]);
     test_util.expectArraysClose(a, [1, 1, 1]);
   });
 
   it('1D float32 dtype', () => {
-    const a = dl.ones<'1'>([3], 'float32');
+    const a = dl.ones<Rank.R1>([3], 'float32');
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([3]);
     test_util.expectArraysClose(a, [1, 1, 1]);
   });
 
   it('1D int32 dtype', () => {
-    const a = dl.ones<'1'>([3], 'int32');
+    const a = dl.ones<Rank.R1>([3], 'int32');
     expect(a.dtype).toBe('int32');
     expect(a.shape).toEqual([3]);
     test_util.expectArraysEqual(a, [1, 1, 1]);
   });
 
   it('1D bool dtype', () => {
-    const a = dl.ones<'1'>([3], 'bool');
+    const a = dl.ones<Rank.R1>([3], 'bool');
     expect(a.dtype).toBe('bool');
     expect(a.shape).toEqual([3]);
     test_util.expectArraysEqual(a, [1, 1, 1]);
   });
 
   it('2D default dtype', () => {
-    const a = dl.ones<'2'>([3, 2]);
+    const a = dl.ones<Rank.R2>([3, 2]);
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([3, 2]);
     test_util.expectArraysClose(a, [1, 1, 1, 1, 1, 1]);
   });
 
   it('2D float32 dtype', () => {
-    const a = dl.ones<'2'>([3, 2], 'float32');
+    const a = dl.ones<Rank.R2>([3, 2], 'float32');
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([3, 2]);
     test_util.expectArraysClose(a, [1, 1, 1, 1, 1, 1]);
   });
 
   it('2D int32 dtype', () => {
-    const a = dl.ones<'2'>([3, 2], 'int32');
+    const a = dl.ones<Rank.R2>([3, 2], 'int32');
     expect(a.dtype).toBe('int32');
     expect(a.shape).toEqual([3, 2]);
     test_util.expectArraysEqual(a, [1, 1, 1, 1, 1, 1]);
   });
 
   it('2D bool dtype', () => {
-    const a = dl.ones<'2'>([3, 2], 'bool');
+    const a = dl.ones<Rank.R2>([3, 2], 'bool');
     expect(a.dtype).toBe('bool');
     expect(a.shape).toEqual([3, 2]);
     test_util.expectArraysEqual(a, [1, 1, 1, 1, 1, 1]);
   });
 
   it('3D default dtype', () => {
-    const a = dl.ones<'3'>([2, 2, 2]);
+    const a = dl.ones<Rank.R3>([2, 2, 2]);
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([2, 2, 2]);
     test_util.expectArraysClose(a, [1, 1, 1, 1, 1, 1, 1, 1]);
   });
 
   it('3D float32 dtype', () => {
-    const a = dl.ones<'3'>([2, 2, 2], 'float32');
+    const a = dl.ones<Rank.R3>([2, 2, 2], 'float32');
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([2, 2, 2]);
     test_util.expectArraysClose(a, [1, 1, 1, 1, 1, 1, 1, 1]);
   });
 
   it('3D int32 dtype', () => {
-    const a = dl.ones<'3'>([2, 2, 2], 'int32');
+    const a = dl.ones<Rank.R3>([2, 2, 2], 'int32');
     expect(a.dtype).toBe('int32');
     expect(a.shape).toEqual([2, 2, 2]);
     test_util.expectArraysEqual(a, [1, 1, 1, 1, 1, 1, 1, 1]);
   });
 
   it('3D bool dtype', () => {
-    const a = dl.ones<'3'>([2, 2, 2], 'bool');
+    const a = dl.ones<Rank.R3>([2, 2, 2], 'bool');
     expect(a.dtype).toBe('bool');
     expect(a.shape).toEqual([2, 2, 2]);
     test_util.expectArraysEqual(a, [1, 1, 1, 1, 1, 1, 1, 1]);
   });
 
   it('4D default dtype', () => {
-    const a = dl.ones<'4'>([3, 2, 1, 1]);
+    const a = dl.ones<Rank.R4>([3, 2, 1, 1]);
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([3, 2, 1, 1]);
     test_util.expectArraysClose(a, [1, 1, 1, 1, 1, 1]);
   });
 
   it('4D float32 dtype', () => {
-    const a = dl.ones<'4'>([3, 2, 1, 1], 'float32');
+    const a = dl.ones<Rank.R4>([3, 2, 1, 1], 'float32');
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([3, 2, 1, 1]);
     test_util.expectArraysClose(a, [1, 1, 1, 1, 1, 1]);
   });
 
   it('4D int32 dtype', () => {
-    const a = dl.ones<'4'>([3, 2, 1, 1], 'int32');
+    const a = dl.ones<Rank.R4>([3, 2, 1, 1], 'int32');
     expect(a.dtype).toBe('int32');
     expect(a.shape).toEqual([3, 2, 1, 1]);
     test_util.expectArraysEqual(a, [1, 1, 1, 1, 1, 1]);
   });
 
   it('4D bool dtype', () => {
-    const a = dl.ones<'4'>([3, 2, 1, 1], 'bool');
+    const a = dl.ones<Rank.R4>([3, 2, 1, 1], 'bool');
     expect(a.dtype).toBe('bool');
     expect(a.shape).toEqual([3, 2, 1, 1]);
     test_util.expectArraysEqual(a, [1, 1, 1, 1, 1, 1]);

--- a/src/math/array_ops_test.ts
+++ b/src/math/array_ops_test.ts
@@ -23,112 +23,112 @@ import {Array1D, Array2D, Array3D, Array4D, NDArray} from './ndarray';
 
 const testsZeros: MathTests = it => {
   it('1D default dtype', () => {
-    const a = dl.zeros<'float32', '1'>([3]);
+    const a = dl.zeros<'1'>([3]);
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([3]);
     test_util.expectArraysClose(a, [0, 0, 0]);
   });
 
   it('1D float32 dtype', () => {
-    const a = dl.zeros<'float32', '1'>([3], 'float32');
+    const a = dl.zeros<'1'>([3], 'float32');
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([3]);
     test_util.expectArraysClose(a, [0, 0, 0]);
   });
 
   it('1D int32 dtype', () => {
-    const a = dl.zeros<'int32', '1'>([3], 'int32');
+    const a = dl.zeros<'1'>([3], 'int32');
     expect(a.dtype).toBe('int32');
     expect(a.shape).toEqual([3]);
     test_util.expectArraysEqual(a, [0, 0, 0]);
   });
 
   it('1D bool dtype', () => {
-    const a = dl.zeros<'bool', '1'>([3], 'bool');
+    const a = dl.zeros<'1'>([3], 'bool');
     expect(a.dtype).toBe('bool');
     expect(a.shape).toEqual([3]);
     test_util.expectArraysEqual(a, [0, 0, 0]);
   });
 
   it('2D default dtype', () => {
-    const a = dl.zeros<'float32', '1'>([3, 2]);
+    const a = dl.zeros<'1'>([3, 2]);
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([3, 2]);
     test_util.expectArraysClose(a, [0, 0, 0, 0, 0, 0]);
   });
 
   it('2D float32 dtype', () => {
-    const a = dl.zeros<'float32', '1'>([3, 2], 'float32');
+    const a = dl.zeros<'1'>([3, 2], 'float32');
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([3, 2]);
     test_util.expectArraysClose(a, [0, 0, 0, 0, 0, 0]);
   });
 
   it('2D int32 dtype', () => {
-    const a = dl.zeros<'int32', '1'>([3, 2], 'int32');
+    const a = dl.zeros<'1'>([3, 2], 'int32');
     expect(a.dtype).toBe('int32');
     expect(a.shape).toEqual([3, 2]);
     test_util.expectArraysEqual(a, [0, 0, 0, 0, 0, 0]);
   });
 
   it('2D bool dtype', () => {
-    const a = dl.zeros<'bool', '1'>([3, 2], 'bool');
+    const a = dl.zeros<'1'>([3, 2], 'bool');
     expect(a.dtype).toBe('bool');
     expect(a.shape).toEqual([3, 2]);
     test_util.expectArraysEqual(a, [0, 0, 0, 0, 0, 0]);
   });
 
   it('3D default dtype', () => {
-    const a = dl.zeros<'float32', '1'>([2, 2, 2]);
+    const a = dl.zeros<'1'>([2, 2, 2]);
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([2, 2, 2]);
     test_util.expectArraysClose(a, [0, 0, 0, 0, 0, 0, 0, 0]);
   });
 
   it('3D float32 dtype', () => {
-    const a = dl.zeros<'float32', '1'>([2, 2, 2], 'float32');
+    const a = dl.zeros<'1'>([2, 2, 2], 'float32');
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([2, 2, 2]);
     test_util.expectArraysClose(a, [0, 0, 0, 0, 0, 0, 0, 0]);
   });
 
   it('3D int32 dtype', () => {
-    const a = dl.zeros<'int32', '1'>([2, 2, 2], 'int32');
+    const a = dl.zeros<'1'>([2, 2, 2], 'int32');
     expect(a.dtype).toBe('int32');
     expect(a.shape).toEqual([2, 2, 2]);
     test_util.expectArraysEqual(a, [0, 0, 0, 0, 0, 0, 0, 0]);
   });
 
   it('3D bool dtype', () => {
-    const a = dl.zeros<'bool', '1'>([2, 2, 2], 'bool');
+    const a = dl.zeros<'1'>([2, 2, 2], 'bool');
     expect(a.dtype).toBe('bool');
     expect(a.shape).toEqual([2, 2, 2]);
     test_util.expectArraysEqual(a, [0, 0, 0, 0, 0, 0, 0, 0]);
   });
 
   it('4D default dtype', () => {
-    const a = dl.zeros<'float32', '1'>([3, 2, 1, 1]);
+    const a = dl.zeros<'1'>([3, 2, 1, 1]);
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([3, 2, 1, 1]);
     test_util.expectArraysClose(a, [0, 0, 0, 0, 0, 0]);
   });
 
   it('4D float32 dtype', () => {
-    const a = dl.zeros<'float32', '1'>([3, 2, 1, 1], 'float32');
+    const a = dl.zeros<'1'>([3, 2, 1, 1], 'float32');
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([3, 2, 1, 1]);
     test_util.expectArraysClose(a, [0, 0, 0, 0, 0, 0]);
   });
 
   it('4D int32 dtype', () => {
-    const a = dl.zeros<'int32', '1'>([3, 2, 1, 1], 'int32');
+    const a = dl.zeros<'1'>([3, 2, 1, 1], 'int32');
     expect(a.dtype).toBe('int32');
     expect(a.shape).toEqual([3, 2, 1, 1]);
     test_util.expectArraysEqual(a, [0, 0, 0, 0, 0, 0]);
   });
 
   it('4D bool dtype', () => {
-    const a = dl.zeros<'bool', '1'>([3, 2, 1, 1], 'bool');
+    const a = dl.zeros<'1'>([3, 2, 1, 1], 'bool');
     expect(a.dtype).toBe('bool');
     expect(a.shape).toEqual([3, 2, 1, 1]);
     test_util.expectArraysEqual(a, [0, 0, 0, 0, 0, 0]);
@@ -136,112 +136,112 @@ const testsZeros: MathTests = it => {
 };
 const testsOnes: MathTests = it => {
   it('1D default dtype', () => {
-    const a = dl.ones<'float32', '1'>([3]);
+    const a = dl.ones<'1'>([3]);
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([3]);
     test_util.expectArraysClose(a, [1, 1, 1]);
   });
 
   it('1D float32 dtype', () => {
-    const a = dl.ones<'float32', '1'>([3], 'float32');
+    const a = dl.ones<'1'>([3], 'float32');
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([3]);
     test_util.expectArraysClose(a, [1, 1, 1]);
   });
 
   it('1D int32 dtype', () => {
-    const a = dl.ones<'int32', '1'>([3], 'int32');
+    const a = dl.ones<'1'>([3], 'int32');
     expect(a.dtype).toBe('int32');
     expect(a.shape).toEqual([3]);
     test_util.expectArraysEqual(a, [1, 1, 1]);
   });
 
   it('1D bool dtype', () => {
-    const a = dl.ones<'bool', '1'>([3], 'bool');
+    const a = dl.ones<'1'>([3], 'bool');
     expect(a.dtype).toBe('bool');
     expect(a.shape).toEqual([3]);
     test_util.expectArraysEqual(a, [1, 1, 1]);
   });
 
   it('2D default dtype', () => {
-    const a = dl.ones<'float32', '2'>([3, 2]);
+    const a = dl.ones<'2'>([3, 2]);
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([3, 2]);
     test_util.expectArraysClose(a, [1, 1, 1, 1, 1, 1]);
   });
 
   it('2D float32 dtype', () => {
-    const a = dl.ones<'float32', '2'>([3, 2], 'float32');
+    const a = dl.ones<'2'>([3, 2], 'float32');
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([3, 2]);
     test_util.expectArraysClose(a, [1, 1, 1, 1, 1, 1]);
   });
 
   it('2D int32 dtype', () => {
-    const a = dl.ones<'int32', '2'>([3, 2], 'int32');
+    const a = dl.ones<'2'>([3, 2], 'int32');
     expect(a.dtype).toBe('int32');
     expect(a.shape).toEqual([3, 2]);
     test_util.expectArraysEqual(a, [1, 1, 1, 1, 1, 1]);
   });
 
   it('2D bool dtype', () => {
-    const a = dl.ones<'bool', '2'>([3, 2], 'bool');
+    const a = dl.ones<'2'>([3, 2], 'bool');
     expect(a.dtype).toBe('bool');
     expect(a.shape).toEqual([3, 2]);
     test_util.expectArraysEqual(a, [1, 1, 1, 1, 1, 1]);
   });
 
   it('3D default dtype', () => {
-    const a = dl.ones<'float32', '3'>([2, 2, 2]);
+    const a = dl.ones<'3'>([2, 2, 2]);
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([2, 2, 2]);
     test_util.expectArraysClose(a, [1, 1, 1, 1, 1, 1, 1, 1]);
   });
 
   it('3D float32 dtype', () => {
-    const a = dl.ones<'float32', '3'>([2, 2, 2], 'float32');
+    const a = dl.ones<'3'>([2, 2, 2], 'float32');
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([2, 2, 2]);
     test_util.expectArraysClose(a, [1, 1, 1, 1, 1, 1, 1, 1]);
   });
 
   it('3D int32 dtype', () => {
-    const a = dl.ones<'int32', '3'>([2, 2, 2], 'int32');
+    const a = dl.ones<'3'>([2, 2, 2], 'int32');
     expect(a.dtype).toBe('int32');
     expect(a.shape).toEqual([2, 2, 2]);
     test_util.expectArraysEqual(a, [1, 1, 1, 1, 1, 1, 1, 1]);
   });
 
   it('3D bool dtype', () => {
-    const a = dl.ones<'bool', '3'>([2, 2, 2], 'bool');
+    const a = dl.ones<'3'>([2, 2, 2], 'bool');
     expect(a.dtype).toBe('bool');
     expect(a.shape).toEqual([2, 2, 2]);
     test_util.expectArraysEqual(a, [1, 1, 1, 1, 1, 1, 1, 1]);
   });
 
   it('4D default dtype', () => {
-    const a = dl.ones<'float32', '4'>([3, 2, 1, 1]);
+    const a = dl.ones<'4'>([3, 2, 1, 1]);
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([3, 2, 1, 1]);
     test_util.expectArraysClose(a, [1, 1, 1, 1, 1, 1]);
   });
 
   it('4D float32 dtype', () => {
-    const a = dl.ones<'float32', '4'>([3, 2, 1, 1], 'float32');
+    const a = dl.ones<'4'>([3, 2, 1, 1], 'float32');
     expect(a.dtype).toBe('float32');
     expect(a.shape).toEqual([3, 2, 1, 1]);
     test_util.expectArraysClose(a, [1, 1, 1, 1, 1, 1]);
   });
 
   it('4D int32 dtype', () => {
-    const a = dl.ones<'int32', '4'>([3, 2, 1, 1], 'int32');
+    const a = dl.ones<'4'>([3, 2, 1, 1], 'int32');
     expect(a.dtype).toBe('int32');
     expect(a.shape).toEqual([3, 2, 1, 1]);
     test_util.expectArraysEqual(a, [1, 1, 1, 1, 1, 1]);
   });
 
   it('4D bool dtype', () => {
-    const a = dl.ones<'bool', '4'>([3, 2, 1, 1], 'bool');
+    const a = dl.ones<'4'>([3, 2, 1, 1], 'bool');
     expect(a.dtype).toBe('bool');
     expect(a.shape).toEqual([3, 2, 1, 1]);
     test_util.expectArraysEqual(a, [1, 1, 1, 1, 1, 1]);

--- a/src/math/axis_util_test.ts
+++ b/src/math/axis_util_test.ts
@@ -16,9 +16,9 @@
  */
 
 import {ENV} from '../environment';
+import * as dl from '../index';
 import * as test_util from '../test_util';
 import * as axis_util from './axis_util';
-import {NDArray} from './ndarray';
 
 describe('axis_util combineLocations', () => {
   it('rank 4, reduce last 2 dims', () => {
@@ -284,7 +284,7 @@ describe('axis_util getUndoAxesPermutation', () => {
     const axes = [2, 0, 1, 3];
     const undoPermutation = axis_util.getUndoAxesPermutation(axes);
 
-    const a = NDArray.randNormal([2, 3, 4, 5]);
+    const a = dl.randNormal([2, 3, 4, 5]);
     const aT = ENV.math.transpose(a, axes);
     const aTT = ENV.math.transpose(aT, undoPermutation);
     test_util.expectArraysClose(a, aTT);

--- a/src/math/axis_util_test.ts
+++ b/src/math/axis_util_test.ts
@@ -18,7 +18,7 @@
 import {ENV} from '../environment';
 import * as test_util from '../test_util';
 import * as axis_util from './axis_util';
-import {Array4D} from './ndarray';
+import {NDArray} from './ndarray';
 
 describe('axis_util combineLocations', () => {
   it('rank 4, reduce last 2 dims', () => {
@@ -284,7 +284,7 @@ describe('axis_util getUndoAxesPermutation', () => {
     const axes = [2, 0, 1, 3];
     const undoPermutation = axis_util.getUndoAxesPermutation(axes);
 
-    const a = Array4D.randNormal([2, 3, 4, 5]);
+    const a = NDArray.randNormal([2, 3, 4, 5]);
     const aT = ENV.math.transpose(a, axes);
     const aTT = ENV.math.transpose(aT, undoPermutation);
     test_util.expectArraysClose(a, aTT);

--- a/src/math/backends/backend.ts
+++ b/src/math/backends/backend.ts
@@ -24,10 +24,10 @@ import {SumTypes} from '../types';
 import {MatrixOrientation} from './types/matmul';
 
 export interface NDArrayStorage {
-  read<D extends DataType>(dataId: number): Promise<DataTypeMap[D]>;
-  readSync<D extends DataType>(dataId: number): DataTypeMap[D];
+  read(dataId: number): Promise<DataTypeMap[D]>;
+  readSync(dataId: number): DataTypeMap[D];
   disposeData(dataId: number): void;
-  write<D extends DataType>(dataId: number, values: DataTypeMap[D]): void;
+  write(dataId: number, values: DataTypeMap[D]): void;
   writePixels(
       dataId: number,
       pixels: ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement,
@@ -49,17 +49,14 @@ export interface MathBackend extends NDArrayStorage {
 
   clone<T extends NDArray>(ndarray: T): T;
 
-  slice1D<D extends DataType>(x: Array1D<D>, begin: number, size: number):
-      Array1D<D>;
-  slice2D<D extends DataType>(x: Array2D<D>, begin: [number, number], size: [
-    number, number
-  ]): Array2D<D>;
-  slice3D<D extends DataType>(
-      x: Array3D<D>, begin: [number, number, number],
-      size: [number, number, number]): Array3D<D>;
-  slice4D<D extends DataType>(
-      x: Array4D<D>, begin: [number, number, number, number],
-      size: [number, number, number, number]): Array4D<D>;
+  slice1D(x: Array1D, begin: number, size: number): Array1D;
+  slice2D(x: Array2D, begin: [number, number], size: [number, number]): Array2D;
+  slice3D(x: Array3D, begin: [number, number, number], size: [
+    number, number, number
+  ]): Array3D;
+  slice4D(x: Array4D, begin: [number, number, number, number], size: [
+    number, number, number, number
+  ]): Array4D;
 
   reverse4D(a: Array4D, axis: number[]): Array4D;
 
@@ -70,45 +67,43 @@ export interface MathBackend extends NDArrayStorage {
 
   neg<T extends NDArray>(a: T): T;
 
-  add<D extends DataType>(a: NDArray<D>, b: NDArray<D>): NDArray<D>;
-  subtract<D extends DataType>(a: NDArray<D>, b: NDArray<D>): NDArray<D>;
-  multiply<D extends DataType>(a: NDArray<D>, b: NDArray<D>): NDArray<D>;
-  divide<D extends DataType>(a: NDArray<D>, b: NDArray<D>): NDArray<'float32'>;
+  add(a: NDArray, b: NDArray): NDArray;
+  subtract(a: NDArray, b: NDArray): NDArray;
+  multiply(a: NDArray, b: NDArray): NDArray;
+  divide(a: NDArray, b: NDArray): NDArray;
 
-  sum<D extends DataType>(x: NDArray<D>, axes: number[]): NDArray<SumTypes[D]>;
+  sum(x: NDArray, axes: number[]): NDArray<SumTypes[D]>;
 
-  argMin(x: NDArray, axes: number[]): NDArray<'int32'>;
-  argMax(x: NDArray, axes: number[]): NDArray<'int32'>;
+  argMin(x: NDArray, axes: number[]): NDArray;
+  argMax(x: NDArray, axes: number[]): NDArray;
 
-  equal(a: NDArray, b: NDArray): NDArray<'bool'>;
-  notEqual(a: NDArray, b: NDArray): NDArray<'bool'>;
+  equal(a: NDArray, b: NDArray): NDArray;
+  notEqual(a: NDArray, b: NDArray): NDArray;
 
-  less(a: NDArray, b: NDArray): NDArray<'bool'>;
-  lessEqual(a: NDArray, b: NDArray): NDArray<'bool'>;
+  less(a: NDArray, b: NDArray): NDArray;
+  lessEqual(a: NDArray, b: NDArray): NDArray;
 
-  greater(a: NDArray, b: NDArray): NDArray<'bool'>;
-  greaterEqual(a: NDArray, b: NDArray): NDArray<'bool'>;
+  greater(a: NDArray, b: NDArray): NDArray;
+  greaterEqual(a: NDArray, b: NDArray): NDArray;
 
-  logicalAnd(a: NDArray, b: NDArray): NDArray<'bool'>;
-  logicalOr(a: NDArray, b: NDArray): NDArray<'bool'>;
+  logicalAnd(a: NDArray, b: NDArray): NDArray;
+  logicalOr(a: NDArray, b: NDArray): NDArray;
 
-  where<D extends DataType>(
-      condition: NDArray, a: NDArray, b: NDArray, dtype: D): NDArray<D>;
+  where(condition: NDArray, a: NDArray, b: NDArray, dtype: D): NDArray;
 
-  topKValues<D extends DataType, T extends NDArray<D>>(x: T, k: number):
-      Array1D<D>;
-  topKIndices(x: NDArray, k: number): Array1D<'int32'>;
+  topKValues<T extends NDArray>(x: T, k: number): Array1D;
+  topKIndices(x: NDArray, k: number): Array1D;
 
-  min<D extends DataType>(x: NDArray<D>, axes: number[]): NDArray<D>;
-  minimum<D extends DataType>(a: NDArray<D>, b: NDArray<D>): NDArray<D>;
+  min(x: NDArray, axes: number[]): NDArray;
+  minimum(a: NDArray, b: NDArray): NDArray;
 
-  max<D extends DataType>(x: NDArray<D>, axes: number[]): NDArray<D>;
-  maximum<D extends DataType>(a: NDArray<D>, b: NDArray<D>): NDArray<D>;
+  max(x: NDArray, axes: number[]): NDArray;
+  maximum(a: NDArray, b: NDArray): NDArray;
 
   ceil<T extends NDArray>(x: T): T;
   floor<T extends NDArray>(x: T): T;
 
-  pow<T extends NDArray>(a: T, b: NDArray<'int32'>): T;
+  pow<T extends NDArray>(a: T, b: NDArray): T;
   exp<T extends NDArray>(x: T): T;
   log<T extends NDArray>(x: T): T;
   sqrt<T extends NDArray>(x: T): T;
@@ -122,7 +117,7 @@ export interface MathBackend extends NDArrayStorage {
   leakyRelu<T extends NDArray>(x: T, alpha: number): T;
   prelu<T extends NDArray>(x: T, alpha: T): T;
   preluDer<T extends NDArray>(x: T, alpha: T): T;
-  int<R extends Rank>(x: NDArray<DataType, R>): NDArray<'int32', R>;
+  int<R extends Rank>(x: NDArray<R>): NDArray<R>;
 
   clip<T extends NDArray>(x: T, min: number, max: number): T;
 
@@ -160,17 +155,16 @@ export interface MathBackend extends NDArrayStorage {
   avgPool(x: Array4D, convInfo: Conv2DInfo): Array4D;
   avgPoolBackprop(dy: Array4D, x: Array4D, convInfo: Conv2DInfo): Array4D;
 
-  tile<D extends DataType, T extends NDArray<D>>(x: T, reps: number[]): T;
+  tile<T extends NDArray>(x: T, reps: number[]): T;
 
   pad1D(x: Array1D, paddings: [number, number], constantValue: number): Array1D;
   pad2D(
       x: Array2D, paddings: [[number, number], [number, number]],
       constantValue: number): Array2D;
 
-  transpose<D extends DataType, T extends NDArray<D>>(x: T, perm: number[]): T;
+  transpose<T extends NDArray>(x: T, perm: number[]): T;
 
-  gather<D extends DataType, T extends NDArray<D>>(
-      x: T, indices: Array1D<'int32'>, axis: number): T;
+  gather<T extends NDArray>(x: T, indices: Array1D, axis: number): T;
 
   resizeBilinear3D(
       x: Array3D, newShape2D: [number, number], alignCorners: boolean): Array3D;
@@ -193,7 +187,7 @@ export interface MathBackend extends NDArrayStorage {
       normRegion: 'acrossChannels'|'withinChannel'): Array4D;
 
   multinomial(probabilities: Array2D, numSamples: number, seed: number):
-      Array2D<'int32'>;
+      Array2D;
 
   oneHot(indices: Array1D, depth: number, onValue: number, offValue: number):
       Array2D;

--- a/src/math/backends/backend.ts
+++ b/src/math/backends/backend.ts
@@ -19,15 +19,15 @@
 import {Conv2DInfo} from '../conv_util';
 // tslint:disable-next-line:max-line-length
 import {Array1D, Array2D, Array3D, Array4D, NDArray} from '../ndarray';
-import {DataType, DataTypeMap, Rank} from '../types';
-import {SumTypes} from '../types';
+import {DataType, DataVal, Rank} from '../types';
+
 import {MatrixOrientation} from './types/matmul';
 
 export interface NDArrayStorage {
-  read(dataId: number): Promise<DataTypeMap[D]>;
-  readSync(dataId: number): DataTypeMap[D];
+  read(dataId: number): Promise<DataVal>;
+  readSync(dataId: number): DataVal;
   disposeData(dataId: number): void;
-  write(dataId: number, values: DataTypeMap[D]): void;
+  write(dataId: number, values: DataVal): void;
   writePixels(
       dataId: number,
       pixels: ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement,
@@ -72,7 +72,7 @@ export interface MathBackend extends NDArrayStorage {
   multiply(a: NDArray, b: NDArray): NDArray;
   divide(a: NDArray, b: NDArray): NDArray;
 
-  sum(x: NDArray, axes: number[]): NDArray<SumTypes[D]>;
+  sum(x: NDArray, axes: number[]): NDArray;
 
   argMin(x: NDArray, axes: number[]): NDArray;
   argMax(x: NDArray, axes: number[]): NDArray;
@@ -89,7 +89,7 @@ export interface MathBackend extends NDArrayStorage {
   logicalAnd(a: NDArray, b: NDArray): NDArray;
   logicalOr(a: NDArray, b: NDArray): NDArray;
 
-  where(condition: NDArray, a: NDArray, b: NDArray, dtype: D): NDArray;
+  where(condition: NDArray, a: NDArray, b: NDArray, dtype: DataType): NDArray;
 
   topKValues<T extends NDArray>(x: T, k: number): Array1D;
   topKIndices(x: NDArray, k: number): Array1D;

--- a/src/math/backends/backend.ts
+++ b/src/math/backends/backend.ts
@@ -19,15 +19,15 @@
 import {Conv2DInfo} from '../conv_util';
 // tslint:disable-next-line:max-line-length
 import {Array1D, Array2D, Array3D, Array4D, NDArray} from '../ndarray';
-import {DataType, DataVal, Rank} from '../types';
+import {DataType, Rank, TypedArray} from '../types';
 
 import {MatrixOrientation} from './types/matmul';
 
 export interface NDArrayStorage {
-  read(dataId: number): Promise<DataVal>;
-  readSync(dataId: number): DataVal;
+  read(dataId: number): Promise<TypedArray>;
+  readSync(dataId: number): TypedArray;
   disposeData(dataId: number): void;
-  write(dataId: number, values: DataVal): void;
+  write(dataId: number, values: TypedArray): void;
   writePixels(
       dataId: number,
       pixels: ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement,

--- a/src/math/backends/backend_cpu.ts
+++ b/src/math/backends/backend_cpu.ts
@@ -26,7 +26,7 @@ import {NDArrayMath} from '../math';
 // tslint:disable-next-line:max-line-length
 import {Array1D, Array2D, Array3D, Array4D, NDArray, Scalar} from '../ndarray';
 import * as types from '../types';
-import {DataType, DataTypeMap, Rank, SumTypes, SumTypesMap} from '../types';
+import {DataType, DataTypeMap, Rank} from '../types';
 import * as axis_util from './../axis_util';
 import {MathBackend} from './backend';
 import {MatrixOrientation} from './types/matmul';
@@ -44,7 +44,7 @@ export class MathBackendCPU implements MathBackend {
   register(dataId: number, shape: number[], dtype: DataType): void {
     this.data[dataId] = null;
   }
-  write<D extends DataType>(dataId: number, values: DataTypeMap[D]): void {
+  write(dataId: number, values: DataTypeMap[D]): void {
     if (values == null) {
       throw new Error('MathBackendCPU.write(): values can not be null');
     }
@@ -99,11 +99,11 @@ export class MathBackendCPU implements MathBackend {
     }
     this.data[dataId] = values;
   }
-  async read<D extends DataType>(dataId: number): Promise<DataTypeMap[D]> {
+  async read(dataId: number): Promise<DataTypeMap[D]> {
     this.throwIfNoData(dataId);
     return this.data[dataId];
   }
-  readSync<D extends DataType>(dataId: number): DataTypeMap[D] {
+  readSync(dataId: number): DataTypeMap[D] {
     this.throwIfNoData(dataId);
     return this.data[dataId];
   }
@@ -129,15 +129,13 @@ export class MathBackendCPU implements MathBackend {
     return NDArray.make(x.shape, {values: new Float32Array(x.dataSync())}) as T;
   }
 
-  slice1D<D extends DataType>(x: Array1D<D>, begin: number, size: number):
-      Array1D<D> {
+  slice1D(x: Array1D, begin: number, size: number): Array1D {
     const newVals = x.dataSync().slice(begin, begin + size);
     return Array1D.new(newVals);
   }
 
-  slice2D<D extends DataType>(x: Array2D<D>, begin: [number, number], size: [
-    number, number
-  ]): Array2D<D> {
+  slice2D(x: Array2D, begin: [number, number], size: [number, number]):
+      Array2D {
     const result = NDArray.zeros<D, '2'>(size, x.dtype);
     const [startI, startJ] = begin;
 
@@ -150,9 +148,9 @@ export class MathBackendCPU implements MathBackend {
     return result;
   }
 
-  slice3D<D extends DataType>(
-      x: Array3D<D>, begin: [number, number, number],
-      size: [number, number, number]): Array3D<D> {
+  slice3D(x: Array3D, begin: [number, number, number], size: [
+    number, number, number
+  ]): Array3D {
     const result = NDArray.zeros<D, '3'>(size, x.dtype);
     const [startI, startJ, startK] = begin;
 
@@ -166,9 +164,9 @@ export class MathBackendCPU implements MathBackend {
     }
     return result;
   }
-  slice4D<D extends DataType>(
-      x: Array4D<D>, begin: [number, number, number, number],
-      size: [number, number, number, number]): Array4D<D> {
+  slice4D(x: Array4D, begin: [number, number, number, number], size: [
+    number, number, number, number
+  ]): Array4D {
     const result = NDArray.zeros<D, '4'>(size, x.dtype);
     const [startI, startJ, startK, startL] = begin;
 
@@ -212,7 +210,7 @@ export class MathBackendCPU implements MathBackend {
 
   concat1D(a: Array1D, b: Array1D): Array1D {
     const outShape = concat_util.computeOutShape(a.shape, b.shape, 0);
-    const result = NDArray.zeros<'float32', '1'>(outShape as [number]);
+    const result = NDArray.zeros<'1'>(outShape as [number]);
 
     // Use built-in TypedArray.set() method for speed.
     const aVals = a.dataSync();
@@ -226,7 +224,7 @@ export class MathBackendCPU implements MathBackend {
 
   concat2D(a: Array2D, b: Array2D, axis: number): Array2D {
     const outShape = concat_util.computeOutShape(a.shape, b.shape, axis);
-    const result = NDArray.zeros<'float32', '2'>(outShape as [number, number]);
+    const result = NDArray.zeros<'2'>(outShape as [number, number]);
 
     if (axis === 0) {
       // Use built-in TypedArray.set() method for speed.
@@ -259,8 +257,7 @@ export class MathBackendCPU implements MathBackend {
   concat3D(a: Array3D, b: Array3D, axis: number): Array3D {
     const outShape = concat_util.computeOutShape(a.shape, b.shape, axis);
 
-    const result =
-        NDArray.zeros<'float32', '3'>(outShape as [number, number, number]);
+    const result = NDArray.zeros<'3'>(outShape as [number, number, number]);
 
     if (axis === 0) {
       // Use built-in TypedArray.set() method for speed.
@@ -296,8 +293,8 @@ export class MathBackendCPU implements MathBackend {
 
   concat4D(a: Array4D, b: Array4D, axis: number): Array4D {
     const outShape = concat_util.computeOutShape(a.shape, b.shape, axis);
-    const result = NDArray.zeros<'float32', '4'>(
-        outShape as [number, number, number, number]);
+    const result =
+        NDArray.zeros<'4'>(outShape as [number, number, number, number]);
 
     if (axis === 0) {
       // Use built-in TypedArray.set() method for speed.
@@ -337,19 +334,19 @@ export class MathBackendCPU implements MathBackend {
     return this.multiply(Scalar.new(-1), x) as T;
   }
 
-  add<D extends DataType>(a: NDArray<D>, b: NDArray<D>): NDArray<D> {
+  add(a: NDArray, b: NDArray): NDArray {
     return this.broadcastedBinaryOp(
                a, b, types.upcastType(a.dtype, b.dtype),
-               (aValue, bValue) => aValue + bValue) as NDArray<D>;
+               (aValue, bValue) => aValue + bValue) as NDArray;
   }
 
-  subtract<D extends DataType>(a: NDArray<D>, b: NDArray<D>): NDArray<D> {
+  subtract(a: NDArray, b: NDArray): NDArray {
     return this.broadcastedBinaryOp(
                a, b, types.upcastType(a.dtype, b.dtype),
-               (aValue, bValue) => aValue - bValue) as NDArray<D>;
+               (aValue, bValue) => aValue - bValue) as NDArray;
   }
 
-  pow<T extends NDArray>(a: T, b: NDArray<'int32'>): T {
+  pow<T extends NDArray>(a: T, b: NDArray): T {
     return this.broadcastedBinaryOp(
                a, b, a.dtype, (aValue, bValue) => Math.pow(aValue, bValue)) as
         T;
@@ -392,19 +389,18 @@ export class MathBackendCPU implements MathBackend {
     return Array2D.new([leftDim, rightDim], values);
   }
 
-  multiply<D extends DataType>(a: NDArray<D>, b: NDArray<D>): NDArray<D> {
+  multiply(a: NDArray, b: NDArray): NDArray {
     return this.broadcastedBinaryOp(
                a, b, types.upcastType(a.dtype, b.dtype),
-               (aValue, bValue) => aValue * bValue) as NDArray<D>;
+               (aValue, bValue) => aValue * bValue) as NDArray;
   }
 
-  divide(a: NDArray, b: NDArray): NDArray<'float32'> {
+  divide(a: NDArray, b: NDArray): NDArray {
     return this.broadcastedBinaryOp(
-               a, b, 'float32', (aValue, bValue) => aValue / bValue) as
-        NDArray<'float32'>;
+               a, b, 'float32', (aValue, bValue) => aValue / bValue) as NDArray;
   }
 
-  sum<D extends DataType>(x: NDArray<D>, axes: number[]): NDArray<SumTypes[D]> {
+  sum(x: NDArray, axes: number[]): NDArray<SumTypes[D]> {
     axis_util.assertAxesAreInnerMostDims('sum', axes, x.rank);
     const [outShape, reduceShape] =
         axis_util.computeOutAndReduceShapes(x.shape, axes);
@@ -425,7 +421,7 @@ export class MathBackendCPU implements MathBackend {
     return result as NDArray<SumTypes[D]>;
   }
 
-  argMin(x: NDArray, axes: number[]): NDArray<'int32'> {
+  argMin(x: NDArray, axes: number[]): NDArray {
     axis_util.assertAxesAreInnerMostDims('argMin', axes, x.rank);
     const [outShape, reduceShape] =
         axis_util.computeOutAndReduceShapes(x.shape, axes);
@@ -454,7 +450,7 @@ export class MathBackendCPU implements MathBackend {
     return result;
   }
 
-  argMax(x: NDArray, axes: number[]): NDArray<'int32'> {
+  argMax(x: NDArray, axes: number[]): NDArray {
     axis_util.assertAxesAreInnerMostDims('argMax', axes, x.rank);
     const [outShape, reduceShape] =
         axis_util.computeOutAndReduceShapes(x.shape, axes);
@@ -483,7 +479,7 @@ export class MathBackendCPU implements MathBackend {
     return result;
   }
 
-  equal(a: NDArray, b: NDArray): NDArray<'bool'> {
+  equal(a: NDArray, b: NDArray): NDArray {
     return this.broadcastedBinaryOp(a, b, 'bool', (aVal, bVal) => {
       if (util.isValNaN(aVal, a.dtype) || util.isValNaN(bVal, b.dtype)) {
         return util.getNaN('bool');
@@ -493,7 +489,7 @@ export class MathBackendCPU implements MathBackend {
     });
   }
 
-  notEqual(a: NDArray, b: NDArray): NDArray<'bool'> {
+  notEqual(a: NDArray, b: NDArray): NDArray {
     return this.broadcastedBinaryOp(a, b, 'bool', (aVal, bVal) => {
       if (util.isValNaN(aVal, a.dtype) || util.isValNaN(bVal, b.dtype)) {
         return util.getNaN('bool');
@@ -503,7 +499,7 @@ export class MathBackendCPU implements MathBackend {
     });
   }
 
-  less(a: NDArray, b: NDArray): NDArray<'bool'> {
+  less(a: NDArray, b: NDArray): NDArray {
     return this.broadcastedBinaryOp(a, b, 'bool', (aVal, bVal) => {
       if (util.isValNaN(aVal, a.dtype) || util.isValNaN(bVal, b.dtype)) {
         return util.getNaN('bool');
@@ -513,7 +509,7 @@ export class MathBackendCPU implements MathBackend {
     });
   }
 
-  lessEqual(a: NDArray, b: NDArray): NDArray<'bool'> {
+  lessEqual(a: NDArray, b: NDArray): NDArray {
     return this.broadcastedBinaryOp(a, b, 'bool', (aVal, bVal) => {
       if (util.isValNaN(aVal, a.dtype) || util.isValNaN(bVal, b.dtype)) {
         return util.getNaN('bool');
@@ -523,7 +519,7 @@ export class MathBackendCPU implements MathBackend {
     });
   }
 
-  greater(a: NDArray, b: NDArray): NDArray<'bool'> {
+  greater(a: NDArray, b: NDArray): NDArray {
     return this.broadcastedBinaryOp(a, b, 'bool', (aVal, bVal) => {
       if (util.isValNaN(aVal, a.dtype) || util.isValNaN(bVal, b.dtype)) {
         return util.getNaN('bool');
@@ -533,7 +529,7 @@ export class MathBackendCPU implements MathBackend {
     });
   }
 
-  greaterEqual(a: NDArray, b: NDArray): NDArray<'bool'> {
+  greaterEqual(a: NDArray, b: NDArray): NDArray {
     return this.broadcastedBinaryOp(a, b, 'bool', (aVal, bVal) => {
       if (util.isValNaN(aVal, a.dtype) || util.isValNaN(bVal, b.dtype)) {
         return util.getNaN('bool');
@@ -543,7 +539,7 @@ export class MathBackendCPU implements MathBackend {
     });
   }
 
-  logicalAnd(a: NDArray, b: NDArray): NDArray<'bool'> {
+  logicalAnd(a: NDArray, b: NDArray): NDArray {
     return this.broadcastedBinaryOp(a, b, 'bool', (aVal, bVal) => {
       if (util.isValNaN(aVal, a.dtype) || util.isValNaN(bVal, b.dtype)) {
         return util.getNaN('bool');
@@ -553,7 +549,7 @@ export class MathBackendCPU implements MathBackend {
     });
   }
 
-  logicalOr(a: NDArray, b: NDArray): NDArray<'bool'> {
+  logicalOr(a: NDArray, b: NDArray): NDArray {
     return this.broadcastedBinaryOp(a, b, 'bool', (aVal, bVal) => {
       if (util.isValNaN(aVal, a.dtype) || util.isValNaN(bVal, b.dtype)) {
         return util.getNaN('bool');
@@ -563,8 +559,7 @@ export class MathBackendCPU implements MathBackend {
     });
   }
 
-  where<D extends DataType>(
-      condition: NDArray, a: NDArray, b: NDArray, dtype: D): NDArray<D> {
+  where(condition: NDArray, a: NDArray, b: NDArray, dtype: D): NDArray {
     const values = condition.dataSync();
     const aValues = a.dataSync();
     const bValues = b.dataSync();
@@ -584,17 +579,16 @@ export class MathBackendCPU implements MathBackend {
     return result;
   }
 
-  topKValues<D extends DataType, T extends NDArray<D>>(x: T, k: number):
-      Array1D<D> {
-    return this.topK(x, k).values as Array1D<D>;
+  topKValues<T extends NDArray>(x: T, k: number): Array1D {
+    return this.topK(x, k).values as Array1D;
   }
 
-  topKIndices(x: NDArray, k: number): Array1D<'int32'> {
+  topKIndices(x: NDArray, k: number): Array1D {
     return this.topK(x, k).indices;
   }
 
-  private topK<D extends DataType, T extends NDArray<D>>(x: T, k: number):
-      {values: Array1D<D>, indices: Array1D<'int32'>} {
+  private topK<T extends NDArray>(x: T, k: number):
+      {values: Array1D, indices: Array1D} {
     const values = x.dataSync();
     const valuesAndIndices: Array<{value: number, index: number}> = [];
     for (let i = 0; i < values.length; i++) {
@@ -616,7 +610,7 @@ export class MathBackendCPU implements MathBackend {
     };
   }
 
-  min<D extends DataType>(x: NDArray<D>, axes: number[]): NDArray<D> {
+  min(x: NDArray, axes: number[]): NDArray {
     axis_util.assertAxesAreInnerMostDims('min', axes, x.rank);
     const [outShape, reduceShape] =
         axis_util.computeOutAndReduceShapes(x.shape, axes);
@@ -643,12 +637,12 @@ export class MathBackendCPU implements MathBackend {
     return result;
   }
 
-  minimum<D extends DataType>(a: NDArray<D>, b: NDArray<D>): NDArray<D> {
+  minimum(a: NDArray, b: NDArray): NDArray {
     return this.broadcastedBinaryOp(
         a, b, a.dtype, (aVal, bVal) => Math.min(aVal, bVal));
   }
 
-  max<D extends DataType>(x: NDArray<D>, axes: number[]): NDArray<D> {
+  max(x: NDArray, axes: number[]): NDArray {
     axis_util.assertAxesAreInnerMostDims('max', axes, x.rank);
     const [outShape, reduceShape] =
         axis_util.computeOutAndReduceShapes(x.shape, axes);
@@ -675,7 +669,7 @@ export class MathBackendCPU implements MathBackend {
     return result;
   }
 
-  maximum<D extends DataType>(a: NDArray<D>, b: NDArray<D>): NDArray<D> {
+  maximum(a: NDArray, b: NDArray): NDArray {
     return this.broadcastedBinaryOp(
         a, b, a.dtype, (aVal, bVal) => Math.max(aVal, bVal));
   }
@@ -863,14 +857,13 @@ export class MathBackendCPU implements MathBackend {
     return NDArray.make(x.shape, {values: resultValues}) as T;
   }
 
-  int<R extends Rank>(x: NDArray<DataType, R>): NDArray<'int32', R> {
+  int<R extends Rank>(x: NDArray<R>): NDArray<R> {
     const resultValues = new Int32Array(x.size);
     const values = x.dataSync();
     for (let i = 0; i < values.length; ++i) {
       resultValues[i] = values[i];
     }
-    return NDArray.make(x.shape, {values: resultValues}, 'int32') as
-        NDArray<'int32', R>;
+    return NDArray.make(x.shape, {values: resultValues}, 'int32') as NDArray<R>;
   }
 
   sigmoid<T extends NDArray>(x: T): T {
@@ -983,7 +976,7 @@ export class MathBackendCPU implements MathBackend {
     const filterWidth = convInfo.filterWidth;
     const padLeft = convInfo.padInfo.left;
     const padTop = convInfo.padInfo.top;
-    const y = NDArray.zeros<'float32', '4'>(convInfo.outShape);
+    const y = NDArray.zeros<'4'>(convInfo.outShape);
 
     for (let b = 0; b < convInfo.batchSize; ++b) {
       for (let d2 = 0; d2 < convInfo.outChannels; ++d2) {
@@ -1023,7 +1016,7 @@ export class MathBackendCPU implements MathBackend {
     const leftPad = filterWidth - 1 - convInfo.padInfo.left;
     const strideHeight = convInfo.strideHeight;
     const strideWidth = convInfo.strideWidth;
-    const dx = NDArray.zeros<'float32', '4'>(convInfo.inShape);
+    const dx = NDArray.zeros<'4'>(convInfo.inShape);
     for (let b = 0; b < convInfo.batchSize; ++b) {
       for (let d1 = 0; d1 < convInfo.inChannels; ++d1) {
         for (let xR = 0; xR < convInfo.inHeight; ++xR) {
@@ -1066,7 +1059,7 @@ export class MathBackendCPU implements MathBackend {
     const strideWidth = convInfo.strideWidth;
     const filterHeight = convInfo.filterHeight;
     const filterWidth = convInfo.filterWidth;
-    const dW = NDArray.zeros<'float32', '4'>(convInfo.filterShape);
+    const dW = NDArray.zeros<'4'>(convInfo.filterShape);
 
     const leftPad = convInfo.padInfo.left;
     const topPad = convInfo.padInfo.top;
@@ -1125,7 +1118,7 @@ export class MathBackendCPU implements MathBackend {
     const padLeft = convInfo.padInfo.left;
     const padTop = convInfo.padInfo.top;
     const chMul = convInfo.outChannels / convInfo.inChannels;
-    const y = NDArray.zeros<'float32', '4'>(convInfo.outShape);
+    const y = NDArray.zeros<'4'>(convInfo.outShape);
 
     for (let b = 0; b < convInfo.batchSize; ++b) {
       for (let d1 = 0; d1 < convInfo.inChannels; ++d1) {
@@ -1157,7 +1150,7 @@ export class MathBackendCPU implements MathBackend {
     return y;
   }
 
-  tile<D extends DataType, T extends NDArray<D>>(x: T, reps: number[]): T {
+  tile<T extends NDArray>(x: T, reps: number[]): T {
     const newShape: number[] = new Array(x.rank);
     for (let i = 0; i < newShape.length; i++) {
       newShape[i] = x.shape[i] * reps[i];
@@ -1241,7 +1234,7 @@ export class MathBackendCPU implements MathBackend {
     return result;
   }
 
-  transpose<D extends DataType, T extends NDArray<D>>(x: T, perm: number[]): T {
+  transpose<T extends NDArray>(x: T, perm: number[]): T {
     const newShape: number[] = new Array(x.rank);
     for (let i = 0; i < newShape.length; i++) {
       newShape[i] = x.shape[perm[i]];
@@ -1264,8 +1257,7 @@ export class MathBackendCPU implements MathBackend {
     return result;
   }
 
-  gather<D extends DataType, T extends NDArray<D>>(
-      x: T, indices: Array1D<'int32'>, axis: number): T {
+  gather<T extends NDArray>(x: T, indices: Array1D, axis: number): T {
     const newShape: number[] = x.shape.slice();
     const indicesValues = indices.dataSync();
     newShape[axis] = indicesValues.length;
@@ -1289,7 +1281,7 @@ export class MathBackendCPU implements MathBackend {
     const strideWidth = convInfo.strideWidth;
     const filterHeight = convInfo.filterHeight;
     const filterWidth = convInfo.filterWidth;
-    const y = NDArray.zeros<'float32', '4'>(convInfo.outShape);
+    const y = NDArray.zeros<'4'>(convInfo.outShape);
     const padTop = convInfo.padInfo.top;
     const padLeft = convInfo.padInfo.left;
     for (let b = 0; b < convInfo.batchSize; ++b) {
@@ -1339,7 +1331,7 @@ export class MathBackendCPU implements MathBackend {
   }
 
   maxPoolPositions(x: Array4D, convInfo: Conv2DInfo) {
-    const maxPositions = NDArray.zeros<'float32', '4'>(convInfo.outShape);
+    const maxPositions = NDArray.zeros<'4'>(convInfo.outShape);
     const strideHeight = convInfo.strideHeight;
     const strideWidth = convInfo.strideWidth;
     const filterHeight = convInfo.filterHeight;
@@ -1386,7 +1378,7 @@ export class MathBackendCPU implements MathBackend {
     const filterWidth = convInfo.filterWidth;
     const padLeft = filterWidth - 1 - convInfo.padInfo.left;
     const padTop = filterHeight - 1 - convInfo.padInfo.top;
-    const dx = NDArray.zeros<'float32', '4'>(x.shape);
+    const dx = NDArray.zeros<'4'>(x.shape);
 
     for (let b = 0; b < convInfo.batchSize; ++b) {
       for (let d = 0; d < convInfo.inChannels; ++d) {
@@ -1436,7 +1428,7 @@ export class MathBackendCPU implements MathBackend {
     const filterWidth = convInfo.filterWidth;
     const padLeft = filterWidth - 1 - convInfo.padInfo.left;
     const padTop = filterHeight - 1 - convInfo.padInfo.top;
-    const dx = NDArray.zeros<'float32', '4'>(x.shape);
+    const dx = NDArray.zeros<'4'>(x.shape);
 
     const avgMultiplier = 1 / (filterHeight * filterWidth);
 
@@ -1484,8 +1476,8 @@ export class MathBackendCPU implements MathBackend {
   resizeBilinear3D(
       x: Array3D, newShape2D: [number, number],
       alignCorners: boolean): Array3D {
-    const output = NDArray.zeros<'float32', '3'>(
-        [newShape2D[0], newShape2D[1], x.shape[2]]);
+    const output =
+        NDArray.zeros<'3'>([newShape2D[0], newShape2D[1], x.shape[2]]);
 
     const effectiveInputSize =
         alignCorners ? [x.shape[0] - 1, x.shape[1] - 1, x.shape[2]] : x.shape;
@@ -1596,7 +1588,7 @@ export class MathBackendCPU implements MathBackend {
   localResponseNormalization4D(
       x: Array4D, radius: number, bias: number, alpha: number, beta: number,
       normRegion: 'acrossChannels'|'withinChannel'): Array4D {
-    const output = NDArray.zeros<'float32', '4'>(x.shape);
+    const output = NDArray.zeros<'4'>(x.shape);
     const rad = radius;
     const maxW = output.shape[1] - 1;
     const maxH = output.shape[2] - 1;
@@ -1644,7 +1636,7 @@ export class MathBackendCPU implements MathBackend {
   }
 
   multinomial(probabilities: Array2D, numSamples: number, seed: number):
-      Array2D<'int32'> {
+      Array2D {
     const batchSize = probabilities.shape[0];
     const numEvents = probabilities.shape[1];
     const res = NDArray.zeros<'int32', '2'>([batchSize, numSamples], 'int32');
@@ -1691,9 +1683,9 @@ export class MathBackendCPU implements MathBackend {
     return Array2D.new([indices.size, depth], res);
   }
 
-  private broadcastedBinaryOp<D extends DataType>(
+  private broadcastedBinaryOp(
       a: NDArray, b: NDArray, dtype: D,
-      op: (a: number, b: number) => number): NDArray<D> {
+      op: (a: number, b: number) => number): NDArray {
     const newShape =
         broadcast_util.assertAndGetBroadcastShape(a.shape, b.shape);
     const result = NDArray.zeros(newShape, dtype);

--- a/src/math/backends/backend_cpu.ts
+++ b/src/math/backends/backend_cpu.ts
@@ -25,9 +25,9 @@ import {Conv2DInfo} from '../conv_util';
 import {NDArrayMath} from '../math';
 // tslint:disable-next-line:max-line-length
 import {Array1D, Array2D, Array3D, Array4D, NDArray, Scalar} from '../ndarray';
+import * as ops from '../ops';
 import * as types from '../types';
 import {DataType, DataTypeMap, Rank, TypedArray} from '../types';
-
 import * as axis_util from './../axis_util';
 import {MathBackend} from './backend';
 import {MatrixOrientation} from './types/matmul';
@@ -137,7 +137,7 @@ export class MathBackendCPU implements MathBackend {
 
   slice2D(x: Array2D, begin: [number, number], size: [number, number]):
       Array2D {
-    const result = NDArray.zeros<'2'>(size, x.dtype);
+    const result = ops.zeros<'2'>(size, x.dtype);
     const [startI, startJ] = begin;
 
     for (let i = 0; i < size[0]; ++i) {
@@ -152,7 +152,7 @@ export class MathBackendCPU implements MathBackend {
   slice3D(x: Array3D, begin: [number, number, number], size: [
     number, number, number
   ]): Array3D {
-    const result = NDArray.zeros<'3'>(size, x.dtype);
+    const result = ops.zeros<'3'>(size, x.dtype);
     const [startI, startJ, startK] = begin;
 
     for (let i = 0; i < size[0]; ++i) {
@@ -168,7 +168,7 @@ export class MathBackendCPU implements MathBackend {
   slice4D(x: Array4D, begin: [number, number, number, number], size: [
     number, number, number, number
   ]): Array4D {
-    const result = NDArray.zeros<'4'>(size, x.dtype);
+    const result = ops.zeros<'4'>(size, x.dtype);
     const [startI, startJ, startK, startL] = begin;
 
     for (let i = 0; i < size[0]; ++i) {
@@ -185,7 +185,7 @@ export class MathBackendCPU implements MathBackend {
   }
 
   reverse4D(x: Array4D, axis: number[]): Array4D {
-    const result = NDArray.like(x);
+    const result = ops.clone(x);
 
     // Reverse axis only if the axis has dim != 1
     const revAxis = (i: number) => axis.indexOf(i) !== -1 && x.shape[i] !== 1;
@@ -211,7 +211,7 @@ export class MathBackendCPU implements MathBackend {
 
   concat1D(a: Array1D, b: Array1D): Array1D {
     const outShape = concat_util.computeOutShape(a.shape, b.shape, 0);
-    const result = NDArray.zeros<'1'>(outShape as [number]);
+    const result = ops.zeros<'1'>(outShape as [number]);
 
     // Use built-in TypedArray.set() method for speed.
     const aVals = a.dataSync();
@@ -225,7 +225,7 @@ export class MathBackendCPU implements MathBackend {
 
   concat2D(a: Array2D, b: Array2D, axis: number): Array2D {
     const outShape = concat_util.computeOutShape(a.shape, b.shape, axis);
-    const result = NDArray.zeros<'2'>(outShape as [number, number]);
+    const result = ops.zeros<'2'>(outShape as [number, number]);
 
     if (axis === 0) {
       // Use built-in TypedArray.set() method for speed.
@@ -258,7 +258,7 @@ export class MathBackendCPU implements MathBackend {
   concat3D(a: Array3D, b: Array3D, axis: number): Array3D {
     const outShape = concat_util.computeOutShape(a.shape, b.shape, axis);
 
-    const result = NDArray.zeros<'3'>(outShape as [number, number, number]);
+    const result = ops.zeros<'3'>(outShape as [number, number, number]);
 
     if (axis === 0) {
       // Use built-in TypedArray.set() method for speed.
@@ -294,8 +294,7 @@ export class MathBackendCPU implements MathBackend {
 
   concat4D(a: Array4D, b: Array4D, axis: number): Array4D {
     const outShape = concat_util.computeOutShape(a.shape, b.shape, axis);
-    const result =
-        NDArray.zeros<'4'>(outShape as [number, number, number, number]);
+    const result = ops.zeros<'4'>(outShape as [number, number, number, number]);
 
     if (axis === 0) {
       // Use built-in TypedArray.set() method for speed.
@@ -406,7 +405,7 @@ export class MathBackendCPU implements MathBackend {
     const [outShape, reduceShape] =
         axis_util.computeOutAndReduceShapes(x.shape, axes);
     const resultDtype = types.upcastType(x.dtype, 'int32');
-    const result = NDArray.zeros(outShape, resultDtype);
+    const result = ops.zeros(outShape, resultDtype);
     const reduceSize = util.sizeFromShape(reduceShape);
     const vals = result.dataSync();
 
@@ -426,7 +425,7 @@ export class MathBackendCPU implements MathBackend {
     axis_util.assertAxesAreInnerMostDims('argMin', axes, x.rank);
     const [outShape, reduceShape] =
         axis_util.computeOutAndReduceShapes(x.shape, axes);
-    const result = NDArray.zeros(outShape, 'int32');
+    const result = ops.zeros(outShape, 'int32');
     const reduceSize = util.sizeFromShape(reduceShape);
     const vals = result.dataSync();
 
@@ -455,7 +454,7 @@ export class MathBackendCPU implements MathBackend {
     axis_util.assertAxesAreInnerMostDims('argMax', axes, x.rank);
     const [outShape, reduceShape] =
         axis_util.computeOutAndReduceShapes(x.shape, axes);
-    const result = NDArray.zeros(outShape, 'int32');
+    const result = ops.zeros(outShape, 'int32');
     const reduceSize = util.sizeFromShape(reduceShape);
     const vals = result.dataSync();
 
@@ -564,7 +563,7 @@ export class MathBackendCPU implements MathBackend {
     const values = condition.dataSync();
     const aValues = a.dataSync();
     const bValues = b.dataSync();
-    const result = NDArray.zeros(a.shape, dtype);
+    const result = ops.zeros(a.shape, dtype);
     const newValues = result.dataSync();
     let index = 0;
     const offset = condition.rank > 1 || a.rank === 1 ? 1 : a.shape[1];
@@ -615,7 +614,7 @@ export class MathBackendCPU implements MathBackend {
     axis_util.assertAxesAreInnerMostDims('min', axes, x.rank);
     const [outShape, reduceShape] =
         axis_util.computeOutAndReduceShapes(x.shape, axes);
-    const result = NDArray.zeros(outShape, x.dtype);
+    const result = ops.zeros(outShape, x.dtype);
     const reduceSize = util.sizeFromShape(reduceShape);
     const vals = result.dataSync();
 
@@ -647,7 +646,7 @@ export class MathBackendCPU implements MathBackend {
     axis_util.assertAxesAreInnerMostDims('max', axes, x.rank);
     const [outShape, reduceShape] =
         axis_util.computeOutAndReduceShapes(x.shape, axes);
-    const result = NDArray.zeros(outShape, x.dtype);
+    const result = ops.zeros(outShape, x.dtype);
     const reduceSize = util.sizeFromShape(reduceShape);
     const vals = result.dataSync();
 
@@ -733,7 +732,7 @@ export class MathBackendCPU implements MathBackend {
   }
 
   relu<T extends NDArray>(x: T): T {
-    const res = NDArray.zeros(x.shape, x.dtype);
+    const res = ops.zeros(x.shape, x.dtype);
     const resVals = res.dataSync();
     const inVals = x.dataSync();
     for (let i = 0; i < inVals.length; ++i) {
@@ -977,7 +976,7 @@ export class MathBackendCPU implements MathBackend {
     const filterWidth = convInfo.filterWidth;
     const padLeft = convInfo.padInfo.left;
     const padTop = convInfo.padInfo.top;
-    const y = NDArray.zeros<'4'>(convInfo.outShape);
+    const y = ops.zeros<'4'>(convInfo.outShape);
 
     for (let b = 0; b < convInfo.batchSize; ++b) {
       for (let d2 = 0; d2 < convInfo.outChannels; ++d2) {
@@ -1017,7 +1016,7 @@ export class MathBackendCPU implements MathBackend {
     const leftPad = filterWidth - 1 - convInfo.padInfo.left;
     const strideHeight = convInfo.strideHeight;
     const strideWidth = convInfo.strideWidth;
-    const dx = NDArray.zeros<'4'>(convInfo.inShape);
+    const dx = ops.zeros<'4'>(convInfo.inShape);
     for (let b = 0; b < convInfo.batchSize; ++b) {
       for (let d1 = 0; d1 < convInfo.inChannels; ++d1) {
         for (let xR = 0; xR < convInfo.inHeight; ++xR) {
@@ -1060,7 +1059,7 @@ export class MathBackendCPU implements MathBackend {
     const strideWidth = convInfo.strideWidth;
     const filterHeight = convInfo.filterHeight;
     const filterWidth = convInfo.filterWidth;
-    const dW = NDArray.zeros<'4'>(convInfo.filterShape);
+    const dW = ops.zeros<'4'>(convInfo.filterShape);
 
     const leftPad = convInfo.padInfo.left;
     const topPad = convInfo.padInfo.top;
@@ -1119,7 +1118,7 @@ export class MathBackendCPU implements MathBackend {
     const padLeft = convInfo.padInfo.left;
     const padTop = convInfo.padInfo.top;
     const chMul = convInfo.outChannels / convInfo.inChannels;
-    const y = NDArray.zeros<'4'>(convInfo.outShape);
+    const y = ops.zeros<'4'>(convInfo.outShape);
 
     for (let b = 0; b < convInfo.batchSize; ++b) {
       for (let d1 = 0; d1 < convInfo.inChannels; ++d1) {
@@ -1156,7 +1155,7 @@ export class MathBackendCPU implements MathBackend {
     for (let i = 0; i < newShape.length; i++) {
       newShape[i] = x.shape[i] * reps[i];
     }
-    const result = NDArray.zeros(newShape, x.dtype);
+    const result = ops.zeros(newShape, x.dtype);
     const newValues = result.dataSync();
     const values = x.dataSync();
     for (let i = 0; i < result.size; ++i) {
@@ -1180,8 +1179,8 @@ export class MathBackendCPU implements MathBackend {
     const rightPadding = paddings[1];
 
     const values = x.dataSync();
-    const result = NDArray.zeros<'1'>(
-        [leftPadding + values.length + rightPadding], x.dtype);
+    const result =
+        ops.zeros<'1'>([leftPadding + values.length + rightPadding], x.dtype);
     const newValues = result.dataSync();
 
     let z = 0;
@@ -1208,7 +1207,7 @@ export class MathBackendCPU implements MathBackend {
       leftPadding + x.shape[1] + rightPadding
     ];
 
-    const result = NDArray.zeros<'2'>(newShape, x.dtype);
+    const result = ops.zeros<'2'>(newShape, x.dtype);
     const newValues = result.dataSync();
 
     const values = x.dataSync();
@@ -1262,7 +1261,7 @@ export class MathBackendCPU implements MathBackend {
     const newShape: number[] = x.shape.slice();
     const indicesValues = indices.dataSync();
     newShape[axis] = indicesValues.length;
-    const result = NDArray.zeros(newShape, x.dtype) as T;
+    const result = ops.zeros(newShape, x.dtype) as T;
     const values = x.dataSync();
     const resultValues = result.dataSync();
     for (let i = 0; i < result.size; ++i) {
@@ -1282,7 +1281,7 @@ export class MathBackendCPU implements MathBackend {
     const strideWidth = convInfo.strideWidth;
     const filterHeight = convInfo.filterHeight;
     const filterWidth = convInfo.filterWidth;
-    const y = NDArray.zeros<'4'>(convInfo.outShape);
+    const y = ops.zeros<'4'>(convInfo.outShape);
     const padTop = convInfo.padInfo.top;
     const padLeft = convInfo.padInfo.left;
     for (let b = 0; b < convInfo.batchSize; ++b) {
@@ -1332,7 +1331,7 @@ export class MathBackendCPU implements MathBackend {
   }
 
   maxPoolPositions(x: Array4D, convInfo: Conv2DInfo) {
-    const maxPositions = NDArray.zeros<'4'>(convInfo.outShape);
+    const maxPositions = ops.zeros<'4'>(convInfo.outShape);
     const strideHeight = convInfo.strideHeight;
     const strideWidth = convInfo.strideWidth;
     const filterHeight = convInfo.filterHeight;
@@ -1379,7 +1378,7 @@ export class MathBackendCPU implements MathBackend {
     const filterWidth = convInfo.filterWidth;
     const padLeft = filterWidth - 1 - convInfo.padInfo.left;
     const padTop = filterHeight - 1 - convInfo.padInfo.top;
-    const dx = NDArray.zeros<'4'>(x.shape);
+    const dx = ops.zeros<'4'>(x.shape);
 
     for (let b = 0; b < convInfo.batchSize; ++b) {
       for (let d = 0; d < convInfo.inChannels; ++d) {
@@ -1429,7 +1428,7 @@ export class MathBackendCPU implements MathBackend {
     const filterWidth = convInfo.filterWidth;
     const padLeft = filterWidth - 1 - convInfo.padInfo.left;
     const padTop = filterHeight - 1 - convInfo.padInfo.top;
-    const dx = NDArray.zeros<'4'>(x.shape);
+    const dx = ops.zeros<'4'>(x.shape);
 
     const avgMultiplier = 1 / (filterHeight * filterWidth);
 
@@ -1477,8 +1476,7 @@ export class MathBackendCPU implements MathBackend {
   resizeBilinear3D(
       x: Array3D, newShape2D: [number, number],
       alignCorners: boolean): Array3D {
-    const output =
-        NDArray.zeros<'3'>([newShape2D[0], newShape2D[1], x.shape[2]]);
+    const output = ops.zeros<'3'>([newShape2D[0], newShape2D[1], x.shape[2]]);
 
     const effectiveInputSize =
         alignCorners ? [x.shape[0] - 1, x.shape[1] - 1, x.shape[2]] : x.shape;
@@ -1589,7 +1587,7 @@ export class MathBackendCPU implements MathBackend {
   localResponseNormalization4D(
       x: Array4D, radius: number, bias: number, alpha: number, beta: number,
       normRegion: 'acrossChannels'|'withinChannel'): Array4D {
-    const output = NDArray.zeros<'4'>(x.shape);
+    const output = ops.zeros<'4'>(x.shape);
     const rad = radius;
     const maxW = output.shape[1] - 1;
     const maxH = output.shape[2] - 1;
@@ -1640,7 +1638,7 @@ export class MathBackendCPU implements MathBackend {
       Array2D {
     const batchSize = probabilities.shape[0];
     const numEvents = probabilities.shape[1];
-    const res = NDArray.zeros<'2'>([batchSize, numSamples], 'int32');
+    const res = ops.zeros<'2'>([batchSize, numSamples], 'int32');
     const resVals = res.dataSync();
     const probVals = probabilities.dataSync();
 
@@ -1689,7 +1687,7 @@ export class MathBackendCPU implements MathBackend {
       op: (a: number, b: number) => number): NDArray {
     const newShape =
         broadcast_util.assertAndGetBroadcastShape(a.shape, b.shape);
-    const result = NDArray.zeros(newShape, dtype);
+    const result = ops.zeros(newShape, dtype);
     const newValues = result.dataSync();
     const aValues = a.dataSync();
     const bValues = b.dataSync();

--- a/src/math/backends/backend_cpu.ts
+++ b/src/math/backends/backend_cpu.ts
@@ -137,7 +137,7 @@ export class MathBackendCPU implements MathBackend {
 
   slice2D(x: Array2D, begin: [number, number], size: [number, number]):
       Array2D {
-    const result = ops.zeros<'2'>(size, x.dtype);
+    const result = ops.zeros<Rank.R2>(size, x.dtype);
     const [startI, startJ] = begin;
 
     for (let i = 0; i < size[0]; ++i) {
@@ -152,7 +152,7 @@ export class MathBackendCPU implements MathBackend {
   slice3D(x: Array3D, begin: [number, number, number], size: [
     number, number, number
   ]): Array3D {
-    const result = ops.zeros<'3'>(size, x.dtype);
+    const result = ops.zeros<Rank.R3>(size, x.dtype);
     const [startI, startJ, startK] = begin;
 
     for (let i = 0; i < size[0]; ++i) {
@@ -168,7 +168,7 @@ export class MathBackendCPU implements MathBackend {
   slice4D(x: Array4D, begin: [number, number, number, number], size: [
     number, number, number, number
   ]): Array4D {
-    const result = ops.zeros<'4'>(size, x.dtype);
+    const result = ops.zeros<Rank.R4>(size, x.dtype);
     const [startI, startJ, startK, startL] = begin;
 
     for (let i = 0; i < size[0]; ++i) {
@@ -211,7 +211,7 @@ export class MathBackendCPU implements MathBackend {
 
   concat1D(a: Array1D, b: Array1D): Array1D {
     const outShape = concat_util.computeOutShape(a.shape, b.shape, 0);
-    const result = ops.zeros<'1'>(outShape as [number]);
+    const result = ops.zeros<Rank.R1>(outShape as [number]);
 
     // Use built-in TypedArray.set() method for speed.
     const aVals = a.dataSync();
@@ -225,7 +225,7 @@ export class MathBackendCPU implements MathBackend {
 
   concat2D(a: Array2D, b: Array2D, axis: number): Array2D {
     const outShape = concat_util.computeOutShape(a.shape, b.shape, axis);
-    const result = ops.zeros<'2'>(outShape as [number, number]);
+    const result = ops.zeros<Rank.R2>(outShape as [number, number]);
 
     if (axis === 0) {
       // Use built-in TypedArray.set() method for speed.
@@ -258,7 +258,7 @@ export class MathBackendCPU implements MathBackend {
   concat3D(a: Array3D, b: Array3D, axis: number): Array3D {
     const outShape = concat_util.computeOutShape(a.shape, b.shape, axis);
 
-    const result = ops.zeros<'3'>(outShape as [number, number, number]);
+    const result = ops.zeros<Rank.R3>(outShape as [number, number, number]);
 
     if (axis === 0) {
       // Use built-in TypedArray.set() method for speed.
@@ -294,7 +294,8 @@ export class MathBackendCPU implements MathBackend {
 
   concat4D(a: Array4D, b: Array4D, axis: number): Array4D {
     const outShape = concat_util.computeOutShape(a.shape, b.shape, axis);
-    const result = ops.zeros<'4'>(outShape as [number, number, number, number]);
+    const result =
+        ops.zeros<Rank.R4>(outShape as [number, number, number, number]);
 
     if (axis === 0) {
       // Use built-in TypedArray.set() method for speed.
@@ -976,7 +977,7 @@ export class MathBackendCPU implements MathBackend {
     const filterWidth = convInfo.filterWidth;
     const padLeft = convInfo.padInfo.left;
     const padTop = convInfo.padInfo.top;
-    const y = ops.zeros<'4'>(convInfo.outShape);
+    const y = ops.zeros<Rank.R4>(convInfo.outShape);
 
     for (let b = 0; b < convInfo.batchSize; ++b) {
       for (let d2 = 0; d2 < convInfo.outChannels; ++d2) {
@@ -1016,7 +1017,7 @@ export class MathBackendCPU implements MathBackend {
     const leftPad = filterWidth - 1 - convInfo.padInfo.left;
     const strideHeight = convInfo.strideHeight;
     const strideWidth = convInfo.strideWidth;
-    const dx = ops.zeros<'4'>(convInfo.inShape);
+    const dx = ops.zeros<Rank.R4>(convInfo.inShape);
     for (let b = 0; b < convInfo.batchSize; ++b) {
       for (let d1 = 0; d1 < convInfo.inChannels; ++d1) {
         for (let xR = 0; xR < convInfo.inHeight; ++xR) {
@@ -1059,7 +1060,7 @@ export class MathBackendCPU implements MathBackend {
     const strideWidth = convInfo.strideWidth;
     const filterHeight = convInfo.filterHeight;
     const filterWidth = convInfo.filterWidth;
-    const dW = ops.zeros<'4'>(convInfo.filterShape);
+    const dW = ops.zeros<Rank.R4>(convInfo.filterShape);
 
     const leftPad = convInfo.padInfo.left;
     const topPad = convInfo.padInfo.top;
@@ -1118,7 +1119,7 @@ export class MathBackendCPU implements MathBackend {
     const padLeft = convInfo.padInfo.left;
     const padTop = convInfo.padInfo.top;
     const chMul = convInfo.outChannels / convInfo.inChannels;
-    const y = ops.zeros<'4'>(convInfo.outShape);
+    const y = ops.zeros<Rank.R4>(convInfo.outShape);
 
     for (let b = 0; b < convInfo.batchSize; ++b) {
       for (let d1 = 0; d1 < convInfo.inChannels; ++d1) {
@@ -1179,8 +1180,8 @@ export class MathBackendCPU implements MathBackend {
     const rightPadding = paddings[1];
 
     const values = x.dataSync();
-    const result =
-        ops.zeros<'1'>([leftPadding + values.length + rightPadding], x.dtype);
+    const result = ops.zeros<Rank.R1>(
+        [leftPadding + values.length + rightPadding], x.dtype);
     const newValues = result.dataSync();
 
     let z = 0;
@@ -1207,7 +1208,7 @@ export class MathBackendCPU implements MathBackend {
       leftPadding + x.shape[1] + rightPadding
     ];
 
-    const result = ops.zeros<'2'>(newShape, x.dtype);
+    const result = ops.zeros<Rank.R2>(newShape, x.dtype);
     const newValues = result.dataSync();
 
     const values = x.dataSync();
@@ -1281,7 +1282,7 @@ export class MathBackendCPU implements MathBackend {
     const strideWidth = convInfo.strideWidth;
     const filterHeight = convInfo.filterHeight;
     const filterWidth = convInfo.filterWidth;
-    const y = ops.zeros<'4'>(convInfo.outShape);
+    const y = ops.zeros<Rank.R4>(convInfo.outShape);
     const padTop = convInfo.padInfo.top;
     const padLeft = convInfo.padInfo.left;
     for (let b = 0; b < convInfo.batchSize; ++b) {
@@ -1331,7 +1332,7 @@ export class MathBackendCPU implements MathBackend {
   }
 
   maxPoolPositions(x: Array4D, convInfo: Conv2DInfo) {
-    const maxPositions = ops.zeros<'4'>(convInfo.outShape);
+    const maxPositions = ops.zeros<Rank.R4>(convInfo.outShape);
     const strideHeight = convInfo.strideHeight;
     const strideWidth = convInfo.strideWidth;
     const filterHeight = convInfo.filterHeight;
@@ -1378,7 +1379,7 @@ export class MathBackendCPU implements MathBackend {
     const filterWidth = convInfo.filterWidth;
     const padLeft = filterWidth - 1 - convInfo.padInfo.left;
     const padTop = filterHeight - 1 - convInfo.padInfo.top;
-    const dx = ops.zeros<'4'>(x.shape);
+    const dx = ops.zeros<Rank.R4>(x.shape);
 
     for (let b = 0; b < convInfo.batchSize; ++b) {
       for (let d = 0; d < convInfo.inChannels; ++d) {
@@ -1428,7 +1429,7 @@ export class MathBackendCPU implements MathBackend {
     const filterWidth = convInfo.filterWidth;
     const padLeft = filterWidth - 1 - convInfo.padInfo.left;
     const padTop = filterHeight - 1 - convInfo.padInfo.top;
-    const dx = ops.zeros<'4'>(x.shape);
+    const dx = ops.zeros<Rank.R4>(x.shape);
 
     const avgMultiplier = 1 / (filterHeight * filterWidth);
 
@@ -1476,7 +1477,8 @@ export class MathBackendCPU implements MathBackend {
   resizeBilinear3D(
       x: Array3D, newShape2D: [number, number],
       alignCorners: boolean): Array3D {
-    const output = ops.zeros<'3'>([newShape2D[0], newShape2D[1], x.shape[2]]);
+    const output =
+        ops.zeros<Rank.R3>([newShape2D[0], newShape2D[1], x.shape[2]]);
 
     const effectiveInputSize =
         alignCorners ? [x.shape[0] - 1, x.shape[1] - 1, x.shape[2]] : x.shape;
@@ -1587,7 +1589,7 @@ export class MathBackendCPU implements MathBackend {
   localResponseNormalization4D(
       x: Array4D, radius: number, bias: number, alpha: number, beta: number,
       normRegion: 'acrossChannels'|'withinChannel'): Array4D {
-    const output = ops.zeros<'4'>(x.shape);
+    const output = ops.zeros<Rank.R4>(x.shape);
     const rad = radius;
     const maxW = output.shape[1] - 1;
     const maxH = output.shape[2] - 1;
@@ -1638,7 +1640,7 @@ export class MathBackendCPU implements MathBackend {
       Array2D {
     const batchSize = probabilities.shape[0];
     const numEvents = probabilities.shape[1];
-    const res = ops.zeros<'2'>([batchSize, numSamples], 'int32');
+    const res = ops.zeros<Rank.R2>([batchSize, numSamples], 'int32');
     const resVals = res.dataSync();
     const probVals = probabilities.dataSync();
 

--- a/src/math/backends/backend_cpu.ts
+++ b/src/math/backends/backend_cpu.ts
@@ -138,7 +138,7 @@ export class MathBackendCPU implements MathBackend {
   slice2D<D extends DataType>(x: Array2D<D>, begin: [number, number], size: [
     number, number
   ]): Array2D<D> {
-    const result = Array2D.zeros(size, x.dtype);
+    const result = NDArray.zeros<D, '2'>(size, x.dtype);
     const [startI, startJ] = begin;
 
     for (let i = 0; i < size[0]; ++i) {
@@ -153,7 +153,7 @@ export class MathBackendCPU implements MathBackend {
   slice3D<D extends DataType>(
       x: Array3D<D>, begin: [number, number, number],
       size: [number, number, number]): Array3D<D> {
-    const result = Array3D.zeros(size, x.dtype);
+    const result = NDArray.zeros<D, '3'>(size, x.dtype);
     const [startI, startJ, startK] = begin;
 
     for (let i = 0; i < size[0]; ++i) {
@@ -169,7 +169,7 @@ export class MathBackendCPU implements MathBackend {
   slice4D<D extends DataType>(
       x: Array4D<D>, begin: [number, number, number, number],
       size: [number, number, number, number]): Array4D<D> {
-    const result = Array4D.zeros(size, x.dtype);
+    const result = NDArray.zeros<D, '4'>(size, x.dtype);
     const [startI, startJ, startK, startL] = begin;
 
     for (let i = 0; i < size[0]; ++i) {
@@ -212,7 +212,7 @@ export class MathBackendCPU implements MathBackend {
 
   concat1D(a: Array1D, b: Array1D): Array1D {
     const outShape = concat_util.computeOutShape(a.shape, b.shape, 0);
-    const result = Array1D.zeros(outShape as [number]);
+    const result = NDArray.zeros<'float32', '1'>(outShape as [number]);
 
     // Use built-in TypedArray.set() method for speed.
     const aVals = a.dataSync();
@@ -226,7 +226,7 @@ export class MathBackendCPU implements MathBackend {
 
   concat2D(a: Array2D, b: Array2D, axis: number): Array2D {
     const outShape = concat_util.computeOutShape(a.shape, b.shape, axis);
-    const result = Array2D.zeros(outShape as [number, number]);
+    const result = NDArray.zeros<'float32', '2'>(outShape as [number, number]);
 
     if (axis === 0) {
       // Use built-in TypedArray.set() method for speed.
@@ -259,7 +259,8 @@ export class MathBackendCPU implements MathBackend {
   concat3D(a: Array3D, b: Array3D, axis: number): Array3D {
     const outShape = concat_util.computeOutShape(a.shape, b.shape, axis);
 
-    const result = Array3D.zeros(outShape as [number, number, number]);
+    const result =
+        NDArray.zeros<'float32', '3'>(outShape as [number, number, number]);
 
     if (axis === 0) {
       // Use built-in TypedArray.set() method for speed.
@@ -295,7 +296,8 @@ export class MathBackendCPU implements MathBackend {
 
   concat4D(a: Array4D, b: Array4D, axis: number): Array4D {
     const outShape = concat_util.computeOutShape(a.shape, b.shape, axis);
-    const result = Array4D.zeros(outShape as [number, number, number, number]);
+    const result = NDArray.zeros<'float32', '4'>(
+        outShape as [number, number, number, number]);
 
     if (axis === 0) {
       // Use built-in TypedArray.set() method for speed.
@@ -981,7 +983,7 @@ export class MathBackendCPU implements MathBackend {
     const filterWidth = convInfo.filterWidth;
     const padLeft = convInfo.padInfo.left;
     const padTop = convInfo.padInfo.top;
-    const y = Array4D.zeros(convInfo.outShape);
+    const y = NDArray.zeros<'float32', '4'>(convInfo.outShape);
 
     for (let b = 0; b < convInfo.batchSize; ++b) {
       for (let d2 = 0; d2 < convInfo.outChannels; ++d2) {
@@ -1021,7 +1023,7 @@ export class MathBackendCPU implements MathBackend {
     const leftPad = filterWidth - 1 - convInfo.padInfo.left;
     const strideHeight = convInfo.strideHeight;
     const strideWidth = convInfo.strideWidth;
-    const dx = Array4D.zeros(convInfo.inShape);
+    const dx = NDArray.zeros<'float32', '4'>(convInfo.inShape);
     for (let b = 0; b < convInfo.batchSize; ++b) {
       for (let d1 = 0; d1 < convInfo.inChannels; ++d1) {
         for (let xR = 0; xR < convInfo.inHeight; ++xR) {
@@ -1064,7 +1066,7 @@ export class MathBackendCPU implements MathBackend {
     const strideWidth = convInfo.strideWidth;
     const filterHeight = convInfo.filterHeight;
     const filterWidth = convInfo.filterWidth;
-    const dW = Array4D.zeros(convInfo.filterShape);
+    const dW = NDArray.zeros<'float32', '4'>(convInfo.filterShape);
 
     const leftPad = convInfo.padInfo.left;
     const topPad = convInfo.padInfo.top;
@@ -1123,7 +1125,7 @@ export class MathBackendCPU implements MathBackend {
     const padLeft = convInfo.padInfo.left;
     const padTop = convInfo.padInfo.top;
     const chMul = convInfo.outChannels / convInfo.inChannels;
-    const y = Array4D.zeros(convInfo.outShape);
+    const y = NDArray.zeros<'float32', '4'>(convInfo.outShape);
 
     for (let b = 0; b < convInfo.batchSize; ++b) {
       for (let d1 = 0; d1 < convInfo.inChannels; ++d1) {
@@ -1184,8 +1186,8 @@ export class MathBackendCPU implements MathBackend {
     const rightPadding = paddings[1];
 
     const values = x.dataSync();
-    const result =
-        Array1D.zeros([leftPadding + values.length + rightPadding], x.dtype);
+    const result = NDArray.zeros<DataType, '1'>(
+        [leftPadding + values.length + rightPadding], x.dtype);
     const newValues = result.dataSync();
 
     let z = 0;
@@ -1212,7 +1214,7 @@ export class MathBackendCPU implements MathBackend {
       leftPadding + x.shape[1] + rightPadding
     ];
 
-    const result = Array2D.zeros(newShape, x.dtype);
+    const result = NDArray.zeros<DataType, '2'>(newShape, x.dtype);
     const newValues = result.dataSync();
 
     const values = x.dataSync();
@@ -1287,7 +1289,7 @@ export class MathBackendCPU implements MathBackend {
     const strideWidth = convInfo.strideWidth;
     const filterHeight = convInfo.filterHeight;
     const filterWidth = convInfo.filterWidth;
-    const y = Array4D.zeros(convInfo.outShape);
+    const y = NDArray.zeros<'float32', '4'>(convInfo.outShape);
     const padTop = convInfo.padInfo.top;
     const padLeft = convInfo.padInfo.left;
     for (let b = 0; b < convInfo.batchSize; ++b) {
@@ -1337,7 +1339,7 @@ export class MathBackendCPU implements MathBackend {
   }
 
   maxPoolPositions(x: Array4D, convInfo: Conv2DInfo) {
-    const maxPositions = Array4D.zeros(convInfo.outShape);
+    const maxPositions = NDArray.zeros<'float32', '4'>(convInfo.outShape);
     const strideHeight = convInfo.strideHeight;
     const strideWidth = convInfo.strideWidth;
     const filterHeight = convInfo.filterHeight;
@@ -1384,7 +1386,7 @@ export class MathBackendCPU implements MathBackend {
     const filterWidth = convInfo.filterWidth;
     const padLeft = filterWidth - 1 - convInfo.padInfo.left;
     const padTop = filterHeight - 1 - convInfo.padInfo.top;
-    const dx = Array4D.zeros(x.shape);
+    const dx = NDArray.zeros<'float32', '4'>(x.shape);
 
     for (let b = 0; b < convInfo.batchSize; ++b) {
       for (let d = 0; d < convInfo.inChannels; ++d) {
@@ -1434,7 +1436,7 @@ export class MathBackendCPU implements MathBackend {
     const filterWidth = convInfo.filterWidth;
     const padLeft = filterWidth - 1 - convInfo.padInfo.left;
     const padTop = filterHeight - 1 - convInfo.padInfo.top;
-    const dx = Array4D.zeros(x.shape);
+    const dx = NDArray.zeros<'float32', '4'>(x.shape);
 
     const avgMultiplier = 1 / (filterHeight * filterWidth);
 
@@ -1482,7 +1484,8 @@ export class MathBackendCPU implements MathBackend {
   resizeBilinear3D(
       x: Array3D, newShape2D: [number, number],
       alignCorners: boolean): Array3D {
-    const output = Array3D.zeros([newShape2D[0], newShape2D[1], x.shape[2]]);
+    const output = NDArray.zeros<'float32', '3'>(
+        [newShape2D[0], newShape2D[1], x.shape[2]]);
 
     const effectiveInputSize =
         alignCorners ? [x.shape[0] - 1, x.shape[1] - 1, x.shape[2]] : x.shape;
@@ -1593,7 +1596,7 @@ export class MathBackendCPU implements MathBackend {
   localResponseNormalization4D(
       x: Array4D, radius: number, bias: number, alpha: number, beta: number,
       normRegion: 'acrossChannels'|'withinChannel'): Array4D {
-    const output = Array4D.zeros(x.shape);
+    const output = NDArray.zeros<'float32', '4'>(x.shape);
     const rad = radius;
     const maxW = output.shape[1] - 1;
     const maxH = output.shape[2] - 1;
@@ -1644,7 +1647,7 @@ export class MathBackendCPU implements MathBackend {
       Array2D<'int32'> {
     const batchSize = probabilities.shape[0];
     const numEvents = probabilities.shape[1];
-    const res = Array2D.zeros([batchSize, numSamples], 'int32');
+    const res = NDArray.zeros<'int32', '2'>([batchSize, numSamples], 'int32');
     const resVals = res.dataSync();
     const probVals = probabilities.dataSync();
 

--- a/src/math/backends/backend_engine.ts
+++ b/src/math/backends/backend_engine.ts
@@ -97,17 +97,15 @@ export class BackendEngine {
     return result;
   }
 
-  customGradient<R extends Rank>(
+  customGradient<R extends Rank, T extends NDArray<R>>(
       f: () => {
-        value: NDArray<R>,
-        gradients:
-            (dy: NDArray<R>, y: NDArray<R>) => TapeNodeInputGradientArrays
+        value: T,
+        gradients: (dy: T, y: T) => TapeNodeInputGradientArrays
       },
-      inputs: NamedArrayMap, name: string): NDArray<R> {
+      inputs: NamedArrayMap, name: string): T {
     this.customGradientDepth++;
 
-    let gradientsFunc: (dy: NDArray<R>, y: NDArray<R>) =>
-        TapeNodeInputGradientArrays;
+    let gradientsFunc: (dy: T, y: T) => TapeNodeInputGradientArrays;
     const gradientsMode = true;
     const result = this.scope('customGradient', () => {
       const {value, gradients} = f();
@@ -130,7 +128,7 @@ export class BackendEngine {
       this.activeTape.push(evaluatedNode);
     }
 
-    return result as NDArray<R>;
+    return result;
   }
 
   gradients(f: () => Scalar, xs: NDArray[], returnValue: boolean): NDArray[]|
@@ -158,8 +156,8 @@ export class BackendEngine {
     }
   }
 
-  vjp<R extends Rank, T extends NDArray<R>>(
-      f: () => T, xs: NDArray[], dy: NDArray<R>): NDArray[] {
+  vjp<R extends Rank, T extends NDArray<R>>(f: () => T, xs: NDArray[], dy: T):
+      NDArray[] {
     const gradientsMode = true;
     return this.scope('vjp', () => {
       const y = f();
@@ -202,8 +200,8 @@ export class BackendEngine {
     return {value: result[0] as Scalar, gradients};
   }
 
-  private gradientWrt<R extends Rank>(
-      y: NDArray<R>, xs: NDArray[], dy?: NDArray<R>): NDArray[] {
+  private gradientWrt<R extends Rank, T extends NDArray<R>>(
+      y: T, xs: NDArray[], dy?: T): NDArray[] {
     // Filter out the nodes that don't connect x => y.
     const filteredTape = tape_util.getFilteredNodesXToY(this.activeTape, xs, y);
     if (filteredTape.length === 0) {

--- a/src/math/backends/backend_engine.ts
+++ b/src/math/backends/backend_engine.ts
@@ -18,7 +18,7 @@
 import * as util from '../../util';
 import {NamedArrayMap} from '../../util';
 import {NDArray, Scalar, Variable} from '../ndarray';
-import {DataType, Rank} from '../types';
+import {Rank} from '../types';
 import {MathBackend} from './backend';
 import * as kernel_registry from './kernel_registry';
 import {KernelConfigRegistry} from './kernel_registry';
@@ -203,7 +203,7 @@ export class BackendEngine {
   }
 
   private gradientWrt<R extends Rank>(
-      y: NDArray<R>, xs: NDArray[], dy?: NDArray<'float32', R>): NDArray[] {
+      y: NDArray<R>, xs: NDArray[], dy?: NDArray<R>): NDArray[] {
     // Filter out the nodes that don't connect x => y.
     const filteredTape = tape_util.getFilteredNodesXToY(this.activeTape, xs, y);
     if (filteredTape.length === 0) {
@@ -241,9 +241,8 @@ export class BackendEngine {
   scope<T extends ScopeResult>(
       name: string,
       scopeFn:
-          (keep: <T1 extends NDArray<D1>>(ndarray: T1) => T1,
-           track: <D2 extends DataType, T2 extends NDArray<D2>>(ndarray: T2) =>
-               T2) => T,
+          (keep: <T1 extends NDArray>(ndarray: T1) => T1,
+           track: <T2 extends NDArray>(ndarray: T2) => T2) => T,
       gradientsMode: boolean): T {
     this.startScope(gradientsMode);
 

--- a/src/math/backends/backend_engine.ts
+++ b/src/math/backends/backend_engine.ts
@@ -15,8 +15,8 @@
  * =============================================================================
  */
 
+import {NamedArrayMap} from '../../math/types';
 import * as util from '../../util';
-import {NamedArrayMap} from '../../util';
 import {NDArray, Scalar, Variable} from '../ndarray';
 import {Rank} from '../types';
 import {MathBackend} from './backend';

--- a/src/math/backends/backend_engine.ts
+++ b/src/math/backends/backend_engine.ts
@@ -18,7 +18,7 @@
 import * as util from '../../util';
 import {NamedArrayMap} from '../../util';
 import {NDArray, Scalar, Variable} from '../ndarray';
-import {DataType, Rank, RankMap} from '../types';
+import {DataType, Rank} from '../types';
 import {MathBackend} from './backend';
 import * as kernel_registry from './kernel_registry';
 import {KernelConfigRegistry} from './kernel_registry';
@@ -105,7 +105,7 @@ export class BackendEngine {
         gradients: (dy: NDArray<'float32', R>, y: NDArray<D, R>) =>
             TapeNodeInputGradientArrays
       },
-      inputs: NamedArrayMap, name: string): RankMap<D>[R] {
+      inputs: NamedArrayMap, name: string): NDArray<D, R> {
     this.customGradientDepth++;
 
     let gradientsFunc: (dy: NDArray<'float32', R>, y: NDArray<D, R>) =>
@@ -132,7 +132,7 @@ export class BackendEngine {
       this.activeTape.push(evaluatedNode);
     }
 
-    return result as RankMap<D>[R];
+    return result as NDArray<D, R>;
   }
 
   gradients(f: () => Scalar, xs: NDArray[], returnValue: boolean): NDArray[]|

--- a/src/math/backends/backend_webgl.ts
+++ b/src/math/backends/backend_webgl.ts
@@ -493,7 +493,7 @@ export class MathBackendWebGL implements MathBackend {
         axis_util.computeOutAndReduceShapes(x.shape, axes);
     const inSize = util.sizeFromShape(reduceShape);
     const a2D = x.as2D(-1, inSize);
-    const outputDType = types.upcastType(x.dtype, 'int32');
+    const outputDType = types.sumOutType(x.dtype);
     return this.reduce(a2D, 'sum', outputDType).reshape(outShape);
   }
 

--- a/src/math/backends/backend_webgl.ts
+++ b/src/math/backends/backend_webgl.ts
@@ -118,7 +118,7 @@ export class MathBackendWebGL implements MathBackend {
     // Pixel data is immediate storage since it already lives on gpu.
     this.gpgpu.uploadPixelDataToTexture(texture, pixels);
   }
-  write<D extends DataType>(dataId: number, values: DataTypeMap[D]): void {
+  write(dataId: number, values: DataTypeMap[D]): void {
     if (values == null) {
       throw new Error('MathBackendWebGL.write(): values can not be null');
     }
@@ -139,7 +139,7 @@ export class MathBackendWebGL implements MathBackend {
     }
   }
 
-  readSync<D extends DataType>(dataId: number): DataTypeMap[D] {
+  readSync(dataId: number): DataTypeMap[D] {
     this.throwIfNoData(dataId);
     const {texture, values, textureType, texShape, numChannels} =
         this.texData[dataId];
@@ -158,7 +158,7 @@ export class MathBackendWebGL implements MathBackend {
     this.cacheOnCPU(dataId, float32Values);
     return this.texData[dataId].values;
   }
-  async read<D extends DataType>(dataId: number): Promise<DataTypeMap[D]> {
+  async read(dataId: number): Promise<DataTypeMap[D]> {
     this.throwIfNoData(dataId);
     const {texture, values, textureType, texShape} = this.texData[dataId];
     if (values != null) {
@@ -235,45 +235,43 @@ export class MathBackendWebGL implements MathBackend {
     return this.gpgpu;
   }
 
-  clone<D extends DataType, T extends NDArray<D>>(x: T): T {
+  clone<T extends NDArray>(x: T): T {
     this.throwIfNoData(x.dataId);
     this.uploadToGPU(x.dataId);
     const {texShape} = this.texData[x.dataId];
     // Pretend the source was in logical shape that matches the texture shape.
     const source = x.as2D(texShape[0], texShape[1]);
     // Do the same for output.
-    const output = this.makeOutputArray<D, Array2D<D>>(texShape, x.dtype);
+    const output = this.makeOutputArray<D, Array2D>(texShape, x.dtype);
     this.copy2D(source, [0, 0], texShape, output, [0, 0], texShape);
     // Get back to the original logical shape.
     return output.reshape(x.shape) as T;
   }
 
-  slice1D<D extends DataType>(x: Array1D<D>, begin: number, size: number):
-      Array1D<D> {
+  slice1D(x: Array1D, begin: number, size: number): Array1D {
     const program = new SliceProgram([size]);
     const customSetup = program.getCustomSetupFunc([begin]);
     return this.compileAndRun(program, [x], null, customSetup);
   }
 
-  slice2D<D extends DataType>(x: Array2D<D>, begin: [number, number], size: [
-    number, number
-  ]): Array2D<D> {
+  slice2D(x: Array2D, begin: [number, number], size: [number, number]):
+      Array2D {
     const program = new SliceProgram(size);
     const customSetup = program.getCustomSetupFunc(begin);
     return this.compileAndRun(program, [x], null, customSetup);
   }
 
-  slice3D<D extends DataType>(
-      x: Array3D<D>, begin: [number, number, number],
-      size: [number, number, number]): Array3D<D> {
+  slice3D(x: Array3D, begin: [number, number, number], size: [
+    number, number, number
+  ]): Array3D {
     const program = new SliceProgram(size);
     const customSetup = program.getCustomSetupFunc(begin);
     return this.compileAndRun(program, [x], null, customSetup);
   }
 
-  slice4D<D extends DataType>(
-      x: Array4D<D>, begin: [number, number, number, number],
-      size: [number, number, number, number]): Array4D<D> {
+  slice4D(x: Array4D, begin: [number, number, number, number], size: [
+    number, number, number, number
+  ]): Array4D {
     const program = new SliceProgram(size);
     const customSetup = program.getCustomSetupFunc(begin);
     return this.compileAndRun(program, [x], null, customSetup);
@@ -328,12 +326,12 @@ export class MathBackendWebGL implements MathBackend {
     return this.compileAndRun<Array2D, Array2D>(program, [a, b]);
   }
 
-  multiply<D extends DataType>(a: NDArray<D>, b: NDArray<D>): NDArray<D> {
+  multiply(a: NDArray, b: NDArray): NDArray {
     const program = new BinaryOpProgram(binaryop_gpu.MUL, a.shape, b.shape);
-    const output = this.makeOutputArray(
-                       program.outputShape,
-                       types.upcastType(a.dtype, b.dtype)) as NDArray<D>;
-    return this.compileAndRun(program, [a, b], output) as NDArray<D>;
+    const output =
+        this.makeOutputArray(
+            program.outputShape, types.upcastType(a.dtype, b.dtype)) as NDArray;
+    return this.compileAndRun(program, [a, b], output) as NDArray;
   }
 
   batchNormalization2D(
@@ -416,7 +414,7 @@ export class MathBackendWebGL implements MathBackend {
     return this.compileAndRun(program, [x]);
   }
 
-  tile<D extends DataType, T extends NDArray<D>>(x: T, reps: number[]): T {
+  tile<T extends NDArray>(x: T, reps: number[]): T {
     const program = new TileProgram(x.shape, reps);
     return this.compileAndRun(program, [x]);
   }
@@ -434,19 +432,17 @@ export class MathBackendWebGL implements MathBackend {
     return this.compileAndRun(program, [x]);
   }
 
-  transpose<D extends DataType, T extends NDArray<D>>(x: T, perm: number[]): T {
+  transpose<T extends NDArray>(x: T, perm: number[]): T {
     const program = new TransposeProgram(x.shape, perm);
     return this.compileAndRun(program, [x]);
   }
 
-  gather<D extends DataType, T extends NDArray<D>>(
-      x: T, indices: Array1D<'int32'>, axis: number): T {
+  gather<T extends NDArray>(x: T, indices: Array1D, axis: number): T {
     const program = new GatherProgram(x.shape, indices.size, axis);
     return this.compileAndRun(program, [x, indices]);
   }
 
-  private reduce<D extends DataType>(
-      x: Array2D, reduceType: 'max'|'min'|'sum', dtype: D): Array2D<D> {
+  private reduce(x: Array2D, reduceType: 'max'|'min'|'sum', dtype: D): Array2D {
     const batchSize = x.shape[0];
     const inSize = x.shape[1];
     const windowSize = reduce_util.computeOptimalWindowSize(inSize);
@@ -465,7 +461,7 @@ export class MathBackendWebGL implements MathBackend {
 
   private argReduce(
       x: Array2D, reduceType: 'max'|'min',
-      bestIndicesA: Array2D = null): Array2D<'int32'> {
+      bestIndicesA: Array2D = null): Array2D {
     let batchSize = x.shape[0];
     let inSize = x.shape[1];
     if (bestIndicesA != null) {
@@ -491,7 +487,7 @@ export class MathBackendWebGL implements MathBackend {
     return this.argReduce(x, reduceType, output);
   }
 
-  sum<D extends DataType>(x: NDArray<D>, axes: number[]): NDArray<SumTypes[D]> {
+  sum(x: NDArray, axes: number[]): NDArray<SumTypes[D]> {
     axis_util.assertAxesAreInnerMostDims('sum', axes, x.rank);
     const [outShape, reduceShape] =
         axis_util.computeOutAndReduceShapes(x.shape, axes);
@@ -501,7 +497,7 @@ export class MathBackendWebGL implements MathBackend {
     return this.reduce(a2D, 'sum', outputDType).reshape(outShape);
   }
 
-  argMin(x: NDArray, axes: number[]): NDArray<'int32'> {
+  argMin(x: NDArray, axes: number[]): NDArray {
     axis_util.assertAxesAreInnerMostDims('argMin', axes, x.rank);
     const [outShape, reduceShape] =
         axis_util.computeOutAndReduceShapes(x.shape, axes);
@@ -510,7 +506,7 @@ export class MathBackendWebGL implements MathBackend {
     return this.argReduce(a2D, 'min').reshape(outShape);
   }
 
-  argMax(x: NDArray, axes: number[]): NDArray<'int32'> {
+  argMax(x: NDArray, axes: number[]): NDArray {
     axis_util.assertAxesAreInnerMostDims('argMax', axes, x.rank);
     const [outShape, reduceShape] =
         axis_util.computeOutAndReduceShapes(x.shape, axes);
@@ -519,76 +515,74 @@ export class MathBackendWebGL implements MathBackend {
     return this.argReduce(a2D, 'max').reshape(outShape);
   }
 
-  equal(a: NDArray, b: NDArray): NDArray<'bool'> {
+  equal(a: NDArray, b: NDArray): NDArray {
     const program = new BinaryOpProgram(binaryop_gpu.EQUAL, a.shape, b.shape);
     const output = this.makeOutputArray(program.outputShape, 'bool');
     return this.compileAndRun(program, [a, b], output);
   }
 
-  notEqual(a: NDArray, b: NDArray): NDArray<'bool'> {
+  notEqual(a: NDArray, b: NDArray): NDArray {
     const program =
         new BinaryOpProgram(binaryop_gpu.NOT_EQUAL, a.shape, b.shape);
     const output = this.makeOutputArray(program.outputShape, 'bool');
     return this.compileAndRun(program, [a, b], output);
   }
 
-  less(a: NDArray, b: NDArray): NDArray<'bool'> {
+  less(a: NDArray, b: NDArray): NDArray {
     const program = new BinaryOpProgram(binaryop_gpu.LESS, a.shape, b.shape);
     const output = this.makeOutputArray(program.outputShape, 'bool');
     return this.compileAndRun(program, [a, b], output);
   }
 
-  lessEqual(a: NDArray, b: NDArray): NDArray<'bool'> {
+  lessEqual(a: NDArray, b: NDArray): NDArray {
     const program =
         new BinaryOpProgram(binaryop_gpu.LESS_EQUAL, a.shape, b.shape);
     const output = this.makeOutputArray(program.outputShape, 'bool');
     return this.compileAndRun(program, [a, b], output);
   }
 
-  greater(a: NDArray, b: NDArray): NDArray<'bool'> {
+  greater(a: NDArray, b: NDArray): NDArray {
     const program = new BinaryOpProgram(binaryop_gpu.GREATER, a.shape, b.shape);
     const output = this.makeOutputArray(program.outputShape, 'bool');
     return this.compileAndRun(program, [a, b], output);
   }
 
-  greaterEqual(a: NDArray, b: NDArray): NDArray<'bool'> {
+  greaterEqual(a: NDArray, b: NDArray): NDArray {
     const program =
         new BinaryOpProgram(binaryop_gpu.GREATER_EQUAL, a.shape, b.shape);
     const output = this.makeOutputArray(program.outputShape, 'bool');
     return this.compileAndRun(program, [a, b], output);
   }
 
-  logicalAnd(a: NDArray, b: NDArray): NDArray<'bool'> {
+  logicalAnd(a: NDArray, b: NDArray): NDArray {
     const program =
         new BinaryOpProgram(binaryop_gpu.LOGICAL_AND, a.shape, b.shape);
     const output = this.makeOutputArray(program.outputShape, 'bool');
     return this.compileAndRun(program, [a, b], output);
   }
 
-  logicalOr(a: NDArray, b: NDArray): NDArray<'bool'> {
+  logicalOr(a: NDArray, b: NDArray): NDArray {
     const program =
         new BinaryOpProgram(binaryop_gpu.LOGICAL_OR, a.shape, b.shape);
     const output = this.makeOutputArray(program.outputShape, 'bool');
     return this.compileAndRun(program, [a, b], output);
   }
 
-  where<D extends DataType>(
-      condition: NDArray, a: NDArray, b: NDArray, dtype: D): NDArray<D> {
+  where(condition: NDArray, a: NDArray, b: NDArray, dtype: D): NDArray {
     const program = new WhereProgram(condition.rank, a.shape, a.rank);
     const output = this.makeOutputArray(program.outputShape, dtype);
     return this.compileAndRun(program, [condition, a, b], output);
   }
 
-  topKValues<D extends DataType, T extends NDArray<D>>(x: T, k: number):
-      Array1D<D> {
+  topKValues<T extends NDArray>(x: T, k: number): Array1D {
     throw new Error('topKValues GPU not yet implemented!');
   }
 
-  topKIndices(x: NDArray, k: number): Array1D<'int32'> {
+  topKIndices(x: NDArray, k: number): Array1D {
     throw new Error('topKIndices GPU not yet implemented!');
   }
 
-  min<D extends DataType>(x: NDArray<D>, axes: number[]): NDArray<D> {
+  min(x: NDArray, axes: number[]): NDArray {
     axis_util.assertAxesAreInnerMostDims('min', axes, x.rank);
     const [outShape, reduceShape] =
         axis_util.computeOutAndReduceShapes(x.shape, axes);
@@ -597,12 +591,12 @@ export class MathBackendWebGL implements MathBackend {
     return this.reduce(a2D, 'min', a2D.dtype).reshape(outShape);
   }
 
-  minimum<D extends DataType>(a: NDArray<D>, b: NDArray<D>): NDArray<D> {
+  minimum(a: NDArray, b: NDArray): NDArray {
     const program = new BinaryOpProgram(binaryop_gpu.MIN, a.shape, b.shape);
     return this.compileAndRun(program, [a, b]);
   }
 
-  max<D extends DataType>(x: NDArray<D>, axes: number[]): NDArray<D> {
+  max(x: NDArray, axes: number[]): NDArray {
     axis_util.assertAxesAreInnerMostDims('max', axes, x.rank);
     const [outShape, reduceShape] =
         axis_util.computeOutAndReduceShapes(x.shape, axes);
@@ -611,35 +605,34 @@ export class MathBackendWebGL implements MathBackend {
     return this.reduce(a2D, 'max', a2D.dtype).reshape(outShape);
   }
 
-  maximum<D extends DataType>(a: NDArray<D>, b: NDArray<D>): NDArray<D> {
+  maximum(a: NDArray, b: NDArray): NDArray {
     const program = new BinaryOpProgram(binaryop_gpu.MAX, a.shape, b.shape);
     return this.compileAndRun(program, [a, b]);
   }
 
-  divide(a: NDArray, b: NDArray): NDArray<'float32'> {
+  divide(a: NDArray, b: NDArray): NDArray {
     const program = new BinaryOpProgram(binaryop_gpu.DIV, a.shape, b.shape);
     const output = this.makeOutputArray(program.outputShape, 'float32');
-    return this.compileAndRun<NDArray, NDArray<'float32'>>(
-        program, [a, b], output);
+    return this.compileAndRun<NDArray, NDArray>(program, [a, b], output);
   }
 
-  add<D extends DataType>(a: NDArray<D>, b: NDArray<D>): NDArray<D> {
+  add(a: NDArray, b: NDArray): NDArray {
     const program = new BinaryOpProgram(binaryop_gpu.ADD, a.shape, b.shape);
-    const output = this.makeOutputArray(
-                       program.outputShape,
-                       types.upcastType(a.dtype, b.dtype)) as NDArray<D>;
-    return this.compileAndRun<NDArray, NDArray<D>>(program, [a, b], output);
+    const output =
+        this.makeOutputArray(
+            program.outputShape, types.upcastType(a.dtype, b.dtype)) as NDArray;
+    return this.compileAndRun<NDArray, NDArray>(program, [a, b], output);
   }
 
-  subtract<D extends DataType>(a: NDArray<D>, b: NDArray<D>): NDArray<D> {
+  subtract(a: NDArray, b: NDArray): NDArray {
     const program = new BinaryOpProgram(binaryop_gpu.SUB, a.shape, b.shape);
-    const output = this.makeOutputArray(
-                       program.outputShape,
-                       types.upcastType(a.dtype, b.dtype)) as NDArray<D>;
-    return this.compileAndRun<NDArray, NDArray<D>>(program, [a, b], output);
+    const output =
+        this.makeOutputArray(
+            program.outputShape, types.upcastType(a.dtype, b.dtype)) as NDArray;
+    return this.compileAndRun<NDArray, NDArray>(program, [a, b], output);
   }
 
-  pow<T extends NDArray>(a: T, b: NDArray<'int32'>): T {
+  pow<T extends NDArray>(a: T, b: NDArray): T {
     const program = new BinaryOpProgram(binaryop_gpu.POW, a.shape, b.shape);
     const output =
         this.makeOutputArray(
@@ -713,10 +706,10 @@ export class MathBackendWebGL implements MathBackend {
     return this.compileAndRun(program, [a, b]) as T;
   }
 
-  int<R extends Rank>(x: NDArray<DataType, R>): NDArray<'int32', R> {
+  int<R extends Rank>(x: NDArray<R>): NDArray<R> {
     const program = new UnaryOpProgram(x.shape, unary_op.TO_INT);
     const output = this.makeOutputArray(program.outputShape, 'int32');
-    return this.compileAndRun(program, [x], output) as NDArray<'int32', R>;
+    return this.compileAndRun(program, [x], output) as NDArray<R>;
   }
 
   clip<T extends NDArray>(x: T, min: number, max: number): T {
@@ -825,10 +818,10 @@ export class MathBackendWebGL implements MathBackend {
     return this.compileAndRun(program, [x], output);
   }
 
-  avgPool(x: Array4D, convInfo: Conv2DInfo): Array4D<'float32'> {
+  avgPool(x: Array4D, convInfo: Conv2DInfo): Array4D {
     const program = new Pool2DProgram(convInfo, 'avg', false);
     const output = this.makeOutputArray(program.outputShape, 'float32');
-    return this.compileAndRun(program, [x], output) as Array4D<'float32'>;
+    return this.compileAndRun(program, [x], output) as Array4D;
   }
 
   maxPoolBackprop(dy: Array4D, x: Array4D, convInfo: Conv2DInfo): Array4D {
@@ -862,13 +855,12 @@ export class MathBackendWebGL implements MathBackend {
     return this.compileAndRun(program, [x]);
   }
 
-  multinomial(probs: Array2D, numSamples: number, seed: number):
-      Array2D<'int32'> {
+  multinomial(probs: Array2D, numSamples: number, seed: number): Array2D {
     const batchSize = probs.shape[0];
     const numOutcomes = probs.shape[1];
     const program = new MultinomialProgram(batchSize, numOutcomes, numSamples);
     const output =
-        this.makeOutputArray(program.outputShape, 'int32') as Array2D<'int32'>;
+        this.makeOutputArray(program.outputShape, 'int32') as Array2D;
     const customSetup = program.getCustomSetupFunc(seed);
     return this.compileAndRun(program, [probs], output, customSetup);
   }
@@ -879,8 +871,7 @@ export class MathBackendWebGL implements MathBackend {
     return this.compileAndRun(program, [indices]);
   }
 
-  private makeOutputArray<D extends DataType, T extends NDArray<D>>(
-      shape: number[], dtype: D): T {
+  private makeOutputArray<T extends NDArray>(shape: number[], dtype: D): T {
     return NDArray.make(shape, {}, dtype) as T;
   }
 
@@ -1007,8 +998,7 @@ export class NDArrayMathGPU extends NDArrayMath {
   }
 }
 
-function float32ToTypedArray<D extends DataType>(
-    a: Float32Array, dtype: D): DataTypeMap[D] {
+function float32ToTypedArray(a: Float32Array, dtype: D): DataTypeMap[D] {
   if (dtype === 'float32') {
     return a;
   } else if (dtype === 'int32' || dtype === 'bool') {

--- a/src/math/backends/backend_webgl.ts
+++ b/src/math/backends/backend_webgl.ts
@@ -24,8 +24,8 @@ import {NDArrayMath} from '../math';
 import {Array1D, Array2D, Array3D, Array4D, NDArray} from '../ndarray';
 import * as reduce_util from '../reduce_util';
 import * as types from '../types';
-import {SumTypes, SumTypesMap} from '../types';
-import {DataType, DataTypeMap, Rank} from '../types';
+import {DataType, DataTypeMap, DataVal, Rank} from '../types';
+
 import {MathBackend} from './backend';
 import {MatrixOrientation} from './types/matmul';
 import {ArgMinMaxProgram} from './webgl/argminmax_gpu';
@@ -118,7 +118,7 @@ export class MathBackendWebGL implements MathBackend {
     // Pixel data is immediate storage since it already lives on gpu.
     this.gpgpu.uploadPixelDataToTexture(texture, pixels);
   }
-  write(dataId: number, values: DataTypeMap[D]): void {
+  write(dataId: number, values: DataVal): void {
     if (values == null) {
       throw new Error('MathBackendWebGL.write(): values can not be null');
     }
@@ -139,7 +139,7 @@ export class MathBackendWebGL implements MathBackend {
     }
   }
 
-  readSync(dataId: number): DataTypeMap[D] {
+  readSync(dataId: number): DataVal {
     this.throwIfNoData(dataId);
     const {texture, values, textureType, texShape, numChannels} =
         this.texData[dataId];
@@ -158,7 +158,7 @@ export class MathBackendWebGL implements MathBackend {
     this.cacheOnCPU(dataId, float32Values);
     return this.texData[dataId].values;
   }
-  async read(dataId: number): Promise<DataTypeMap[D]> {
+  async read(dataId: number): Promise<DataVal> {
     this.throwIfNoData(dataId);
     const {texture, values, textureType, texShape} = this.texData[dataId];
     if (values != null) {
@@ -242,7 +242,7 @@ export class MathBackendWebGL implements MathBackend {
     // Pretend the source was in logical shape that matches the texture shape.
     const source = x.as2D(texShape[0], texShape[1]);
     // Do the same for output.
-    const output = this.makeOutputArray<D, Array2D>(texShape, x.dtype);
+    const output = this.makeOutputArray<Array2D>(texShape, x.dtype);
     this.copy2D(source, [0, 0], texShape, output, [0, 0], texShape);
     // Get back to the original logical shape.
     return output.reshape(x.shape) as T;

--- a/src/math/backends/kernel_registry.ts
+++ b/src/math/backends/kernel_registry.ts
@@ -113,7 +113,7 @@ executeKernel<R extends Rank, K extends keyof KernelConfigRegistry<R>, O extends
     const config = inputAndArgs as BinaryNode['inputAndArgs'];
     return backend.divide(config.inputs.a, config.inputs.b) as O;
   } else if (kernelName === 'Sum') {
-    const config = inputAndArgs as SumNode<'float32'|'int32'>['inputAndArgs'];
+    const config = inputAndArgs as SumNode['inputAndArgs'];
     return backend.sum(config.inputs.x, config.args.axes) as O;
   } else if (kernelName === 'ArgMax') {
     const config = inputAndArgs as ArgMaxNode['inputAndArgs'];
@@ -157,16 +157,16 @@ executeKernel<R extends Rank, K extends keyof KernelConfigRegistry<R>, O extends
     const config = inputAndArgs as TopKIndicesNode['inputAndArgs'];
     return backend.topKIndices(config.inputs.x, config.args.k) as O;
   } else if (kernelName === 'Min') {
-    const config = inputAndArgs as MinNode<D>['inputAndArgs'];
+    const config = inputAndArgs as MinNode['inputAndArgs'];
     return backend.min(config.inputs.x, config.args.axes) as O;
   } else if (kernelName === 'Minimum') {
-    const config = inputAndArgs as MinimumNode<D>['inputAndArgs'];
+    const config = inputAndArgs as MinimumNode['inputAndArgs'];
     return backend.minimum(config.inputs.a, config.inputs.b) as O;
   } else if (kernelName === 'Max') {
-    const config = inputAndArgs as MaxNode<D>['inputAndArgs'];
+    const config = inputAndArgs as MaxNode['inputAndArgs'];
     return backend.max(config.inputs.x, config.args.axes) as O;
   } else if (kernelName === 'Maximum') {
-    const config = inputAndArgs as MaximumNode<D>['inputAndArgs'];
+    const config = inputAndArgs as MaximumNode['inputAndArgs'];
     return backend.maximum(config.inputs.a, config.inputs.b) as O;
   } else if (kernelName === 'Ceil') {
     const config = inputAndArgs as UnaryNode<R>['inputAndArgs'];
@@ -376,10 +376,10 @@ executeKernel<R extends Rank, K extends keyof KernelConfigRegistry<R>, O extends
 export interface KernelConfigRegistry<R extends Rank> {
   MatMul: MatMulNode;
   Clone: UnaryNode<R>;
-  Slice1D: Slice1DNode<D>;
-  Slice2D: Slice2DNode<D>;
-  Slice3D: Slice3DNode<D>;
-  Slice4D: Slice4DNode<D>;
+  Slice1D: Slice1DNode;
+  Slice2D: Slice2DNode;
+  Slice3D: Slice3DNode;
+  Slice4D: Slice4DNode;
   Reverse4D: Reverse4DNode;
   Concat1D: Concat1DNode;
   Concat2D: Concat2DNode;
@@ -390,7 +390,7 @@ export interface KernelConfigRegistry<R extends Rank> {
   Sub: BinaryNode;
   Mul: BinaryNode;
   Div: BinaryNode;
-  Sum: SumNode<D>;
+  Sum: SumNode;
   ArgMax: ArgMaxNode;
   ArgMin: ArgMinNode;
   Equal: EqualNode;
@@ -404,10 +404,10 @@ export interface KernelConfigRegistry<R extends Rank> {
   Where: WhereNode;
   TopKValues: TopKValuesNode<R>;
   TopKIndices: TopKIndicesNode;
-  Min: MinNode<D>;
-  Minimum: MinimumNode<D>;
-  Max: MaxNode<D>;
-  Maximum: MaximumNode<D>;
+  Min: MinNode;
+  Minimum: MinimumNode;
+  Max: MaxNode;
+  Maximum: MaximumNode;
   Ceil: UnaryNode<R>;
   Floor: UnaryNode<R>;
   Pow: PowNode<R>;

--- a/src/math/backends/kernel_registry.ts
+++ b/src/math/backends/kernel_registry.ts
@@ -17,7 +17,7 @@
 
 import * as util from '../../util';
 import {NDArray, Scalar} from '../ndarray';
-import {DataType, Rank} from '../types';
+import {Rank} from '../types';
 import {MathBackend} from './backend';
 import {ArgMaxNode, ArgMinNode} from './types/argminmax';
 // tslint:disable-next-line:max-line-length
@@ -50,33 +50,33 @@ import {TopKIndicesNode, TopKValuesNode} from './types/topk';
 // tslint:disable-next-line:max-line-length
 import {ClipNode, LeakyReluNode, StepNode, TileNode, TransposeNode, UnaryNode} from './types/unary';
 
-export function executeKernel<D extends DataType, R extends Rank, K extends
-                                  keyof KernelConfigRegistry<D, R>, O extends
-                                      KernelConfigRegistry<D, R>[K]['output']>(
+export function
+executeKernel<R extends Rank, K extends keyof KernelConfigRegistry<R>, O extends
+                  KernelConfigRegistry<R>[K]['output']>(
     backend: MathBackend, kernelName: K,
-    inputAndArgs: KernelConfigRegistry<D, R>[K]['inputAndArgs']): O {
+    inputAndArgs: KernelConfigRegistry<R>[K]['inputAndArgs']): O {
   if (kernelName === 'MatMul') {
     const config = inputAndArgs as MatMulNode['inputAndArgs'];
     return backend.matMul(
                config.inputs.a, config.inputs.b, config.args.aOrientation,
                config.args.bOrientation) as O;
   } else if (kernelName === 'Clone') {
-    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<R>['inputAndArgs'];
     return backend.clone(config.inputs.x) as O;
   } else if (kernelName === 'Slice1D') {
-    const config = inputAndArgs as Slice1DNode<D>['inputAndArgs'];
+    const config = inputAndArgs as Slice1DNode['inputAndArgs'];
     return backend.slice1D(
                config.inputs.x, config.args.begin, config.args.size) as O;
   } else if (kernelName === 'Slice2D') {
-    const config = inputAndArgs as Slice2DNode<D>['inputAndArgs'];
+    const config = inputAndArgs as Slice2DNode['inputAndArgs'];
     return backend.slice2D(
                config.inputs.x, config.args.begin, config.args.size) as O;
   } else if (kernelName === 'Slice3D') {
-    const config = inputAndArgs as Slice3DNode<D>['inputAndArgs'];
+    const config = inputAndArgs as Slice3DNode['inputAndArgs'];
     return backend.slice3D(
                config.inputs.x, config.args.begin, config.args.size) as O;
   } else if (kernelName === 'Slice4D') {
-    const config = inputAndArgs as Slice4DNode<D>['inputAndArgs'];
+    const config = inputAndArgs as Slice4DNode['inputAndArgs'];
     return backend.slice4D(
                config.inputs.x, config.args.begin, config.args.size) as O;
   } else if (kernelName === 'Reverse4D') {
@@ -98,7 +98,7 @@ export function executeKernel<D extends DataType, R extends Rank, K extends
     return backend.concat4D(
                config.inputs.a, config.inputs.b, config.args.axis) as O;
   } else if (kernelName === 'Neg') {
-    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<R>['inputAndArgs'];
     return backend.neg(config.inputs.x) as O;
   } else if (kernelName === 'Add') {
     const config = inputAndArgs as BinaryNode['inputAndArgs'];
@@ -151,7 +151,7 @@ export function executeKernel<D extends DataType, R extends Rank, K extends
                config.inputs.condition, config.inputs.a, config.inputs.b,
                config.args.dtype) as O;
   } else if (kernelName === 'TopKValues') {
-    const config = inputAndArgs as TopKValuesNode<D, R>['inputAndArgs'];
+    const config = inputAndArgs as TopKValuesNode<R>['inputAndArgs'];
     return backend.topKValues(config.inputs.x, config.args.k) as O;
   } else if (kernelName === 'TopKIndices') {
     const config = inputAndArgs as TopKIndicesNode['inputAndArgs'];
@@ -169,28 +169,28 @@ export function executeKernel<D extends DataType, R extends Rank, K extends
     const config = inputAndArgs as MaximumNode<D>['inputAndArgs'];
     return backend.maximum(config.inputs.a, config.inputs.b) as O;
   } else if (kernelName === 'Ceil') {
-    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<R>['inputAndArgs'];
     return backend.ceil(config.inputs.x) as O;
   } else if (kernelName === 'Floor') {
-    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<R>['inputAndArgs'];
     return backend.floor(config.inputs.x) as O;
   } else if (kernelName === 'Pow') {
-    const config = inputAndArgs as PowNode<D, R>['inputAndArgs'];
+    const config = inputAndArgs as PowNode<R>['inputAndArgs'];
     return backend.pow(config.inputs.base, config.inputs.exp) as O;
   } else if (kernelName === 'Exp') {
-    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<R>['inputAndArgs'];
     return backend.exp(config.inputs.x) as O;
   } else if (kernelName === 'Log') {
-    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<R>['inputAndArgs'];
     return backend.log(config.inputs.x) as O;
   } else if (kernelName === 'Sqrt') {
-    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<R>['inputAndArgs'];
     return backend.sqrt(config.inputs.x) as O;
   } else if (kernelName === 'Square') {
-    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<R>['inputAndArgs'];
     return backend.square(config.inputs.x) as O;
   } else if (kernelName === 'Relu') {
-    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<R>['inputAndArgs'];
     return backend.relu(config.inputs.x) as O;
   } else if (kernelName === 'Reshape') {
     const config = inputAndArgs as ReshapeNode['inputAndArgs'];
@@ -215,67 +215,67 @@ export function executeKernel<D extends DataType, R extends Rank, K extends
       throw new Error(`Error in Cast: unknown dtype argument (${newDType})`);
     }
   } else if (kernelName === 'LeakyRelu') {
-    const config = inputAndArgs as LeakyReluNode<D, R>['inputAndArgs'];
+    const config = inputAndArgs as LeakyReluNode<R>['inputAndArgs'];
     return backend.leakyRelu(config.inputs.x, config.args.alpha) as O;
   } else if (kernelName === 'PReLU') {
-    const config = inputAndArgs as PReLUNode<D, R>['inputAndArgs'];
+    const config = inputAndArgs as PReLUNode<R>['inputAndArgs'];
     return backend.prelu(config.inputs.x, config.inputs.alpha) as O;
   } else if (kernelName === 'PReLUDer') {
-    const config = inputAndArgs as PReLUNode<D, R>['inputAndArgs'];
+    const config = inputAndArgs as PReLUNode<R>['inputAndArgs'];
     return backend.preluDer(config.inputs.x, config.inputs.alpha) as O;
   } else if (kernelName === 'Elu') {
-    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<R>['inputAndArgs'];
     return backend.elu(config.inputs.x) as O;
   } else if (kernelName === 'EluDer') {
-    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<R>['inputAndArgs'];
     return backend.eluDer(config.inputs.x) as O;
   } else if (kernelName === 'Selu') {
-    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<R>['inputAndArgs'];
     return backend.selu(config.inputs.x) as O;
   } else if (kernelName === 'Abs') {
-    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<R>['inputAndArgs'];
     return backend.abs(config.inputs.x) as O;
   } else if (kernelName === 'Sigmoid') {
-    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<R>['inputAndArgs'];
     return backend.sigmoid(config.inputs.x) as O;
   } else if (kernelName === 'Step') {
-    const config = inputAndArgs as StepNode<D, R>['inputAndArgs'];
+    const config = inputAndArgs as StepNode<R>['inputAndArgs'];
     return backend.step(config.inputs.x, config.args.alpha) as O;
   } else if (kernelName === 'Sin') {
-    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<R>['inputAndArgs'];
     return backend.sin(config.inputs.x) as O;
   } else if (kernelName === 'Cos') {
-    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<R>['inputAndArgs'];
     return backend.cos(config.inputs.x) as O;
   } else if (kernelName === 'Tan') {
-    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<R>['inputAndArgs'];
     return backend.tan(config.inputs.x) as O;
   } else if (kernelName === 'Asin') {
-    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<R>['inputAndArgs'];
     return backend.asin(config.inputs.x) as O;
   } else if (kernelName === 'Acos') {
-    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<R>['inputAndArgs'];
     return backend.acos(config.inputs.x) as O;
   } else if (kernelName === 'Atan') {
-    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<R>['inputAndArgs'];
     return backend.atan(config.inputs.x) as O;
   } else if (kernelName === 'Sinh') {
-    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<R>['inputAndArgs'];
     return backend.sinh(config.inputs.x) as O;
   } else if (kernelName === 'Cosh') {
-    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<R>['inputAndArgs'];
     return backend.cosh(config.inputs.x) as O;
   } else if (kernelName === 'Tanh') {
-    const config = inputAndArgs as UnaryNode<D, R>['inputAndArgs'];
+    const config = inputAndArgs as UnaryNode<R>['inputAndArgs'];
     return backend.tanh(config.inputs.x) as O;
   } else if (kernelName === 'Clip') {
-    const config = inputAndArgs as ClipNode<D, R>['inputAndArgs'];
+    const config = inputAndArgs as ClipNode<R>['inputAndArgs'];
     return backend.clip(config.inputs.x, config.args.min, config.args.max) as O;
   } else if (kernelName === 'Tile') {
-    const config = inputAndArgs as TileNode<D, R>['inputAndArgs'];
+    const config = inputAndArgs as TileNode<R>['inputAndArgs'];
     return backend.tile(config.inputs.x, config.args.reps) as O;
   } else if (kernelName === 'Gather') {
-    const config = inputAndArgs as GatherNode<D, R>['inputAndArgs'];
+    const config = inputAndArgs as GatherNode<R>['inputAndArgs'];
     return backend.gather(
                config.inputs.x, config.inputs.indices, config.args.axis) as O;
   } else if (kernelName === 'Pad1D') {
@@ -289,7 +289,7 @@ export function executeKernel<D extends DataType, R extends Rank, K extends
                config.inputs.x, config.args.paddings,
                config.args.constantValue) as O;
   } else if (kernelName === 'Transpose') {
-    const config = inputAndArgs as TransposeNode<D, R>['inputAndArgs'];
+    const config = inputAndArgs as TransposeNode<R>['inputAndArgs'];
     return backend.transpose(config.inputs.x, config.args.perm) as O;
   } else if (kernelName === 'Conv2D') {
     const config = inputAndArgs as Conv2DNode['inputAndArgs'];
@@ -373,9 +373,9 @@ export function executeKernel<D extends DataType, R extends Rank, K extends
   throw new Error(`No backend method found for kernel ${kernelName}`);
 }
 
-export interface KernelConfigRegistry<D extends DataType, R extends Rank> {
+export interface KernelConfigRegistry<R extends Rank> {
   MatMul: MatMulNode;
-  Clone: UnaryNode<D, R>;
+  Clone: UnaryNode<R>;
   Slice1D: Slice1DNode<D>;
   Slice2D: Slice2DNode<D>;
   Slice3D: Slice3DNode<D>;
@@ -385,7 +385,7 @@ export interface KernelConfigRegistry<D extends DataType, R extends Rank> {
   Concat2D: Concat2DNode;
   Concat3D: Concat3DNode;
   Concat4D: Concat4DNode;
-  Neg: UnaryNode<D, R>;
+  Neg: UnaryNode<R>;
   Add: BinaryNode;
   Sub: BinaryNode;
   Mul: BinaryNode;
@@ -402,46 +402,46 @@ export interface KernelConfigRegistry<D extends DataType, R extends Rank> {
   LogicalAnd: LogicalNode;
   LogicalOr: LogicalNode;
   Where: WhereNode;
-  TopKValues: TopKValuesNode<D, R>;
+  TopKValues: TopKValuesNode<R>;
   TopKIndices: TopKIndicesNode;
   Min: MinNode<D>;
   Minimum: MinimumNode<D>;
   Max: MaxNode<D>;
   Maximum: MaximumNode<D>;
-  Ceil: UnaryNode<D, R>;
-  Floor: UnaryNode<D, R>;
-  Pow: PowNode<D, R>;
-  Exp: UnaryNode<D, R>;
-  Log: UnaryNode<D, R>;
-  Sqrt: UnaryNode<D, R>;
-  Square: UnaryNode<D, R>;
-  Relu: UnaryNode<D, R>;
-  LeakyRelu: LeakyReluNode<D, R>;
-  PReLU: PReLUNode<D, R>;
-  PReLUDer: PReLUNode<D, R>;
+  Ceil: UnaryNode<R>;
+  Floor: UnaryNode<R>;
+  Pow: PowNode<R>;
+  Exp: UnaryNode<R>;
+  Log: UnaryNode<R>;
+  Sqrt: UnaryNode<R>;
+  Square: UnaryNode<R>;
+  Relu: UnaryNode<R>;
+  LeakyRelu: LeakyReluNode<R>;
+  PReLU: PReLUNode<R>;
+  PReLUDer: PReLUNode<R>;
   Reshape: ReshapeNode;
   Cast: CastNode;
-  Elu: UnaryNode<D, R>;
-  EluDer: UnaryNode<D, R>;
-  Selu: UnaryNode<D, R>;
-  Abs: UnaryNode<D, R>;
-  Sigmoid: UnaryNode<D, R>;
-  Step: StepNode<D, R>;
-  Sin: UnaryNode<D, R>;
-  Cos: UnaryNode<D, R>;
-  Tan: UnaryNode<D, R>;
-  Asin: UnaryNode<D, R>;
-  Acos: UnaryNode<D, R>;
-  Atan: UnaryNode<D, R>;
-  Sinh: UnaryNode<D, R>;
-  Cosh: UnaryNode<D, R>;
-  Tanh: UnaryNode<D, R>;
-  Clip: ClipNode<D, R>;
-  Transpose: TransposeNode<D, R>;
+  Elu: UnaryNode<R>;
+  EluDer: UnaryNode<R>;
+  Selu: UnaryNode<R>;
+  Abs: UnaryNode<R>;
+  Sigmoid: UnaryNode<R>;
+  Step: StepNode<R>;
+  Sin: UnaryNode<R>;
+  Cos: UnaryNode<R>;
+  Tan: UnaryNode<R>;
+  Asin: UnaryNode<R>;
+  Acos: UnaryNode<R>;
+  Atan: UnaryNode<R>;
+  Sinh: UnaryNode<R>;
+  Cosh: UnaryNode<R>;
+  Tanh: UnaryNode<R>;
+  Clip: ClipNode<R>;
+  Transpose: TransposeNode<R>;
   Pad1D: Pad1DNode;
   Pad2D: Pad2DNode;
-  Tile: TileNode<D, R>;
-  Gather: GatherNode<D, R>;
+  Tile: TileNode<R>;
+  Gather: GatherNode<R>;
   Conv2D: Conv2DNode;
   Conv2DDerInput: Conv2DDerInputNode;
   Conv2DDerFilter: Conv2DDerFilterNode;

--- a/src/math/backends/tape_types.ts
+++ b/src/math/backends/tape_types.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {NamedArrayMap} from '../../util';
+import {NamedArrayMap} from '../../math/types';
 import {NDArray} from '../ndarray';
 import {Rank} from '../types';
 import {KernelConfigRegistry} from './kernel_registry';

--- a/src/math/backends/tape_types.ts
+++ b/src/math/backends/tape_types.ts
@@ -17,7 +17,7 @@
 
 import {NamedArrayMap} from '../../util';
 import {NDArray} from '../ndarray';
-import {DataType, Rank} from '../types';
+import {Rank} from '../types';
 import {KernelConfigRegistry} from './kernel_registry';
 
 export type Tape = Array<TapeNode<TapeNodeOutput>>;
@@ -31,9 +31,7 @@ export interface TapeNode<T extends TapeNodeOutput> {
   inputAndArgs: TapeNodeInputConfig;
 
   output: T;
-  gradient:
-      (dy: NDArray|NamedArrayMap<'float32'>,
-       y: T) => TapeNodeInputGradientArrays;
+  gradient: (dy: NDArray|NamedArrayMap, y: T) => TapeNodeInputGradientArrays;
 }
 
 export interface TapeNodeInputConfig { inputs: NamedArrayMap; }
@@ -44,7 +42,7 @@ export type TapeNodeInputGradientArrays = {
 
 // Kernel nodes
 export interface KernelNode extends TapeNode<NDArray> {
-  kernel: keyof KernelConfigRegistry<DataType, Rank>;
+  kernel: keyof KernelConfigRegistry<Rank>;
   inputAndArgs: KernelInputConfig;
   output: NDArray;
 }

--- a/src/math/backends/tape_types.ts
+++ b/src/math/backends/tape_types.ts
@@ -32,14 +32,14 @@ export interface TapeNode<T extends TapeNodeOutput> {
 
   output: T;
   gradient:
-      (dy: NDArray<'float32'>|NamedArrayMap<'float32'>,
+      (dy: NDArray|NamedArrayMap<'float32'>,
        y: T) => TapeNodeInputGradientArrays;
 }
 
 export interface TapeNodeInputConfig { inputs: NamedArrayMap; }
 
 export type TapeNodeInputGradientArrays = {
-  [inputName: string]: () => NDArray<'float32'>;
+  [inputName: string]: () => NDArray;
 };
 
 // Kernel nodes

--- a/src/math/backends/tape_util.ts
+++ b/src/math/backends/tape_util.ts
@@ -150,13 +150,13 @@ export function getFilteredNodesXToY(
  * @param filteredTape The filtered TapeNodes to backprop through.
  */
 export function backpropagateGradients(
-    arrayAccumulatedGradientMap: {[ndarrayId: number]: NDArray<'float32'>},
+    arrayAccumulatedGradientMap: {[ndarrayId: number]: NDArray},
     filteredTape: Tape) {
   // Walk the tape backwards and keep a map of NDArray to its gradient.
   for (let i = filteredTape.length - 1; i >= 0; i--) {
     const node = filteredTape[i];
 
-    let dy: NDArray<'float32'>|NamedArrayMap<'float32'>;
+    let dy: NDArray|NamedArrayMap<'float32'>;
     if (node.output instanceof NDArray) {
       dy = arrayAccumulatedGradientMap[node.output.id];
     } else {

--- a/src/math/backends/tape_util.ts
+++ b/src/math/backends/tape_util.ts
@@ -156,7 +156,7 @@ export function backpropagateGradients(
   for (let i = filteredTape.length - 1; i >= 0; i--) {
     const node = filteredTape[i];
 
-    let dy: NDArray|NamedArrayMap<'float32'>;
+    let dy: NDArray|NamedArrayMap;
     if (node.output instanceof NDArray) {
       dy = arrayAccumulatedGradientMap[node.output.id];
     } else {

--- a/src/math/backends/tape_util.ts
+++ b/src/math/backends/tape_util.ts
@@ -16,8 +16,8 @@
  */
 
 import * as util from '../../util';
-import {NamedArrayMap} from '../../util';
 import {NDArray, Variable} from '../ndarray';
+import {NamedArrayMap} from '../types';
 
 // tslint:disable-next-line:max-line-length
 import {Tape, TapeNode, TapeNodeInputConfig, TapeNodeOutput} from './tape_types';

--- a/src/math/backends/tape_util_test.ts
+++ b/src/math/backends/tape_util_test.ts
@@ -434,7 +434,7 @@ import * as tape_util from './tape_util';
       const dy = Scalar.new(1);
 
       const accumulatedGradientsMap:
-          {[ndarrayId: number]: NDArray<'float32'>} = {};
+          {[ndarrayId: number]: NDArray} = {};
       accumulatedGradientsMap[y.id] = dy;
 
       const tape: Tape = [{
@@ -460,7 +460,7 @@ import * as tape_util from './tape_util';
       const dy = Scalar.new(1);
 
       const accumulatedGradientsMap:
-          {[ndarrayId: number]: NDArray<'float32'>} = {};
+          {[ndarrayId: number]: NDArray} = {};
       accumulatedGradientsMap[y.id] = dy;
 
       const tape: Tape = [{
@@ -471,7 +471,7 @@ import * as tape_util from './tape_util';
           inputs: {x},
         },
         output: y,
-        gradient: (dy: Scalar<'float32'>, y: Scalar) => {
+        gradient: (dy: Scalar, y: Scalar) => {
           return {x: () => math.add(dy, Scalar.new(1))};
         }
       }];
@@ -489,7 +489,7 @@ import * as tape_util from './tape_util';
       const dy = Scalar.new(1);
 
       const accumulatedGradientsMap:
-          {[ndarrayId: number]: NDArray<'float32'>} = {};
+          {[ndarrayId: number]: NDArray} = {};
       accumulatedGradientsMap[y.id] = dy;
 
       const tape: Tape = [
@@ -501,7 +501,7 @@ import * as tape_util from './tape_util';
             inputs: {x},
           },
           output: intermediate,
-          gradient: (dy: Scalar<'float32'>, y: Scalar) => {
+          gradient: (dy: Scalar, y: Scalar) => {
             return {x: () => math.add(dy, Scalar.new(1))};
           }
         },
@@ -513,7 +513,7 @@ import * as tape_util from './tape_util';
             inputs: {intermediate},
           },
           output: y,
-          gradient: (dy: Scalar<'float32'>, y: Scalar) => {
+          gradient: (dy: Scalar, y: Scalar) => {
             return {intermediate: () => math.add(dy, Scalar.new(1))};
           }
         }
@@ -534,7 +534,7 @@ import * as tape_util from './tape_util';
       const dy = Scalar.new(1);
 
       const accumulatedGradientsMap:
-          {[ndarrayId: number]: NDArray<'float32'>} = {};
+          {[ndarrayId: number]: NDArray} = {};
       accumulatedGradientsMap[y.id] = dy;
 
       const tape: Tape = [
@@ -546,7 +546,7 @@ import * as tape_util from './tape_util';
             inputs: {x},
           },
           output: intermediate1,
-          gradient: (dy: Scalar<'float32'>, y: Scalar) => {
+          gradient: (dy: Scalar, y: Scalar) => {
             return {x: () => math.add(dy, Scalar.new(1))};
           }
         },
@@ -558,7 +558,7 @@ import * as tape_util from './tape_util';
             inputs: {x},
           },
           output: intermediate2,
-          gradient: (dy: Scalar<'float32'>, y: Scalar) => {
+          gradient: (dy: Scalar, y: Scalar) => {
             return {x: () => math.add(dy, Scalar.new(1))};
           }
         },
@@ -570,7 +570,7 @@ import * as tape_util from './tape_util';
             inputs: {intermediate1, intermediate2},
           },
           output: y,
-          gradient: (dy: Scalar<'float32'>, y: Scalar) => {
+          gradient: (dy: Scalar, y: Scalar) => {
             return {
               intermediate1: () => math.add(dy, Scalar.new(1)),
               intermediate2: () => math.add(dy, Scalar.new(1))
@@ -596,7 +596,7 @@ import * as tape_util from './tape_util';
          const dy = Scalar.new(1);
 
          const accumulatedGradientsMap:
-             {[ndarrayId: number]: NDArray<'float32'>} = {};
+             {[ndarrayId: number]: NDArray} = {};
          accumulatedGradientsMap[y.id] = dy;
 
          const tape: Array<TapeNode<TapeNodeOutput>> = [
@@ -623,7 +623,7 @@ import * as tape_util from './tape_util';
                inputs: {intermediate1, intermediate2},
              },
              output: y,
-             gradient: (dy: Scalar<'float32'>, y: Scalar) => {
+             gradient: (dy: Scalar, y: Scalar) => {
                return {
                  intermediate1: () => math.add(dy, Scalar.new(2)),
                  intermediate2: () => math.add(dy, Scalar.new(3))

--- a/src/math/backends/tape_util_test.ts
+++ b/src/math/backends/tape_util_test.ts
@@ -433,8 +433,7 @@ import * as tape_util from './tape_util';
 
       const dy = Scalar.new(1);
 
-      const accumulatedGradientsMap:
-          {[ndarrayId: number]: NDArray} = {};
+      const accumulatedGradientsMap: {[ndarrayId: number]: NDArray} = {};
       accumulatedGradientsMap[y.id] = dy;
 
       const tape: Tape = [{
@@ -459,8 +458,7 @@ import * as tape_util from './tape_util';
 
       const dy = Scalar.new(1);
 
-      const accumulatedGradientsMap:
-          {[ndarrayId: number]: NDArray} = {};
+      const accumulatedGradientsMap: {[ndarrayId: number]: NDArray} = {};
       accumulatedGradientsMap[y.id] = dy;
 
       const tape: Tape = [{
@@ -488,8 +486,7 @@ import * as tape_util from './tape_util';
 
       const dy = Scalar.new(1);
 
-      const accumulatedGradientsMap:
-          {[ndarrayId: number]: NDArray} = {};
+      const accumulatedGradientsMap: {[ndarrayId: number]: NDArray} = {};
       accumulatedGradientsMap[y.id] = dy;
 
       const tape: Tape = [
@@ -533,8 +530,7 @@ import * as tape_util from './tape_util';
 
       const dy = Scalar.new(1);
 
-      const accumulatedGradientsMap:
-          {[ndarrayId: number]: NDArray} = {};
+      const accumulatedGradientsMap: {[ndarrayId: number]: NDArray} = {};
       accumulatedGradientsMap[y.id] = dy;
 
       const tape: Tape = [
@@ -595,8 +591,7 @@ import * as tape_util from './tape_util';
 
          const dy = Scalar.new(1);
 
-         const accumulatedGradientsMap:
-             {[ndarrayId: number]: NDArray} = {};
+         const accumulatedGradientsMap: {[ndarrayId: number]: NDArray} = {};
          accumulatedGradientsMap[y.id] = dy;
 
          const tape: Array<TapeNode<TapeNodeOutput>> = [
@@ -608,7 +603,7 @@ import * as tape_util from './tape_util';
                inputs: {x},
              },
              output: {intermediate1, intermediate2},
-             gradient: (dy: NamedArrayMap<'float32'>, y: NamedArrayMap) => {
+             gradient: (dy: NamedArrayMap, y: NamedArrayMap) => {
                return {
                  x: () =>
                      math.multiply(dy['intermediate1'], dy['intermediate2'])

--- a/src/math/backends/tape_util_test.ts
+++ b/src/math/backends/tape_util_test.ts
@@ -16,11 +16,10 @@
  * =============================================================================
  */
 
+import {NamedArrayMap} from '../../math/types';
 import * as test_util from '../../test_util';
 import {MathTests} from '../../test_util';
-import {NamedArrayMap} from '../../util';
 import {NDArray, Scalar, variable, Variable} from '../ndarray';
-
 // tslint:disable-next-line:max-line-length
 import {Tape, TapeNode, TapeNodeInputConfig, TapeNodeOutput} from './tape_types';
 import * as tape_util from './tape_util';

--- a/src/math/backends/types/argminmax.ts
+++ b/src/math/backends/types/argminmax.ts
@@ -20,16 +20,16 @@ import {KernelNode} from '../tape_types';
 
 export interface ArgMaxNode extends KernelNode {
   inputAndArgs: {inputs: {x: NDArray;}; args: {axes: number[];};};
-  output: NDArray<'int32'>;
-  gradient: (dy: NDArray<'float32'>, y: NDArray<'int32'>) => {
-    x: () => NDArray<'float32'>;
+  output: NDArray;
+  gradient: (dy: NDArray, y: NDArray) => {
+    x: () => NDArray;
   };
 }
 
 export interface ArgMinNode extends KernelNode {
   inputAndArgs: {inputs: {x: NDArray;}; args: {axes: number[];};};
-  output: NDArray<'int32'>;
-  gradient: (dy: NDArray<'float32'>, y: NDArray<'int32'>) => {
-    x: () => NDArray<'float32'>;
+  output: NDArray;
+  gradient: (dy: NDArray, y: NDArray) => {
+    x: () => NDArray;
   };
 }

--- a/src/math/backends/types/batchnorm.ts
+++ b/src/math/backends/types/batchnorm.ts
@@ -29,12 +29,12 @@ export interface BatchNorm4DNode extends KernelNode {
     args: {varianceEpsilon: number};
   };
   output: Array4D;
-  gradient: (dy: Array4D<'float32'>, y: Array4D) => {
-    x: () => Array4D<'float32'>;
-    mean: () => Array4D<'float32'>| Array1D<'float32'>;
-    variance: () => Array4D<'float32'>| Array1D<'float32'>;
-    scale?: () => Array4D<'float32'>| Array1D<'float32'>;
-    offset?: () => Array4D<'float32'>| Array1D<'float32'>;
+  gradient: (dy: Array4D, y: Array4D) => {
+    x: () => Array4D;
+    mean: () => Array4D| Array1D;
+    variance: () => Array4D| Array1D;
+    scale?: () => Array4D| Array1D;
+    offset?: () => Array4D| Array1D;
   };
 }
 
@@ -48,12 +48,12 @@ export interface BatchNorm3DNode extends KernelNode {
     args: {varianceEpsilon: number};
   };
   output: Array3D;
-  gradient: (dy: Array3D<'float32'>, y: Array3D) => {
-    x: () => Array3D<'float32'>;
-    mean: () => Array3D<'float32'>| Array1D<'float32'>;
-    variance: () => Array3D<'float32'>| Array1D<'float32'>;
-    scale?: () => Array3D<'float32'>| Array1D<'float32'>;
-    offset?: () => Array3D<'float32'>| Array1D<'float32'>;
+  gradient: (dy: Array3D, y: Array3D) => {
+    x: () => Array3D;
+    mean: () => Array3D| Array1D;
+    variance: () => Array3D| Array1D;
+    scale?: () => Array3D| Array1D;
+    offset?: () => Array3D| Array1D;
   };
 }
 
@@ -67,11 +67,11 @@ export interface BatchNorm2DNode extends KernelNode {
     args: {varianceEpsilon: number};
   };
   output: Array2D;
-  gradient: (dy: Array2D<'float32'>, y: Array2D) => {
-    x: () => Array2D<'float32'>;
-    mean: () => Array2D<'float32'>| Array1D<'float32'>;
-    variance: () => Array2D<'float32'>| Array1D<'float32'>;
-    scale?: () => Array2D<'float32'>| Array1D<'float32'>;
-    offset?: () => Array2D<'float32'>| Array1D<'float32'>;
+  gradient: (dy: Array2D, y: Array2D) => {
+    x: () => Array2D;
+    mean: () => Array2D| Array1D;
+    variance: () => Array2D| Array1D;
+    scale?: () => Array2D| Array1D;
+    offset?: () => Array2D| Array1D;
   };
 }

--- a/src/math/backends/types/binary.ts
+++ b/src/math/backends/types/binary.ts
@@ -21,8 +21,8 @@ import {KernelNode} from '../tape_types';
 export interface BinaryNode extends KernelNode {
   inputAndArgs: {inputs: {a: NDArray; b: NDArray;};};
   output: NDArray;
-  gradient: (dy: NDArray<'float32'>, y: NDArray) => {
-    a: () => NDArray<'float32'>;
-    b: () => NDArray<'float32'>;
+  gradient: (dy: NDArray, y: NDArray) => {
+    a: () => NDArray;
+    b: () => NDArray;
   };
 }

--- a/src/math/backends/types/cast.ts
+++ b/src/math/backends/types/cast.ts
@@ -22,7 +22,7 @@ import {KernelNode} from '../tape_types';
 export interface CastNode extends KernelNode {
   inputAndArgs: {inputs: {x: NDArray}; args: {newDType: DataType};};
   output: NDArray;
-  gradient: (dy: NDArray<'float32'>, y: NDArray) => {
-    x: () => NDArray<'float32'>
+  gradient: (dy: NDArray, y: NDArray) => {
+    x: () => NDArray
   };
 }

--- a/src/math/backends/types/concat.ts
+++ b/src/math/backends/types/concat.ts
@@ -21,35 +21,35 @@ import {KernelNode} from '../tape_types';
 export interface Concat1DNode extends KernelNode {
   inputAndArgs: {inputs: {a: Array1D; b: Array1D;};};
   output: Array1D;
-  gradient: (dy: Array1D<'float32'>, y: Array1D) => {
-    a: () => Array1D<'float32'>;
-    b: () => Array1D<'float32'>;
+  gradient: (dy: Array1D, y: Array1D) => {
+    a: () => Array1D;
+    b: () => Array1D;
   };
 }
 
 export interface Concat2DNode extends KernelNode {
   inputAndArgs: {inputs: {a: Array2D; b: Array2D;}; args: {axis: number};};
   output: Array2D;
-  gradient: (dy: Array2D<'float32'>, y: Array2D) => {
-    a: () => Array2D<'float32'>;
-    b: () => Array2D<'float32'>;
+  gradient: (dy: Array2D, y: Array2D) => {
+    a: () => Array2D;
+    b: () => Array2D;
   };
 }
 
 export interface Concat3DNode extends KernelNode {
   inputAndArgs: {inputs: {a: Array3D; b: Array3D;}; args: {axis: number};};
   output: Array3D;
-  gradient: (dy: Array3D<'float32'>, y: Array3D) => {
-    a: () => Array3D<'float32'>;
-    b: () => Array3D<'float32'>;
+  gradient: (dy: Array3D, y: Array3D) => {
+    a: () => Array3D;
+    b: () => Array3D;
   };
 }
 
 export interface Concat4DNode extends KernelNode {
   inputAndArgs: {inputs: {a: Array4D; b: Array4D;}; args: {axis: number};};
   output: Array4D;
-  gradient: (dy: Array4D<'float32'>, y: Array4D) => {
-    a: () => Array4D<'float32'>;
-    b: () => Array4D<'float32'>;
+  gradient: (dy: Array4D, y: Array4D) => {
+    a: () => Array4D;
+    b: () => Array4D;
   };
 }

--- a/src/math/backends/types/conv.ts
+++ b/src/math/backends/types/conv.ts
@@ -25,42 +25,42 @@ export interface Conv2DNode extends KernelNode {
     args: {convInfo: Conv2DInfo;};
   };
   output: Array4D;
-  gradient: (dy: Array4D<'float32'>, y: Array4D) => {
-    x: () => Array4D<'float32'>;
-    filter: () => Array4D<'float32'>;
-    bias?: () => Array1D<'float32'>;
+  gradient: (dy: Array4D, y: Array4D) => {
+    x: () => Array4D;
+    filter: () => Array4D;
+    bias?: () => Array1D;
   };
 }
 
 export interface Conv2DDerInputNode extends KernelNode {
   inputAndArgs: {
-    inputs: {dy: Array4D<'float32'>; filter: Array4D;};
+    inputs: {dy: Array4D; filter: Array4D;};
     args: {convInfo: Conv2DInfo;};
   };
-  output: Array4D<'float32'>;
-  gradient: (dy: Array4D<'float32'>, y: Array4D) => {
-    dy: () => Array4D<'float32'>;
-    filter: () => Array4D<'float32'>;
+  output: Array4D;
+  gradient: (dy: Array4D, y: Array4D) => {
+    dy: () => Array4D;
+    filter: () => Array4D;
   };
 }
 
 export interface Conv2DDerFilterNode extends KernelNode {
   inputAndArgs: {
-    inputs: {x: Array4D; dy: Array4D<'float32'>;};
+    inputs: {x: Array4D; dy: Array4D;};
     args: {convInfo: Conv2DInfo;};
   };
-  output: Array4D<'float32'>;
-  gradient: (dy: Array4D<'float32'>, y: Array4D<'float32'>) => {
-    x: () => Array4D<'float32'>;
-    dy: () => Array4D<'float32'>;
+  output: Array4D;
+  gradient: (dy: Array4D, y: Array4D) => {
+    x: () => Array4D;
+    dy: () => Array4D;
   };
 }
 
 export interface Conv2DDerBiasNode extends KernelNode {
   inputAndArgs: {inputs: {dy: Array4D;};};
-  output: Array1D<'float32'>;
-  gradient: (dy: Array1D<'float32'>, y: Array1D<'float32'>) => {
-    dy: () => Array4D<'float32'>;
+  output: Array1D;
+  gradient: (dy: Array1D, y: Array1D) => {
+    dy: () => Array4D;
   };
 }
 
@@ -68,8 +68,8 @@ export interface DepthwiseConv2DNode extends KernelNode {
   inputAndArgs:
       {inputs: {x: Array4D; filter: Array4D;}; args: {convInfo: Conv2DInfo;};};
   output: Array4D;
-  gradient: (dy: Array4D<'float32'>, y: Array4D) => {
-    x: () => Array4D<'float32'>;
-    filter: () => Array4D<'float32'>;
+  gradient: (dy: Array4D, y: Array4D) => {
+    x: () => Array4D;
+    filter: () => Array4D;
   };
 }

--- a/src/math/backends/types/gather.ts
+++ b/src/math/backends/types/gather.ts
@@ -16,17 +16,15 @@
  */
 
 import {Array1D, NDArray} from '../../ndarray';
-import {DataType, Rank} from '../../types';
+import {Rank} from '../../types';
 import {KernelNode} from '../tape_types';
 
-export interface GatherNode<D extends DataType, R extends Rank, T extends
-                                NDArray<D, R> = NDArray<D, R>> extends
-    KernelNode {
-  inputAndArgs:
-      {inputs: {x: T; indices: Array1D<'int32'>;}; args: {axis: number};};
+export interface GatherNode<R extends Rank, T extends NDArray<R> = NDArray<R>>
+    extends KernelNode {
+  inputAndArgs: {inputs: {x: T; indices: Array1D;}; args: {axis: number};};
   output: T;
-  gradient: (dy: NDArray<'float32', R>, y: T) => {
-    x: () => NDArray<'float32', R>;
-    indices: () => Array1D<'float32'>;
+  gradient: (dy: NDArray<R>, y: T) => {
+    x: () => NDArray<R>;
+    indices: () => Array1D;
   };
 }

--- a/src/math/backends/types/logical.ts
+++ b/src/math/backends/types/logical.ts
@@ -22,20 +22,20 @@ import {KernelNode} from '../tape_types';
 // Equal/NotEqual/Less/LessEqual/Greater/GreaterEqual
 export interface EqualNode extends KernelNode {
   inputAndArgs: {inputs: {a: NDArray; b: NDArray;};};
-  output: NDArray<'bool'>;
-  gradient: (dy: NDArray<'float32'>, y: NDArray<'bool'>) => {
-    a: () => NDArray<'float32'>;
-    b: () => NDArray<'float32'>;
+  output: NDArray;
+  gradient: (dy: NDArray, y: NDArray) => {
+    a: () => NDArray;
+    b: () => NDArray;
   };
 }
 
 // LogicalAnd/LogicalOr
 export interface LogicalNode extends KernelNode {
   inputAndArgs: {inputs: {a: NDArray; b: NDArray;};};
-  output: NDArray<'bool'>;
-  gradient: (dy: NDArray<'float32'>, y: NDArray<'bool'>) => {
-    a: () => NDArray<'float32'>;
-    b: () => NDArray<'float32'>;
+  output: NDArray;
+  gradient: (dy: NDArray, y: NDArray) => {
+    a: () => NDArray;
+    b: () => NDArray;
   };
 }
 
@@ -46,9 +46,9 @@ export interface WhereNode extends KernelNode {
     args: {dtype: DataType};
   };
   output: NDArray;
-  gradient: (dy: NDArray<'float32'>, y: NDArray) => {
-    condition: () => NDArray<'float32'>;
-    a: () => NDArray<'float32'>;
-    b: () => NDArray<'float32'>;
+  gradient: (dy: NDArray, y: NDArray) => {
+    condition: () => NDArray;
+    a: () => NDArray;
+    b: () => NDArray;
   };
 }

--- a/src/math/backends/types/lrn.ts
+++ b/src/math/backends/types/lrn.ts
@@ -31,7 +31,7 @@ export interface LRN4DNode extends KernelNode {
     };
   };
   output: Array4D;
-  gradient: (dy: Array4D<'float32'>, y: Array4D) => {
-    x: () => Array4D<'float32'>;
+  gradient: (dy: Array4D, y: Array4D) => {
+    x: () => Array4D;
   };
 }

--- a/src/math/backends/types/matmul.ts
+++ b/src/math/backends/types/matmul.ts
@@ -24,9 +24,9 @@ export interface MatMulNode extends KernelNode {
     args: {aOrientation: MatrixOrientation; bOrientation: MatrixOrientation};
   };
   output: Array2D;
-  gradient: (dy: Array2D<'float32'>, y: Array2D) => {
-    a: () => Array2D<'float32'>;
-    b: () => Array2D<'float32'>;
+  gradient: (dy: Array2D, y: Array2D) => {
+    a: () => Array2D;
+    b: () => Array2D;
   };
 }
 

--- a/src/math/backends/types/minmax.ts
+++ b/src/math/backends/types/minmax.ts
@@ -16,41 +16,40 @@
  */
 
 import {NDArray} from '../../ndarray';
-import {DataType} from '../../types';
 import {KernelNode} from '../tape_types';
 
 // Reduction min.
-export interface MinNode<D extends DataType> extends KernelNode {
-  inputAndArgs: {inputs: {x: NDArray<D>;}; args: {axes: number[]}};
-  output: NDArray<D>;
-  gradient: (dy: NDArray<'float32'>, y: NDArray<D>) => {
-    x: () => NDArray<'float32'>;
+export interface MinNode extends KernelNode {
+  inputAndArgs: {inputs: {x: NDArray;}; args: {axes: number[]}};
+  output: NDArray;
+  gradient: (dy: NDArray, y: NDArray) => {
+    x: () => NDArray;
   };
 }
 
 // Element-wise min.
-export interface MinimumNode<D extends DataType> extends KernelNode {
-  inputAndArgs: {inputs: {a: NDArray<D>, b: NDArray<D>};};
-  output: NDArray<D>;
-  gradient: (dy: NDArray<'float32'>, y: NDArray<D>) => {
-    a: () => NDArray<'float32'>, b: () => NDArray<'float32'>
+export interface MinimumNode extends KernelNode {
+  inputAndArgs: {inputs: {a: NDArray, b: NDArray};};
+  output: NDArray;
+  gradient: (dy: NDArray, y: NDArray) => {
+    a: () => NDArray, b: () => NDArray
   };
 }
 
 // Reduction Max
-export interface MaxNode<D extends DataType> extends KernelNode {
-  inputAndArgs: {inputs: {x: NDArray<D>;}; args: {axes: number[]}};
-  output: NDArray<D>;
-  gradient: (dy: NDArray<'float32'>, y: NDArray<D>) => {
-    x: () => NDArray<'float32'>;
+export interface MaxNode extends KernelNode {
+  inputAndArgs: {inputs: {x: NDArray;}; args: {axes: number[]}};
+  output: NDArray;
+  gradient: (dy: NDArray, y: NDArray) => {
+    x: () => NDArray;
   };
 }
 
 // Element-wise max.
-export interface MaximumNode<D extends DataType> extends KernelNode {
-  inputAndArgs: {inputs: {a: NDArray<D>, b: NDArray<D>};};
-  output: NDArray<D>;
-  gradient: (dy: NDArray<'float32'>, y: NDArray<D>) => {
-    a: () => NDArray<'float32'>, b: () => NDArray<'float32'>
+export interface MaximumNode extends KernelNode {
+  inputAndArgs: {inputs: {a: NDArray, b: NDArray};};
+  output: NDArray;
+  gradient: (dy: NDArray, y: NDArray) => {
+    a: () => NDArray, b: () => NDArray
   };
 }

--- a/src/math/backends/types/multinomial.ts
+++ b/src/math/backends/types/multinomial.ts
@@ -22,8 +22,8 @@ import {KernelNode} from '../tape_types';
 export interface MultinomialNode extends KernelNode {
   inputAndArgs:
       {inputs: {probs: Array2D;}; args: {numSamples: number; seed: number};};
-  output: Array2D<'int32'>;
-  gradient: (dy: Array2D<'float32'>, y: Array2D<'int32'>) => {
-    probs: () => Array2D<'float32'>;
+  output: Array2D;
+  gradient: (dy: Array2D, y: Array2D) => {
+    probs: () => Array2D;
   };
 }

--- a/src/math/backends/types/onehot.ts
+++ b/src/math/backends/types/onehot.ts
@@ -24,7 +24,7 @@ export interface OneHotNode extends KernelNode {
     args: {depth: number; onValue: number; offValue: number};
   };
   output: Array2D;
-  gradient: (dy: Array2D<'float32'>, y: Array2D) => {
-    indices: () => Array1D<'float32'>;
+  gradient: (dy: Array2D, y: Array2D) => {
+    indices: () => Array1D;
   };
 }

--- a/src/math/backends/types/pad.ts
+++ b/src/math/backends/types/pad.ts
@@ -24,8 +24,8 @@ export interface Pad1DNode extends KernelNode {
     args: {paddings: [number, number], constantValue: number};
   };
   output: Array1D;
-  gradient: (dy: Array1D<'float32'>, y: Array1D) => {
-    x: () => Array1D<'float32'>;
+  gradient: (dy: Array1D, y: Array1D) => {
+    x: () => Array1D;
   };
 }
 
@@ -37,7 +37,7 @@ export interface Pad2DNode extends KernelNode {
     };
   };
   output: Array2D;
-  gradient: (dy: Array2D<'float32'>, y: Array2D) => {
-    x: () => Array2D<'float32'>;
+  gradient: (dy: Array2D, y: Array2D) => {
+    x: () => Array2D;
   };
 }

--- a/src/math/backends/types/pool.ts
+++ b/src/math/backends/types/pool.ts
@@ -23,8 +23,8 @@ import {KernelNode} from '../tape_types';
 export interface PoolNode extends KernelNode {
   inputAndArgs: {inputs: {x: Array4D;}; args: {convInfo: Conv2DInfo;};};
   output: Array4D;
-  gradient: (dy: Array4D<'float32'>, y: Array4D) => {
-    x: () => Array4D<'float32'>;
+  gradient: (dy: Array4D, y: Array4D) => {
+    x: () => Array4D;
   };
 }
 
@@ -33,8 +33,8 @@ export interface PoolBackpropNode extends KernelNode {
   inputAndArgs:
       {inputs: {dy: Array4D; x: Array4D;}; args: {convInfo: Conv2DInfo;};};
   output: Array4D;
-  gradient: (dy: Array4D<'float32'>, y: Array4D) => {
-    dy: () => Array4D<'float32'>;
-    x: () => Array4D<'float32'>;
+  gradient: (dy: Array4D, y: Array4D) => {
+    dy: () => Array4D;
+    x: () => Array4D;
   };
 }

--- a/src/math/backends/types/pow.ts
+++ b/src/math/backends/types/pow.ts
@@ -16,15 +16,15 @@
  */
 
 import {NDArray} from '../../ndarray';
-import {DataType, Rank} from '../../types';
+import {Rank} from '../../types';
 import {KernelNode} from '../tape_types';
 
-export interface PowNode<D extends DataType, R extends Rank, T extends
-                             NDArray<D, R> = NDArray<D, R>> extends KernelNode {
-  inputAndArgs: {inputs: {base: T; exp: NDArray<'int32'>;};};
+export interface PowNode<R extends Rank, T extends NDArray<R> = NDArray<R>>
+    extends KernelNode {
+  inputAndArgs: {inputs: {base: T; exp: NDArray;};};
   output: T;
-  gradient: (dy: NDArray<'float32', R>, y: T) => {
-    base: () => NDArray<'float32', R>;
-    exp: () => NDArray<'float32'>;
+  gradient: (dy: NDArray<R>, y: T) => {
+    base: () => NDArray<R>;
+    exp: () => NDArray;
   };
 }

--- a/src/math/backends/types/prelu.ts
+++ b/src/math/backends/types/prelu.ts
@@ -16,17 +16,16 @@
  */
 
 import {NDArray} from '../../ndarray';
-import {DataType, Rank} from '../../types';
+import {Rank} from '../../types';
 import {KernelNode} from '../tape_types';
 
 // PReLU
-export interface PReLUNode<D extends DataType, R extends Rank, T extends
-                               NDArray<D, R> = NDArray<D, R>> extends
-    KernelNode {
+export interface PReLUNode<R extends Rank, T extends NDArray<R> = NDArray<R>>
+    extends KernelNode {
   inputAndArgs: {inputs: {x: T; alpha: T;};};
   output: T;
-  gradient: (dy: NDArray<'float32', R>, y: T) => {
-    x: () => NDArray<'float32', R>;
-    alpha: () => NDArray<'float32', R>;
+  gradient: (dy: NDArray<R>, y: T) => {
+    x: () => NDArray<R>;
+    alpha: () => NDArray<R>;
   };
 }

--- a/src/math/backends/types/reshape.ts
+++ b/src/math/backends/types/reshape.ts
@@ -21,7 +21,7 @@ import {KernelNode} from '../tape_types';
 export interface ReshapeNode extends KernelNode {
   inputAndArgs: {inputs: {x: NDArray}; args: {newShape: number[]};};
   output: NDArray;
-  gradient: (dy: NDArray<'float32'>, y: NDArray) => {
-    x: () => NDArray<'float32'>
+  gradient: (dy: NDArray, y: NDArray) => {
+    x: () => NDArray
   };
 }

--- a/src/math/backends/types/resize_bilinear.ts
+++ b/src/math/backends/types/resize_bilinear.ts
@@ -24,7 +24,7 @@ export interface ResizeBilinear3DNode extends KernelNode {
     args: {newShape2D: [number, number]; alignCorners: boolean};
   };
   output: Array3D;
-  gradient: (dy: Array3D<'float32'>, y: Array3D) => {
-    x: () => Array3D<'float32'>;
+  gradient: (dy: Array3D, y: Array3D) => {
+    x: () => Array3D;
   };
 }

--- a/src/math/backends/types/reverse.ts
+++ b/src/math/backends/types/reverse.ts
@@ -21,7 +21,7 @@ import {KernelNode} from '../tape_types';
 export interface Reverse4DNode extends KernelNode {
   inputAndArgs: {inputs: {x: Array4D;}; args: {axis: number[];};};
   output: Array4D;
-  gradient: (dy: Array4D<'float32'>, y: Array4D) => {
-    x: () => Array4D<'float32'>;
+  gradient: (dy: Array4D, y: Array4D) => {
+    x: () => Array4D;
   };
 }

--- a/src/math/backends/types/slice.ts
+++ b/src/math/backends/types/slice.ts
@@ -16,49 +16,47 @@
  */
 
 import {Array1D, Array2D, Array3D, Array4D} from '../../ndarray';
-import {DataType} from '../../types';
 import {KernelNode} from '../tape_types';
 
-export interface Slice1DNode<D extends DataType> extends KernelNode {
-  inputAndArgs:
-      {inputs: {x: Array1D<D>;}; args: {begin: number; size: number;};};
-  output: Array1D<D>;
-  gradient: (dy: Array1D<'float32'>, y: Array1D<D>) => {
-    x: () => Array1D<'float32'>;
+export interface Slice1DNode extends KernelNode {
+  inputAndArgs: {inputs: {x: Array1D;}; args: {begin: number; size: number;};};
+  output: Array1D;
+  gradient: (dy: Array1D, y: Array1D) => {
+    x: () => Array1D;
   };
 }
 
-export interface Slice2DNode<D extends DataType> extends KernelNode {
+export interface Slice2DNode extends KernelNode {
   inputAndArgs: {
-    inputs: {x: Array2D<D>;};
+    inputs: {x: Array2D;};
     args: {begin: [number, number]; size: [number, number];};
   };
-  output: Array2D<D>;
-  gradient: (dy: Array2D<'float32'>, y: Array2D<D>) => {
-    x: () => Array2D<'float32'>;
+  output: Array2D;
+  gradient: (dy: Array2D, y: Array2D) => {
+    x: () => Array2D;
   };
 }
 
-export interface Slice3DNode<D extends DataType> extends KernelNode {
+export interface Slice3DNode extends KernelNode {
   inputAndArgs: {
-    inputs: {x: Array3D<D>;};
+    inputs: {x: Array3D;};
     args: {begin: [number, number, number]; size: [number, number, number];};
   };
-  output: Array3D<D>;
-  gradient: (dy: Array3D<'float32'>, y: Array3D<D>) => {
-    x: () => Array3D<'float32'>;
+  output: Array3D;
+  gradient: (dy: Array3D, y: Array3D) => {
+    x: () => Array3D;
   };
 }
 
-export interface Slice4DNode<D extends DataType> extends KernelNode {
+export interface Slice4DNode extends KernelNode {
   inputAndArgs: {
-    inputs: {x: Array4D<D>;}; args: {
+    inputs: {x: Array4D;}; args: {
       begin: [number, number, number, number];
       size: [number, number, number, number];
     };
   };
-  output: Array4D<D>;
-  gradient: (dy: Array4D<'float32'>, y: Array4D<D>) => {
-    x: () => Array4D<'float32'>;
+  output: Array4D;
+  gradient: (dy: Array4D, y: Array4D) => {
+    x: () => Array4D;
   };
 }

--- a/src/math/backends/types/sum.ts
+++ b/src/math/backends/types/sum.ts
@@ -16,13 +16,12 @@
  */
 
 import {NDArray} from '../../ndarray';
-import {DataType, SumTypes} from '../../types';
 import {KernelNode} from '../tape_types';
 
 export interface SumNode extends KernelNode {
   inputAndArgs: {inputs: {x: NDArray;}; args: {axes: number[];};};
-  output: NDArray<SumTypes[D]>;
-  gradient: (dy: NDArray, y: NDArray<SumTypes[D]>) => {
+  output: NDArray;
+  gradient: (dy: NDArray, y: NDArray) => {
     x: () => NDArray;
   };
 }

--- a/src/math/backends/types/sum.ts
+++ b/src/math/backends/types/sum.ts
@@ -19,10 +19,10 @@ import {NDArray} from '../../ndarray';
 import {DataType, SumTypes} from '../../types';
 import {KernelNode} from '../tape_types';
 
-export interface SumNode<D extends DataType> extends KernelNode {
-  inputAndArgs: {inputs: {x: NDArray<D>;}; args: {axes: number[];};};
+export interface SumNode extends KernelNode {
+  inputAndArgs: {inputs: {x: NDArray;}; args: {axes: number[];};};
   output: NDArray<SumTypes[D]>;
-  gradient: (dy: NDArray<'float32'>, y: NDArray<SumTypes[D]>) => {
-    x: () => NDArray<'float32'>;
+  gradient: (dy: NDArray, y: NDArray<SumTypes[D]>) => {
+    x: () => NDArray;
   };
 }

--- a/src/math/backends/types/topk.ts
+++ b/src/math/backends/types/topk.ts
@@ -25,7 +25,7 @@ export interface TopKValuesNode<
   inputAndArgs: {inputs: {x: T;}; args: {k: number};};
   output: Array1D;
   gradient: (dy: Array1D, y: Array1D) => {
-    x: () => NDArray<R>;
+    x: () => T;
   };
 }
 

--- a/src/math/backends/types/topk.ts
+++ b/src/math/backends/types/topk.ts
@@ -16,25 +16,24 @@
  */
 
 import {Array1D, NDArray} from '../../ndarray';
-import {DataType, Rank} from '../../types';
+import {Rank} from '../../types';
 import {KernelNode} from '../tape_types';
 
 // Values
-export interface TopKValuesNode<D extends DataType, R extends Rank, T extends
-                                    NDArray<D, R> = NDArray<D, R>> extends
-    KernelNode {
+export interface TopKValuesNode<
+    R extends Rank, T extends NDArray<R> = NDArray<R>> extends KernelNode {
   inputAndArgs: {inputs: {x: T;}; args: {k: number};};
-  output: Array1D<D>;
-  gradient: (dy: Array1D<'float32'>, y: Array1D<D>) => {
-    x: () => NDArray<'float32', R>;
+  output: Array1D;
+  gradient: (dy: Array1D, y: Array1D) => {
+    x: () => NDArray<R>;
   };
 }
 
 // Indices
 export interface TopKIndicesNode extends KernelNode {
   inputAndArgs: {inputs: {x: NDArray;}; args: {k: number};};
-  output: Array1D<'int32'>;
-  gradient: (dy: Array1D<'float32'>, y: Array1D<'int32'>) => {
-    x: () => NDArray<'float32'>;
+  output: Array1D;
+  gradient: (dy: Array1D, y: Array1D) => {
+    x: () => NDArray;
   };
 }

--- a/src/math/backends/types/unary.ts
+++ b/src/math/backends/types/unary.ts
@@ -16,64 +16,58 @@
  */
 
 import {NDArray} from '../../ndarray';
-import {DataType, Rank} from '../../types';
+import {Rank} from '../../types';
 import {KernelNode} from '../tape_types';
 
-export interface UnaryNode<D extends DataType, R extends Rank, T extends
-                               NDArray<D, R> = NDArray<D, R>> extends
-    KernelNode {
+export interface UnaryNode<R extends Rank, T extends NDArray<R> = NDArray<R>>
+    extends KernelNode {
   inputAndArgs: {inputs: {x: T;};};
   output: T;
-  gradient: (dy: NDArray<'float32', R>, y: T) => {
-    x: () => NDArray<'float32', R>;
+  gradient: (dy: NDArray<R>, y: T) => {
+    x: () => NDArray<R>;
   };
 }
 
-export interface LeakyReluNode<D extends DataType, R extends Rank, T extends
-                                   NDArray<D, R> = NDArray<D, R>> extends
-    KernelNode {
+export interface LeakyReluNode<
+    R extends Rank, T extends NDArray<R> = NDArray<R>> extends KernelNode {
   inputAndArgs: {inputs: {x: T;}; args: {alpha: number;};};
   output: T;
-  gradient: (dy: NDArray<'float32', R>, y: T) => {
-    x: () => NDArray<'float32', R>;
+  gradient: (dy: NDArray<R>, y: T) => {
+    x: () => NDArray<R>;
   };
 }
-export interface StepNode<D extends DataType, R extends Rank, T extends
-                              NDArray<D, R> = NDArray<D, R>> extends
-    KernelNode {
+export interface StepNode<R extends Rank, T extends NDArray<R> = NDArray<R>>
+    extends KernelNode {
   inputAndArgs: {inputs: {x: T;}; args: {alpha: number;};};
   output: T;
-  gradient: (dy: NDArray<'float32', R>, y: T) => {
-    x: () => NDArray<'float32', R>;
+  gradient: (dy: NDArray<R>, y: T) => {
+    x: () => NDArray<R>;
   };
 }
 
-export interface ClipNode<D extends DataType, R extends Rank, T extends
-                              NDArray<D, R> = NDArray<D, R>> extends
-    KernelNode {
+export interface ClipNode<R extends Rank, T extends NDArray<R> = NDArray<R>>
+    extends KernelNode {
   inputAndArgs: {inputs: {x: T;}; args: {min: number; max: number;};};
   output: T;
-  gradient: (dy: NDArray<'float32', R>, y: T) => {
-    x: () => NDArray<'float32', R>;
+  gradient: (dy: NDArray<R>, y: T) => {
+    x: () => NDArray<R>;
   };
 }
 
-export interface TransposeNode<D extends DataType, R extends Rank, T extends
-                                   NDArray<D, R> = NDArray<D, R>> extends
-    KernelNode {
+export interface TransposeNode<
+    R extends Rank, T extends NDArray<R> = NDArray<R>> extends KernelNode {
   inputAndArgs: {inputs: {x: T;}; args: {perm: number[];};};
   output: T;
-  gradient: (dy: NDArray<'float32', R>, y: T) => {
-    x: () => NDArray<'float32', R>;
+  gradient: (dy: NDArray<R>, y: T) => {
+    x: () => NDArray<R>;
   };
 }
 
-export interface TileNode<D extends DataType, R extends Rank, T extends
-                              NDArray<D, R> = NDArray<D, R>> extends
-    KernelNode {
+export interface TileNode<R extends Rank, T extends NDArray<R> = NDArray<R>>
+    extends KernelNode {
   inputAndArgs: {inputs: {x: T;}; args: {reps: number[];};};
   output: T;
-  gradient: (dy: NDArray<'float32', R>, y: T) => {
-    x: () => NDArray<'float32', R>;
+  gradient: (dy: NDArray<R>, y: T) => {
+    x: () => NDArray<R>;
   };
 }

--- a/src/math/backends/types/unary.ts
+++ b/src/math/backends/types/unary.ts
@@ -23,8 +23,8 @@ export interface UnaryNode<R extends Rank, T extends NDArray<R> = NDArray<R>>
     extends KernelNode {
   inputAndArgs: {inputs: {x: T;};};
   output: T;
-  gradient: (dy: NDArray<R>, y: T) => {
-    x: () => NDArray<R>;
+  gradient: (dy: T, y: T) => {
+    x: () => T;
   };
 }
 
@@ -32,16 +32,16 @@ export interface LeakyReluNode<
     R extends Rank, T extends NDArray<R> = NDArray<R>> extends KernelNode {
   inputAndArgs: {inputs: {x: T;}; args: {alpha: number;};};
   output: T;
-  gradient: (dy: NDArray<R>, y: T) => {
-    x: () => NDArray<R>;
+  gradient: (dy: T, y: T) => {
+    x: () => T;
   };
 }
 export interface StepNode<R extends Rank, T extends NDArray<R> = NDArray<R>>
     extends KernelNode {
   inputAndArgs: {inputs: {x: T;}; args: {alpha: number;};};
   output: T;
-  gradient: (dy: NDArray<R>, y: T) => {
-    x: () => NDArray<R>;
+  gradient: (dy: T, y: T) => {
+    x: () => T;
   };
 }
 
@@ -49,8 +49,8 @@ export interface ClipNode<R extends Rank, T extends NDArray<R> = NDArray<R>>
     extends KernelNode {
   inputAndArgs: {inputs: {x: T;}; args: {min: number; max: number;};};
   output: T;
-  gradient: (dy: NDArray<R>, y: T) => {
-    x: () => NDArray<R>;
+  gradient: (dy: T, y: T) => {
+    x: () => T;
   };
 }
 
@@ -58,8 +58,8 @@ export interface TransposeNode<
     R extends Rank, T extends NDArray<R> = NDArray<R>> extends KernelNode {
   inputAndArgs: {inputs: {x: T;}; args: {perm: number[];};};
   output: T;
-  gradient: (dy: NDArray<R>, y: T) => {
-    x: () => NDArray<R>;
+  gradient: (dy: T, y: T) => {
+    x: () => T;
   };
 }
 
@@ -67,7 +67,7 @@ export interface TileNode<R extends Rank, T extends NDArray<R> = NDArray<R>>
     extends KernelNode {
   inputAndArgs: {inputs: {x: T;}; args: {reps: number[];};};
   output: T;
-  gradient: (dy: NDArray<R>, y: T) => {
-    x: () => NDArray<R>;
+  gradient: (dy: T, y: T) => {
+    x: () => T;
   };
 }

--- a/src/math/batchnorm.ts
+++ b/src/math/batchnorm.ts
@@ -20,7 +20,7 @@ import * as util from '../util';
 
 import {operation} from './decorators';
 import {Array1D, Array2D, Array3D, Array4D, NDArray} from './ndarray';
-import {DataType, Rank} from './types';
+import {Rank} from './types';
 
 export class Ops {
   /**

--- a/src/math/batchnorm.ts
+++ b/src/math/batchnorm.ts
@@ -36,10 +36,10 @@ export class Ops {
    * @param offset An offset NDArray.
    */
   @operation
-  static batchNormalization2D<D extends DataType>(
-      x: Array2D<D>, mean: Array2D<D>|Array1D<D>,
-      variance: Array2D<D>|Array1D<D>, varianceEpsilon = .001,
-      scale?: Array2D|Array1D, offset?: Array2D<D>|Array1D<D>): Array2D<D> {
+  static batchNormalization2D(
+      x: Array2D, mean: Array2D|Array1D, variance: Array2D|Array1D,
+      varianceEpsilon = .001, scale?: Array2D|Array1D,
+      offset?: Array2D|Array1D): Array2D {
     util.assert(
         x.rank === 2,
         `Error in batchNormalization3D: x must be rank 3 but got rank ` +
@@ -68,7 +68,7 @@ export class Ops {
     return ENV.engine.executeKernel('BatchNorm2D', {
       inputs: {x, mean, variance, scale, offset},
       args: {varianceEpsilon}
-    }) as Array2D<D>;
+    }) as Array2D;
   }
 
   /**
@@ -84,11 +84,10 @@ export class Ops {
    * @param offset An offset NDArray.
    */
   @operation
-  static batchNormalization3D<D extends DataType>(
-      x: Array3D<D>, mean: Array3D<D>|Array1D<D>,
-      variance: Array3D<D>|Array1D<D>, varianceEpsilon = .001,
-      scale?: Array3D<D>|Array1D<D>,
-      offset?: Array3D<D>|Array1D<D>): Array3D<D> {
+  static batchNormalization3D(
+      x: Array3D, mean: Array3D|Array1D, variance: Array3D|Array1D,
+      varianceEpsilon = .001, scale?: Array3D|Array1D,
+      offset?: Array3D|Array1D): Array3D {
     util.assert(
         x.rank === 3,
         `Error in batchNormalization3D: x must be rank 3 but got rank ` +
@@ -117,7 +116,7 @@ export class Ops {
     return ENV.engine.executeKernel('BatchNorm3D', {
       inputs: {x, mean, variance, scale, offset},
       args: {varianceEpsilon}
-    }) as Array3D<D>;
+    }) as Array3D;
   }
 
   /**
@@ -133,11 +132,10 @@ export class Ops {
    * @param offset An offset NDArray.
    */
   @operation
-  static batchNormalization4D<D extends DataType>(
-      x: Array4D<D>, mean: Array4D<D>|Array1D<D>,
-      variance: Array4D<D>|Array1D<D>, varianceEpsilon = .001,
-      scale?: Array4D<D>|Array1D<D>,
-      offset?: Array4D<D>|Array1D<D>): Array4D<D> {
+  static batchNormalization4D(
+      x: Array4D, mean: Array4D|Array1D, variance: Array4D|Array1D,
+      varianceEpsilon = .001, scale?: Array4D|Array1D,
+      offset?: Array4D|Array1D): Array4D {
     util.assert(
         x.rank === 4,
         `Error in batchNormalization4D: x must be rank 4 but got rank ` +
@@ -166,36 +164,35 @@ export class Ops {
     return ENV.engine.executeKernel('BatchNorm4D', {
       inputs: {x, mean, variance, scale, offset},
       args: {varianceEpsilon}
-    }) as Array4D<D>;
+    }) as Array4D;
   }
 
-  static batchNormalization<D extends DataType, R extends Rank>(
-      x: NDArray<D, R>, mean: NDArray<D, R>|Array1D,
-      variance: NDArray<D, R>|Array1D, varianceEpsilon = .001,
-      scale?: NDArray<D, R>|Array1D,
-      offset?: NDArray<D, R>|Array1D): NDArray<D, R> {
+  static batchNormalization<R extends Rank>(
+      x: NDArray<R>, mean: NDArray<R>|Array1D, variance: NDArray<R>|Array1D,
+      varianceEpsilon = .001, scale?: NDArray<R>|Array1D,
+      offset?: NDArray<R>|Array1D): NDArray<R> {
     if (x.rank === 0) {
       throw new Error(`Batchnorm for scalar is not supported`);
     } else if (x.rank === 1) {
       throw new Error(`Batchnorm for rank 1 is not yet implemented`);
     } else if (x.rank === 2) {
       return Ops.batchNormalization2D(
-                 x as Array2D<D>, mean as Array2D<D>| Array1D<D>,
-                 variance as Array2D<D>| Array1D<D>, varianceEpsilon,
-                 scale as Array2D<D>| Array1D<D>,
-                 offset as Array2D<D>| Array1D<D>) as NDArray<D, R>;
+                 x as Array2D, mean as Array2D | Array1D,
+                 variance as Array2D | Array1D, varianceEpsilon,
+                 scale as Array2D | Array1D, offset as Array2D | Array1D) as
+          NDArray<R>;
     } else if (x.rank === 3) {
       return Ops.batchNormalization3D(
-                 x as Array3D<D>, mean as Array3D<D>| Array1D<D>,
-                 variance as Array3D<D>| Array1D<D>, varianceEpsilon,
-                 scale as Array3D<D>| Array1D<D>,
-                 offset as Array3D<D>| Array1D<D>) as NDArray<D, R>;
+                 x as Array3D, mean as Array3D | Array1D,
+                 variance as Array3D | Array1D, varianceEpsilon,
+                 scale as Array3D | Array1D, offset as Array3D | Array1D) as
+          NDArray<R>;
     } else if (x.rank === 4) {
       return Ops.batchNormalization4D(
-                 x as Array4D<D>, mean as Array4D<D>| Array1D<D>,
-                 variance as Array4D<D>| Array1D<D>, varianceEpsilon,
-                 scale as Array4D<D>| Array1D<D>,
-                 offset as Array4D<D>| Array1D<D>) as NDArray<D, R>;
+                 x as Array4D, mean as Array4D | Array1D,
+                 variance as Array4D | Array1D, varianceEpsilon,
+                 scale as Array4D | Array1D, offset as Array4D | Array1D) as
+          NDArray<R>;
     } else {
       throw new Error(`Batchnorm for rank ${x.rank} is not yet implemented`);
     }

--- a/src/math/batchnorm.ts
+++ b/src/math/batchnorm.ts
@@ -20,7 +20,7 @@ import * as util from '../util';
 
 import {operation} from './decorators';
 import {Array1D, Array2D, Array3D, Array4D, NDArray} from './ndarray';
-import {DataType, Rank, RankMap} from './types';
+import {DataType, Rank} from './types';
 
 export class Ops {
   /**
@@ -170,29 +170,32 @@ export class Ops {
   }
 
   static batchNormalization<D extends DataType, R extends Rank>(
-      x: NDArray<D, R>, mean: RankMap<D>[R]|Array1D,
-      variance: RankMap<D>[R]|Array1D, varianceEpsilon = .001,
-      scale?: RankMap<D>[R]|Array1D,
-      offset?: RankMap<D>[R]|Array1D): RankMap<D>[R] {
+      x: NDArray<D, R>, mean: NDArray<D, R>|Array1D,
+      variance: NDArray<D, R>|Array1D, varianceEpsilon = .001,
+      scale?: NDArray<D, R>|Array1D,
+      offset?: NDArray<D, R>|Array1D): NDArray<D, R> {
     if (x.rank === 0) {
       throw new Error(`Batchnorm for scalar is not supported`);
     } else if (x.rank === 1) {
       throw new Error(`Batchnorm for rank 1 is not yet implemented`);
     } else if (x.rank === 2) {
       return Ops.batchNormalization2D(
-          x as Array2D<D>, mean as Array2D<D>| Array1D<D>,
-          variance as Array2D<D>| Array1D<D>, varianceEpsilon,
-          scale as Array2D<D>| Array1D<D>, offset as Array2D<D>| Array1D<D>);
+                 x as Array2D<D>, mean as Array2D<D>| Array1D<D>,
+                 variance as Array2D<D>| Array1D<D>, varianceEpsilon,
+                 scale as Array2D<D>| Array1D<D>,
+                 offset as Array2D<D>| Array1D<D>) as NDArray<D, R>;
     } else if (x.rank === 3) {
       return Ops.batchNormalization3D(
-          x as Array3D<D>, mean as Array3D<D>| Array1D<D>,
-          variance as Array3D<D>| Array1D<D>, varianceEpsilon,
-          scale as Array3D<D>| Array1D<D>, offset as Array3D<D>| Array1D<D>);
+                 x as Array3D<D>, mean as Array3D<D>| Array1D<D>,
+                 variance as Array3D<D>| Array1D<D>, varianceEpsilon,
+                 scale as Array3D<D>| Array1D<D>,
+                 offset as Array3D<D>| Array1D<D>) as NDArray<D, R>;
     } else if (x.rank === 4) {
       return Ops.batchNormalization4D(
-          x as Array4D<D>, mean as Array4D<D>| Array1D<D>,
-          variance as Array4D<D>| Array1D<D>, varianceEpsilon,
-          scale as Array4D<D>| Array1D<D>, offset as Array4D<D>| Array1D<D>);
+                 x as Array4D<D>, mean as Array4D<D>| Array1D<D>,
+                 variance as Array4D<D>| Array1D<D>, varianceEpsilon,
+                 scale as Array4D<D>| Array1D<D>,
+                 offset as Array4D<D>| Array1D<D>) as NDArray<D, R>;
     } else {
       throw new Error(`Batchnorm for rank ${x.rank} is not yet implemented`);
     }

--- a/src/math/binary_ops.ts
+++ b/src/math/binary_ops.ts
@@ -80,7 +80,7 @@ export class Ops {
    * @param b The second `NDArray`. Must have the same dtype as `a`.
    */
   @operation
-  static sub<T extends NDArray<D1>>(a: NDArray<R>, b: NDArray<D2>): T {
+  static sub<T extends NDArray>(a: NDArray, b: NDArray): T {
     util.assertTypesMatch(a, b);
     const outShape =
         broadcast_util.assertAndGetBroadcastShape(a.shape, b.shape);
@@ -181,7 +181,7 @@ export class Ops {
    * @param b The second `NDArray`. Must have the same dtype as `a`.
    */
   @operation
-  static mul<T extends NDArray<D1>>(a: NDArray<R>, b: NDArray<D2>): T {
+  static mul<T extends NDArray>(a: NDArray, b: NDArray): T {
     util.assertTypesMatch(a, b);
     const outShape =
         broadcast_util.assertAndGetBroadcastShape(a.shape, b.shape);
@@ -289,7 +289,7 @@ export class Ops {
 
   /** @deprecated Use div(A, c) instead. */
   @operation
-  static arrayDividedByScalar(a: T, c: Scalar): T {
+  static arrayDividedByScalar<T extends NDArray>(a: T, c: Scalar): T {
     util.assert(
         c.size === 1,
         `Error in arrayDividedByScalar: second argument must be rank 0, ` +
@@ -305,7 +305,7 @@ export class Ops {
    * @param b The second ndarray. Must have the same type as `a`.
    */
   @operation
-  static minimum<T extends NDArray<D1>>(a: NDArray<R>, b: NDArray<D2>): T {
+  static minimum<T extends NDArray>(a: NDArray, b: NDArray): T {
     util.assertTypesMatch(a, b);
     broadcast_util.assertAndGetBroadcastShape(a.shape, b.shape);
     return ENV.engine.executeKernel('Minimum', {inputs: {a, b}}) as T;
@@ -333,7 +333,7 @@ export class Ops {
    * @param b The second ndarray. Must have the same type as `a`.
    */
   @operation
-  static maximum<T extends NDArray<D1>>(a: NDArray<R>, b: NDArray<D2>): T {
+  static maximum<T extends NDArray>(a: NDArray, b: NDArray): T {
     util.assertTypesMatch(a, b);
     broadcast_util.assertAndGetBroadcastShape(a.shape, b.shape);
     return ENV.engine.executeKernel('Maximum', {inputs: {a, b}}) as T;

--- a/src/math/binary_ops.ts
+++ b/src/math/binary_ops.ts
@@ -20,7 +20,7 @@ import * as util from '../util';
 import * as broadcast_util from './broadcast_util';
 import {operation} from './decorators';
 import {NDArray, Scalar} from './ndarray';
-import {DataType, Rank, RankMap} from './types';
+import {DataType, Rank} from './types';
 
 export class Ops {
   /**
@@ -69,7 +69,7 @@ export class Ops {
 
   @operation
   static addStrict<D extends DataType, R extends Rank>(
-      a: NDArray<D, R>, b: NDArray<D, R>): RankMap<D>[R] {
+      a: NDArray<D, R>, b: NDArray<D, R>): NDArray<D, R> {
     util.assertShapesMatch(a.shape, b.shape, 'Error in addStrict: ');
     return a.add(b);
   }
@@ -119,7 +119,7 @@ export class Ops {
    */
   @operation
   static subStrict<D extends DataType, R extends Rank>(
-      a: NDArray<D, R>, b: NDArray<D, R>): RankMap<D>[R] {
+      a: NDArray<D, R>, b: NDArray<D, R>): NDArray<D, R> {
     util.assertShapesMatch(a.shape, b.shape, 'Error in subStrict: ');
     return a.sub(b);
   }
@@ -174,7 +174,7 @@ export class Ops {
    */
   @operation
   static powStrict<D extends DataType, R extends Rank>(
-      base: NDArray<D, R>, exp: NDArray<'int32'>): RankMap<D>[R] {
+      base: NDArray<D, R>, exp: NDArray<'int32'>): NDArray<D, R> {
     util.assertShapesMatch(base.shape, exp.shape, 'Error in powStrict: ');
     return base.pow(exp);
   }
@@ -220,7 +220,7 @@ export class Ops {
    */
   @operation
   static elementWiseMul<D extends DataType, R extends Rank>(
-      a: NDArray<D, R>, b: NDArray<D, R>): RankMap<D>[R] {
+      a: NDArray<D, R>, b: NDArray<D, R>): NDArray<D, R> {
     return a.mulStrict(b);
   }
 
@@ -233,9 +233,9 @@ export class Ops {
    */
   @operation
   static mulStrict<D extends DataType, R extends Rank>(
-      a: NDArray<D, R>, b: NDArray<D, R>): RankMap<D>[R] {
+      a: NDArray<D, R>, b: NDArray<D, R>): NDArray<D, R> {
     util.assertShapesMatch(a.shape, b.shape, 'Error in multiplyStrict: ');
-    return a.mul(b) as RankMap<D>[R];
+    return a.mul(b) as NDArray<D, R>;
   }
 
   /**
@@ -282,9 +282,9 @@ export class Ops {
    */
   @operation
   static divStrict<D extends DataType, R extends Rank>(
-      a: NDArray<D, R>, b: NDArray<D, R>): RankMap<D>[R] {
+      a: NDArray<D, R>, b: NDArray<D, R>): NDArray<D, R> {
     util.assertShapesMatch(a.shape, b.shape, 'Error in divideStrict: ');
-    return a.div(b) as RankMap<D>[R];
+    return a.div(b) as NDArray<D, R>;
   }
 
   /** @deprecated Use div() instead. */
@@ -331,9 +331,9 @@ export class Ops {
    */
   @operation
   static minimumStrict<D extends DataType, R extends Rank>(
-      a: NDArray<D, R>, b: NDArray<D, R>): RankMap<D>[R] {
+      a: NDArray<D, R>, b: NDArray<D, R>): NDArray<D, R> {
     util.assertShapesMatch(a.shape, b.shape, 'Error in minimumStrict: ');
-    return a.minimum(b) as RankMap<D>[R];
+    return a.minimum(b) as NDArray<D, R>;
   }
 
   /**
@@ -360,8 +360,8 @@ export class Ops {
    */
   @operation
   static maximumStrict<D extends DataType, R extends Rank>(
-      a: NDArray<D, R>, b: NDArray<D, R>): RankMap<D>[R] {
+      a: NDArray<D, R>, b: NDArray<D, R>): NDArray<D, R> {
     util.assertShapesMatch(a.shape, b.shape, 'Error in minimumStrict: ');
-    return a.maximum(b) as RankMap<D>[R];
+    return a.maximum(b) as NDArray<D, R>;
   }
 }

--- a/src/math/binary_ops.ts
+++ b/src/math/binary_ops.ts
@@ -20,7 +20,7 @@ import * as util from '../util';
 import * as broadcast_util from './broadcast_util';
 import {operation} from './decorators';
 import {NDArray, Scalar} from './ndarray';
-import {DataType, Rank} from './types';
+import {Rank} from './types';
 
 export class Ops {
   /**
@@ -31,13 +31,12 @@ export class Ops {
    * @param b The second `NDArray` to add. Must have the same type as `a`.
    */
   @operation
-  static add<D1 extends DataType, D2 extends D1, T extends NDArray<D1>>(
-      a: NDArray<D1>, b: NDArray<D2>): T {
+  static add<T extends NDArray>(a: NDArray, b: NDArray): T {
     util.assertTypesMatch(a, b);
     const outShape =
         broadcast_util.assertAndGetBroadcastShape(a.shape, b.shape);
 
-    const der = (dy: NDArray<'float32'>, y: NDArray) => {
+    const der = (dy: NDArray, y: NDArray) => {
       const derA = () => {
         let res = dy;
         const reduceAxes = broadcast_util.getReductionAxes(a.shape, outShape);
@@ -68,8 +67,7 @@ export class Ops {
    */
 
   @operation
-  static addStrict<D extends DataType, R extends Rank>(
-      a: NDArray<D, R>, b: NDArray<D, R>): NDArray<D, R> {
+  static addStrict<R extends Rank>(a: NDArray<R>, b: NDArray<R>): NDArray<R> {
     util.assertShapesMatch(a.shape, b.shape, 'Error in addStrict: ');
     return a.add(b);
   }
@@ -82,13 +80,12 @@ export class Ops {
    * @param b The second `NDArray`. Must have the same dtype as `a`.
    */
   @operation
-  static sub<D1 extends DataType, D2 extends D1, T extends NDArray<D1>>(
-      a: NDArray<D1>, b: NDArray<D2>): T {
+  static sub<T extends NDArray<D1>>(a: NDArray<R>, b: NDArray<D2>): T {
     util.assertTypesMatch(a, b);
     const outShape =
         broadcast_util.assertAndGetBroadcastShape(a.shape, b.shape);
 
-    const der = (dy: NDArray<'float32'>, y: NDArray) => {
+    const der = (dy: NDArray, y: NDArray) => {
       const derA = () => {
         let res = dy;
         const reduceAxes = broadcast_util.getReductionAxes(a.shape, outShape);
@@ -118,8 +115,7 @@ export class Ops {
    * @param b The second NDArray to multiply element-wise.
    */
   @operation
-  static subStrict<D extends DataType, R extends Rank>(
-      a: NDArray<D, R>, b: NDArray<D, R>): NDArray<D, R> {
+  static subStrict<R extends Rank>(a: NDArray<R>, b: NDArray<R>): NDArray<R> {
     util.assertShapesMatch(a.shape, b.shape, 'Error in subStrict: ');
     return a.sub(b);
   }
@@ -136,14 +132,13 @@ export class Ops {
    * @param exp The exponent NDArray to pow element-wise.
    */
   @operation
-  static pow<D extends DataType, T extends NDArray<D>>(
-      base: NDArray<D>, exp: NDArray<'int32'>): T {
+  static pow<T extends NDArray>(base: NDArray, exp: NDArray): T {
     util.assert(
         exp.dtype === 'int32',
         'only supports int32 data type for the exponent parameter.');
     broadcast_util.assertAndGetBroadcastShape(base.shape, exp.shape);
 
-    const gradient = (dy: NDArray<'float32'>, y: NDArray<D>) => {
+    const gradient = (dy: NDArray, y: NDArray) => {
       if (!util.arraysEqual(base.shape, exp.shape)) {
         throw new Error(
             `Gradient of pow not yet supported for broadcasted shapes.`);
@@ -173,8 +168,7 @@ export class Ops {
    * @param exp The exponent NDArray to pow element-wise.
    */
   @operation
-  static powStrict<D extends DataType, R extends Rank>(
-      base: NDArray<D, R>, exp: NDArray<'int32'>): NDArray<D, R> {
+  static powStrict<R extends Rank>(base: NDArray<R>, exp: NDArray): NDArray<R> {
     util.assertShapesMatch(base.shape, exp.shape, 'Error in powStrict: ');
     return base.pow(exp);
   }
@@ -187,13 +181,12 @@ export class Ops {
    * @param b The second `NDArray`. Must have the same dtype as `a`.
    */
   @operation
-  static mul<D1 extends DataType, D2 extends D1, T extends NDArray<D1>>(
-      a: NDArray<D1>, b: NDArray<D2>): T {
+  static mul<T extends NDArray<D1>>(a: NDArray<R>, b: NDArray<D2>): T {
     util.assertTypesMatch(a, b);
     const outShape =
         broadcast_util.assertAndGetBroadcastShape(a.shape, b.shape);
 
-    const der = (dy: NDArray<'float32'>, y: NDArray) => {
+    const der = (dy: NDArray, y: NDArray) => {
       const derA = () => {
         const res = dy.mul(b.asType('float32'));
         const reduceAxes = broadcast_util.getReductionAxes(a.shape, outShape);
@@ -219,8 +212,8 @@ export class Ops {
    * @deprecated Use mulStrict() instead.
    */
   @operation
-  static elementWiseMul<D extends DataType, R extends Rank>(
-      a: NDArray<D, R>, b: NDArray<D, R>): NDArray<D, R> {
+  static elementWiseMul<R extends Rank>(a: NDArray<R>, b: NDArray<R>):
+      NDArray<R> {
     return a.mulStrict(b);
   }
 
@@ -232,10 +225,9 @@ export class Ops {
    * @param b The second `NDArray`. Must have the same dtype as `a`.
    */
   @operation
-  static mulStrict<D extends DataType, R extends Rank>(
-      a: NDArray<D, R>, b: NDArray<D, R>): NDArray<D, R> {
+  static mulStrict<R extends Rank>(a: NDArray<R>, b: NDArray<R>): NDArray<R> {
     util.assertShapesMatch(a.shape, b.shape, 'Error in multiplyStrict: ');
-    return a.mul(b) as NDArray<D, R>;
+    return a.mul(b) as NDArray<R>;
   }
 
   /**
@@ -246,11 +238,10 @@ export class Ops {
    * @param b The second `NDArray`. Must have the same dtype as `a`.
    */
   @operation
-  static div<D extends DataType, T extends NDArray<'float32'>>(
-      a: NDArray<D>, b: NDArray<D>): T {
+  static div<T extends NDArray>(a: NDArray, b: NDArray): T {
     const outShape =
         broadcast_util.assertAndGetBroadcastShape(a.shape, b.shape);
-    const der = (dy: NDArray<'float32'>, y: NDArray) => {
+    const der = (dy: NDArray, y: NDArray) => {
       const derA = () => {
         const res = dy.div(b.asType('float32'));
         const reduceAxes = broadcast_util.getReductionAxes(a.shape, outShape);
@@ -266,7 +257,7 @@ export class Ops {
           res = res.sum(reduceAxes).reshape(b.shape);
         }
         const tmp = b.square() as NDArray;
-        return res.div(tmp.asType('float32')).neg() as NDArray<'float32'>;
+        return res.div(tmp.asType('float32')).neg() as NDArray;
       };
       return {a: derA, b: derB};
     };
@@ -281,10 +272,9 @@ export class Ops {
    * @param b The second NDArray to multiply element-wise.
    */
   @operation
-  static divStrict<D extends DataType, R extends Rank>(
-      a: NDArray<D, R>, b: NDArray<D, R>): NDArray<D, R> {
+  static divStrict<R extends Rank>(a: NDArray<R>, b: NDArray<R>): NDArray<R> {
     util.assertShapesMatch(a.shape, b.shape, 'Error in divideStrict: ');
-    return a.div(b) as NDArray<D, R>;
+    return a.div(b) as NDArray<R>;
   }
 
   /** @deprecated Use div() instead. */
@@ -299,7 +289,7 @@ export class Ops {
 
   /** @deprecated Use div(A, c) instead. */
   @operation
-  static arrayDividedByScalar<T extends NDArray>(a: T, c: Scalar): T {
+  static arrayDividedByScalar(a: T, c: Scalar): T {
     util.assert(
         c.size === 1,
         `Error in arrayDividedByScalar: second argument must be rank 0, ` +
@@ -315,8 +305,7 @@ export class Ops {
    * @param b The second ndarray. Must have the same type as `a`.
    */
   @operation
-  static minimum<D1 extends DataType, D2 extends D1, T extends NDArray<D1>>(
-      a: NDArray<D1>, b: NDArray<D2>): T {
+  static minimum<T extends NDArray<D1>>(a: NDArray<R>, b: NDArray<D2>): T {
     util.assertTypesMatch(a, b);
     broadcast_util.assertAndGetBroadcastShape(a.shape, b.shape);
     return ENV.engine.executeKernel('Minimum', {inputs: {a, b}}) as T;
@@ -330,10 +319,10 @@ export class Ops {
    * @param b The second `NDArray`. Must have the same dtype as `a`.
    */
   @operation
-  static minimumStrict<D extends DataType, R extends Rank>(
-      a: NDArray<D, R>, b: NDArray<D, R>): NDArray<D, R> {
+  static minimumStrict<R extends Rank>(a: NDArray<R>, b: NDArray<R>):
+      NDArray<R> {
     util.assertShapesMatch(a.shape, b.shape, 'Error in minimumStrict: ');
-    return a.minimum(b) as NDArray<D, R>;
+    return a.minimum(b) as NDArray<R>;
   }
 
   /**
@@ -344,8 +333,7 @@ export class Ops {
    * @param b The second ndarray. Must have the same type as `a`.
    */
   @operation
-  static maximum<D1 extends DataType, D2 extends D1, T extends NDArray<D1>>(
-      a: NDArray<D1>, b: NDArray<D2>): T {
+  static maximum<T extends NDArray<D1>>(a: NDArray<R>, b: NDArray<D2>): T {
     util.assertTypesMatch(a, b);
     broadcast_util.assertAndGetBroadcastShape(a.shape, b.shape);
     return ENV.engine.executeKernel('Maximum', {inputs: {a, b}}) as T;
@@ -359,9 +347,9 @@ export class Ops {
    * @param b The second `NDArray`. Must have the same dtype as `a`.
    */
   @operation
-  static maximumStrict<D extends DataType, R extends Rank>(
-      a: NDArray<D, R>, b: NDArray<D, R>): NDArray<D, R> {
+  static maximumStrict<R extends Rank>(a: NDArray<R>, b: NDArray<R>):
+      NDArray<R> {
     util.assertShapesMatch(a.shape, b.shape, 'Error in minimumStrict: ');
-    return a.maximum(b) as NDArray<D, R>;
+    return a.maximum(b) as NDArray<R>;
   }
 }

--- a/src/math/compare.ts
+++ b/src/math/compare.ts
@@ -20,7 +20,7 @@ import * as util from '../util';
 import * as broadcast_util from './broadcast_util';
 import {operation} from './decorators';
 import {NDArray} from './ndarray';
-import {DataType, Rank} from './types';
+import {Rank} from './types';
 
 export class Ops {
   /**
@@ -31,16 +31,15 @@ export class Ops {
    * @param b The second input `NDArray`. Must have the same dtype as `a`.
    */
   @operation
-  static notEqual<D1 extends DataType, D2 extends D1, T extends
-                      NDArray<'bool'>>(a: NDArray<D1>, b: NDArray<D2>): T {
+  static notEqual<T extends NDArray>(a: NDArray, b: NDArray): T {
     util.assertTypesMatch(a, b);
     broadcast_util.assertAndGetBroadcastShape(a.shape, b.shape);
     return ENV.engine.executeKernel('NotEqual', {inputs: {a, b}}) as T;
   }
 
   @operation
-  static notEqualStrict<R extends Rank, D1 extends DataType, D2 extends D1>(
-      a: NDArray<D1, R>, b: NDArray<D2, R>): NDArray<'bool', R> {
+  static notEqualStrict<R extends Rank>(a: NDArray<R>, b: NDArray<R>):
+      NDArray<R> {
     util.assertShapesMatch(a.shape, b.shape, 'Error in notEqualStrict: ');
     return a.notEqual(b);
   }
@@ -53,16 +52,14 @@ export class Ops {
    * @param b The second input `NDArray`. Must have the same dtype as `a`.
    */
   @operation
-  static less<D1 extends DataType, D2 extends D1, T extends NDArray<'bool'>>(
-      a: NDArray<D1>, b: NDArray<D2>): T {
+  static less<T extends NDArray>(a: NDArray, b: NDArray): T {
     util.assertTypesMatch(a, b);
     broadcast_util.assertAndGetBroadcastShape(a.shape, b.shape);
     return ENV.engine.executeKernel('Less', {inputs: {a, b}}) as T;
   }
 
   @operation
-  static lessStrict<R extends Rank, D1 extends DataType, D2 extends D1>(
-      a: NDArray<D1, R>, b: NDArray<D2, R>): NDArray<'bool', R> {
+  static lessStrict<R extends Rank>(a: NDArray<R>, b: NDArray<R>): NDArray<R> {
     util.assertShapesMatch(a.shape, b.shape, 'Error in lessStrict: ');
     return a.less(b);
   }
@@ -75,16 +72,14 @@ export class Ops {
    * @param b The second input `NDArray`. Must have the same dtype as `a`.
    */
   @operation
-  static equal<D1 extends DataType, D2 extends D1, T extends NDArray<'bool'>>(
-      a: NDArray<D1>, b: NDArray<D2>): T {
+  static equal<T extends NDArray>(a: NDArray, b: NDArray): T {
     util.assertTypesMatch(a, b);
     broadcast_util.assertAndGetBroadcastShape(a.shape, b.shape);
     return ENV.engine.executeKernel('Equal', {inputs: {a, b}}) as T;
   }
 
   @operation
-  static equalStrict<R extends Rank, D1 extends DataType, D2 extends D1>(
-      a: NDArray<D1, R>, b: NDArray<D2, R>): NDArray<'bool', R> {
+  static equalStrict<R extends Rank>(a: NDArray<R>, b: NDArray<R>): NDArray<R> {
     util.assertShapesMatch(a.shape, b.shape, 'Error in equalStrict: ');
     return a.equal(b);
   }
@@ -97,16 +92,15 @@ export class Ops {
    * @param b The second input `NDArray`. Must have the same dtype as `a`.
    */
   @operation
-  static lessEqual<D1 extends DataType, D2 extends D1, T extends
-                       NDArray<'bool'>>(a: NDArray<D1>, b: NDArray<D2>): T {
+  static lessEqual<T extends NDArray>(a: NDArray, b: NDArray): T {
     util.assertTypesMatch(a, b);
     broadcast_util.assertAndGetBroadcastShape(a.shape, b.shape);
     return ENV.engine.executeKernel('LessEqual', {inputs: {a, b}}) as T;
   }
 
   @operation
-  static lessEqualStrict<R extends Rank, D1 extends DataType, D2 extends D1>(
-      a: NDArray<D1, R>, b: NDArray<D2, R>): NDArray<'bool', R> {
+  static lessEqualStrict<R extends Rank>(a: NDArray<R>, b: NDArray<R>):
+      NDArray<R> {
     util.assertShapesMatch(a.shape, b.shape, 'Error in lessEqualStrict: ');
     return a.lessEqual(b);
   }
@@ -119,16 +113,15 @@ export class Ops {
    * @param b The second input `NDArray`. Must have the same dtype as `a`.
    */
   @operation
-  static greater<D1 extends DataType, D2 extends D1, T extends NDArray<'bool'>>(
-      a: NDArray<D1>, b: NDArray<D2>): T {
+  static greater<T extends NDArray>(a: NDArray, b: NDArray): T {
     util.assertTypesMatch(a, b);
     broadcast_util.assertAndGetBroadcastShape(a.shape, b.shape);
     return ENV.engine.executeKernel('Greater', {inputs: {a, b}}) as T;
   }
 
   @operation
-  static greaterStrict<R extends Rank, D1 extends DataType, D2 extends D1>(
-      a: NDArray<D1, R>, b: NDArray<D2, R>): NDArray<'bool', R> {
+  static greaterStrict<R extends Rank>(a: NDArray<R>, b: NDArray<R>):
+      NDArray<R> {
     util.assertShapesMatch(a.shape, b.shape, 'Error in greaterStrict: ');
     return a.greater(b);
   }
@@ -141,16 +134,15 @@ export class Ops {
    * @param b The second input `NDArray`. Must have the same dtype as `a`.
    */
   @operation
-  static greaterEqual<D1 extends DataType, D2 extends D1, T extends
-                          NDArray<'bool'>>(a: NDArray<D1>, b: NDArray<D2>): T {
+  static greaterEqual<T extends NDArray>(a: NDArray, b: NDArray): T {
     util.assertTypesMatch(a, b);
     broadcast_util.assertAndGetBroadcastShape(a.shape, b.shape);
     return ENV.engine.executeKernel('GreaterEqual', {inputs: {a, b}}) as T;
   }
 
   @operation
-  static greaterEqualStrict<R extends Rank, D1 extends DataType, D2 extends D1>(
-      a: NDArray<D1, R>, b: NDArray<D2, R>): NDArray<'bool', R> {
+  static greaterEqualStrict<R extends Rank>(a: NDArray<R>, b: NDArray<R>):
+      NDArray<R> {
     util.assertShapesMatch(a.shape, b.shape, 'Error in greaterEqualStrict: ');
     return a.greaterEqual(b);
   }

--- a/src/math/compare.ts
+++ b/src/math/compare.ts
@@ -20,7 +20,7 @@ import * as util from '../util';
 import * as broadcast_util from './broadcast_util';
 import {operation} from './decorators';
 import {NDArray} from './ndarray';
-import {DataType, Rank, RankMap} from './types';
+import {DataType, Rank} from './types';
 
 export class Ops {
   /**
@@ -40,7 +40,7 @@ export class Ops {
 
   @operation
   static notEqualStrict<R extends Rank, D1 extends DataType, D2 extends D1>(
-      a: NDArray<D1, R>, b: NDArray<D2, R>): RankMap<'bool'>[R] {
+      a: NDArray<D1, R>, b: NDArray<D2, R>): NDArray<'bool', R> {
     util.assertShapesMatch(a.shape, b.shape, 'Error in notEqualStrict: ');
     return a.notEqual(b);
   }
@@ -62,7 +62,7 @@ export class Ops {
 
   @operation
   static lessStrict<R extends Rank, D1 extends DataType, D2 extends D1>(
-      a: NDArray<D1, R>, b: NDArray<D2, R>): RankMap<'bool'>[R] {
+      a: NDArray<D1, R>, b: NDArray<D2, R>): NDArray<'bool', R> {
     util.assertShapesMatch(a.shape, b.shape, 'Error in lessStrict: ');
     return a.less(b);
   }
@@ -84,7 +84,7 @@ export class Ops {
 
   @operation
   static equalStrict<R extends Rank, D1 extends DataType, D2 extends D1>(
-      a: NDArray<D1, R>, b: NDArray<D2, R>): RankMap<'bool'>[R] {
+      a: NDArray<D1, R>, b: NDArray<D2, R>): NDArray<'bool', R> {
     util.assertShapesMatch(a.shape, b.shape, 'Error in equalStrict: ');
     return a.equal(b);
   }
@@ -106,7 +106,7 @@ export class Ops {
 
   @operation
   static lessEqualStrict<R extends Rank, D1 extends DataType, D2 extends D1>(
-      a: NDArray<D1, R>, b: NDArray<D2, R>): RankMap<'bool'>[R] {
+      a: NDArray<D1, R>, b: NDArray<D2, R>): NDArray<'bool', R> {
     util.assertShapesMatch(a.shape, b.shape, 'Error in lessEqualStrict: ');
     return a.lessEqual(b);
   }
@@ -128,7 +128,7 @@ export class Ops {
 
   @operation
   static greaterStrict<R extends Rank, D1 extends DataType, D2 extends D1>(
-      a: NDArray<D1, R>, b: NDArray<D2, R>): RankMap<'bool'>[R] {
+      a: NDArray<D1, R>, b: NDArray<D2, R>): NDArray<'bool', R> {
     util.assertShapesMatch(a.shape, b.shape, 'Error in greaterStrict: ');
     return a.greater(b);
   }
@@ -150,7 +150,7 @@ export class Ops {
 
   @operation
   static greaterEqualStrict<R extends Rank, D1 extends DataType, D2 extends D1>(
-      a: NDArray<D1, R>, b: NDArray<D2, R>): RankMap<'bool'>[R] {
+      a: NDArray<D1, R>, b: NDArray<D2, R>): NDArray<'bool', R> {
     util.assertShapesMatch(a.shape, b.shape, 'Error in greaterEqualStrict: ');
     return a.greaterEqual(b);
   }

--- a/src/math/concat.ts
+++ b/src/math/concat.ts
@@ -19,7 +19,7 @@ import {ENV} from '../environment';
 import * as concat_util from './concat_util';
 import {operation} from './decorators';
 import {Array1D, Array2D, Array3D, Array4D, NDArray} from './ndarray';
-import {DataType, Rank, RankMap} from './types';
+import {DataType, Rank} from './types';
 
 export class Ops {
   /**
@@ -146,7 +146,7 @@ export class Ops {
 
   @operation
   static concat<D extends DataType, R extends Rank>(
-      a: NDArray<D, R>, b: NDArray<D, R>, axis: number): RankMap<D>[R] {
+      a: NDArray<D, R>, b: NDArray<D, R>, axis: number): NDArray<D, R> {
     concat_util.assertParams(a.shape, b.shape, axis);
     if (a.rank === 0) {
       throw new Error('Cannot concatenate a scalar');

--- a/src/math/concat.ts
+++ b/src/math/concat.ts
@@ -19,7 +19,7 @@ import {ENV} from '../environment';
 import * as concat_util from './concat_util';
 import {operation} from './decorators';
 import {Array1D, Array2D, Array3D, Array4D, NDArray} from './ndarray';
-import {DataType, Rank} from './types';
+import {Rank} from './types';
 
 export class Ops {
   /**
@@ -35,10 +35,9 @@ export class Ops {
    * @return The concatenated array.
    */
   @operation
-  static concat1D<D extends DataType>(a: Array1D<D>, b: Array1D<D>):
-      Array1D<D> {
+  static concat1D(a: Array1D, b: Array1D): Array1D {
     concat_util.assertParams(a.shape, b.shape, 0);
-    return ENV.engine.executeKernel('Concat1D', {inputs: {a, b}}) as Array1D<D>;
+    return ENV.engine.executeKernel('Concat1D', {inputs: {a, b}}) as Array1D;
   }
 
   /**
@@ -70,11 +69,10 @@ export class Ops {
    * @return The concatenated array.
    */
   @operation
-  static concat2D<D extends DataType>(
-      a: Array2D<D>, b: Array2D<D>, axis: number): Array2D<D> {
+  static concat2D(a: Array2D, b: Array2D, axis: number): Array2D {
     concat_util.assertParams(a.shape, b.shape, axis);
     return ENV.engine.executeKernel(
-               'Concat2D', {inputs: {a, b}, args: {axis}}) as Array2D<D>;
+               'Concat2D', {inputs: {a, b}, args: {axis}}) as Array2D;
   }
 
   /**
@@ -109,11 +107,10 @@ export class Ops {
    * @return The concatenated array.
    */
   @operation
-  static concat3D<D extends DataType>(
-      a: Array3D<D>, b: Array3D<D>, axis: number): Array3D<D> {
+  static concat3D(a: Array3D, b: Array3D, axis: number): Array3D {
     concat_util.assertParams(a.shape, b.shape, axis);
 
-    const gradients = (dy: Array3D<'float32'>, y: Array3D) => {
+    const gradients = (dy: Array3D, y: Array3D) => {
       const {x1Begin, x1Size, x2Begin, x2Size} =
           concat_util.computeGradientSliceShapes3D(a.shape, y.shape, axis);
       return {
@@ -124,7 +121,7 @@ export class Ops {
 
     return ENV.engine.executeKernel(
                'Concat3D', {inputs: {a, b}, args: {axis}}, gradients) as
-        Array3D<D>;
+        Array3D;
   }
 
   /**
@@ -137,27 +134,26 @@ export class Ops {
    * @return The concatenated array.
    */
   @operation
-  static concat4D<D extends DataType>(
-      a: Array4D<D>, b: Array4D<D>, axis: number): Array4D<D> {
+  static concat4D(a: Array4D, b: Array4D, axis: number): Array4D {
     concat_util.assertParams(a.shape, b.shape, axis);
     return ENV.engine.executeKernel(
-               'Concat4D', {inputs: {a, b}, args: {axis}}) as Array4D<D>;
+               'Concat4D', {inputs: {a, b}, args: {axis}}) as Array4D;
   }
 
   @operation
-  static concat<D extends DataType, R extends Rank>(
-      a: NDArray<D, R>, b: NDArray<D, R>, axis: number): NDArray<D, R> {
+  static concat<R extends Rank>(a: NDArray<R>, b: NDArray<R>, axis: number):
+      NDArray<R> {
     concat_util.assertParams(a.shape, b.shape, axis);
     if (a.rank === 0) {
       throw new Error('Cannot concatenate a scalar');
     } else if (a.rank === 1) {
-      return a.concat(b, axis);
+      return Ops.concat1D(a as Array1D, b as Array1D) as NDArray<R>;
     } else if (a.rank === 2) {
-      return a.concat(b, axis);
+      return Ops.concat2D(a as Array2D, b as Array2D, axis) as NDArray<R>;
     } else if (a.rank === 3) {
-      return a.concat(b, axis);
+      return Ops.concat3D(a as Array3D, b as Array3D, axis) as NDArray<R>;
     } else if (a.rank === 4) {
-      return a.concat(b, axis);
+      return Ops.concat4D(a as Array4D, b as Array4D, axis) as NDArray<R>;
     } else {
       throw new Error(`Concat for rank ${a.rank} is not yet implemented`);
     }

--- a/src/math/conv.ts
+++ b/src/math/conv.ts
@@ -20,7 +20,7 @@ import * as util from '../util';
 import * as conv_util from './conv_util';
 import {operation} from './decorators';
 import {Array1D, Array3D, Array4D, NDArray} from './ndarray';
-import {DataType, Rank} from './types';
+import {Rank} from './types';
 
 export class Ops {
   /**
@@ -156,7 +156,7 @@ export class Ops {
     const convInfo = conv_util.computeConv2DInfo(
         x4D.shape, filter.shape, strides, pad, dimRoundingMode);
 
-    const gradients = (dy: Array4D<'float32'>, y: Array4D) => {
+    const gradients = (dy: Array4D, y: Array4D) => {
       return {
         x: () => Ops.conv2dDerInput(x4D.shape, dy, filter, strides, pad),
         filter: () => Ops.conv2dDerFilter(x4D, dy, filter.shape, strides, pad),
@@ -193,18 +193,17 @@ export class Ops {
    *     is of fractional size.
    */
   @operation
-  static conv2dDerInput<R extends Rank, T extends NDArray<'float32', R>>(
+  static conv2dDerInput<R extends Rank, T extends NDArray<R>>(
       xShape: [number, number, number, number]|[number, number, number],
-      dy: NDArray<'float32', R>, filter: Array4D,
-      strides: [number, number]|number, pad: 'valid'|'same'|number,
-      dimRoundingMode?: 'floor'|'round'|'ceil'): T {
+      dy: NDArray<R>, filter: Array4D, strides: [number, number]|number,
+      pad: 'valid'|'same'|number, dimRoundingMode?: 'floor'|'round'|'ceil'): T {
     util.assert(
         xShape.length === dy.rank,
         `Length of inShape ` +
             `(${xShape.length}) and rank of dy (${dy.rank}) must match`);
 
     let xShape4D = xShape as [number, number, number, number];
-    let dy4D = dy as Array4D<'float32'>;
+    let dy4D = dy as Array4D;
     let reshapedTo4D = false;
     if (dy.rank === 3) {
       reshapedTo4D = true;
@@ -259,8 +258,7 @@ export class Ops {
    * assumed.
    */
   @operation
-  static conv2dDerBias(dy: Array3D<'float32'>|Array4D<'float32'>):
-      Array1D<'float32'> {
+  static conv2dDerBias(dy: Array3D|Array4D): Array1D {
     let dy4D = dy as Array4D;
     if (dy.rank === 3) {
       dy4D = dy.as4D(1, dy.shape[0], dy.shape[1], dy.shape[2]);
@@ -288,15 +286,15 @@ export class Ops {
    */
   @operation
   static conv2dDerFilter<R extends '3'|'4'>(
-      x: NDArray<DataType, R>, dy: NDArray<'float32', R>,
+      x: NDArray<R>, dy: NDArray<R>,
       filterShape: [number, number, number, number],
       strides: [number, number]|number, pad: 'valid'|'same'|number,
-      dimRoundingMode?: 'floor'|'round'|'ceil'): Array4D<'float32'> {
+      dimRoundingMode?: 'floor'|'round'|'ceil'): Array4D {
     let x4D = x as Array4D;
     if (x.rank === 3) {
       x4D = x.as4D(1, x.shape[0], x.shape[1], x.shape[2]);
     }
-    let dy4D = dy as Array4D<'float32'>;
+    let dy4D = dy as Array4D;
     if (dy4D.rank === 3) {
       dy4D = dy.as4D(1, dy.shape[0], dy.shape[1], dy.shape[2]);
     }
@@ -355,10 +353,10 @@ export class Ops {
    */
   @operation
   static conv2dTranspose<R extends Rank>(
-      x: NDArray<'float32', R>, filter: Array4D,
+      x: NDArray<R>, filter: Array4D,
       outputShape: [number, number, number, number]|[number, number, number],
       strides: [number, number]|number, pad: 'valid'|'same'|number,
-      dimRoundingMode?: 'floor'|'round'|'ceil'): NDArray<'float32', R> {
+      dimRoundingMode?: 'floor'|'round'|'ceil'): NDArray<R> {
     return Ops.conv2dDerInput(
         outputShape, x, filter, strides, pad, dimRoundingMode);
   }

--- a/src/math/conv.ts
+++ b/src/math/conv.ts
@@ -285,7 +285,7 @@ export class Ops {
    *     is of fractional size.
    */
   @operation
-  static conv2dDerFilter<R extends '3'|'4'>(
+  static conv2dDerFilter<R extends Rank.R3|Rank.R4>(
       x: NDArray<R>, dy: NDArray<R>,
       filterShape: [number, number, number, number],
       strides: [number, number]|number, pad: 'valid'|'same'|number,

--- a/src/math/conv.ts
+++ b/src/math/conv.ts
@@ -20,7 +20,7 @@ import * as util from '../util';
 import * as conv_util from './conv_util';
 import {operation} from './decorators';
 import {Array1D, Array3D, Array4D, NDArray} from './ndarray';
-import {DataType, Rank, RankMap} from './types';
+import {DataType, Rank} from './types';
 
 export class Ops {
   /**
@@ -193,7 +193,7 @@ export class Ops {
    *     is of fractional size.
    */
   @operation
-  static conv2dDerInput<R extends Rank, T extends RankMap<'float32'>[R]>(
+  static conv2dDerInput<R extends Rank, T extends NDArray<'float32', R>>(
       xShape: [number, number, number, number]|[number, number, number],
       dy: NDArray<'float32', R>, filter: Array4D,
       strides: [number, number]|number, pad: 'valid'|'same'|number,
@@ -358,7 +358,7 @@ export class Ops {
       x: NDArray<'float32', R>, filter: Array4D,
       outputShape: [number, number, number, number]|[number, number, number],
       strides: [number, number]|number, pad: 'valid'|'same'|number,
-      dimRoundingMode?: 'floor'|'round'|'ceil'): RankMap<'float32'>[R] {
+      dimRoundingMode?: 'floor'|'round'|'ceil'): NDArray<'float32', R> {
     return Ops.conv2dDerInput(
         outputShape, x, filter, strides, pad, dimRoundingMode);
   }

--- a/src/math/conv1d_test.ts
+++ b/src/math/conv1d_test.ts
@@ -15,10 +15,10 @@
  * =============================================================================
  */
 
+import * as dl from '../index';
 import * as test_util from '../test_util';
 import {MathTests} from '../test_util';
-
-import {Array1D, Array2D, Array3D, Array4D, NDArray} from './ndarray';
+import {Array1D, Array2D, Array3D, Array4D} from './ndarray';
 
 // math.conv1d
 {
@@ -116,7 +116,7 @@ import {Array1D, Array2D, Array3D, Array4D, NDArray} from './ndarray';
       const stride = 1;
 
       const x = Array3D.new(inputShape, [1, 2, 3, 4]);
-      const w = NDArray.randNormal<'3'>([fSize, wrongInputDepth, outputDepth]);
+      const w = dl.randNormal<'3'>([fSize, wrongInputDepth, outputDepth]);
       const bias = Array1D.new([-1]);
 
       expect(() => math.conv1d(x, w, bias, stride, pad)).toThrowError();

--- a/src/math/conv1d_test.ts
+++ b/src/math/conv1d_test.ts
@@ -18,7 +18,7 @@
 import * as test_util from '../test_util';
 import {MathTests} from '../test_util';
 
-import {Array1D, Array2D, Array3D, Array4D} from './ndarray';
+import {Array1D, Array2D, Array3D, Array4D, NDArray} from './ndarray';
 
 // math.conv1d
 {
@@ -116,7 +116,8 @@ import {Array1D, Array2D, Array3D, Array4D} from './ndarray';
       const stride = 1;
 
       const x = Array3D.new(inputShape, [1, 2, 3, 4]);
-      const w = Array3D.randNormal([fSize, wrongInputDepth, outputDepth]);
+      const w = NDArray.randNormal<'float32', '3'>(
+          [fSize, wrongInputDepth, outputDepth]);
       const bias = Array1D.new([-1]);
 
       expect(() => math.conv1d(x, w, bias, stride, pad)).toThrowError();

--- a/src/math/conv1d_test.ts
+++ b/src/math/conv1d_test.ts
@@ -116,8 +116,7 @@ import {Array1D, Array2D, Array3D, Array4D, NDArray} from './ndarray';
       const stride = 1;
 
       const x = Array3D.new(inputShape, [1, 2, 3, 4]);
-      const w = NDArray.randNormal<'float32', '3'>(
-          [fSize, wrongInputDepth, outputDepth]);
+      const w = NDArray.randNormal<'3'>([fSize, wrongInputDepth, outputDepth]);
       const bias = Array1D.new([-1]);
 
       expect(() => math.conv1d(x, w, bias, stride, pad)).toThrowError();

--- a/src/math/conv1d_test.ts
+++ b/src/math/conv1d_test.ts
@@ -19,6 +19,7 @@ import * as dl from '../index';
 import * as test_util from '../test_util';
 import {MathTests} from '../test_util';
 import {Array1D, Array2D, Array3D, Array4D} from './ndarray';
+import {Rank} from './types';
 
 // math.conv1d
 {
@@ -116,7 +117,7 @@ import {Array1D, Array2D, Array3D, Array4D} from './ndarray';
       const stride = 1;
 
       const x = Array3D.new(inputShape, [1, 2, 3, 4]);
-      const w = dl.randNormal<'3'>([fSize, wrongInputDepth, outputDepth]);
+      const w = dl.randNormal<Rank.R3>([fSize, wrongInputDepth, outputDepth]);
       const bias = Array1D.new([-1]);
 
       expect(() => math.conv1d(x, w, bias, stride, pad)).toThrowError();

--- a/src/math/conv2d_depthwise_test.ts
+++ b/src/math/conv2d_depthwise_test.ts
@@ -147,8 +147,8 @@ import {Array4D, NDArray} from './ndarray';
       const chMul = 3;
       const inDepth = 2;
 
-      const x = NDArray.zeros<'float32', '3'>([3, 3, inDepth]);
-      const w = NDArray.zeros<'float32', '4'>([fSize, fSize, inDepth, chMul]);
+      const x = NDArray.zeros<'3'>([3, 3, inDepth]);
+      const w = NDArray.zeros<'4'>([fSize, fSize, inDepth, chMul]);
       const result = math.depthwiseConv2D(x, w, stride, pad);
       expect(result.shape).toEqual([3, 3, inDepth * chMul]);
     });

--- a/src/math/conv2d_depthwise_test.ts
+++ b/src/math/conv2d_depthwise_test.ts
@@ -15,9 +15,10 @@
  * =============================================================================
  */
 
+import * as dl from '../index';
 import * as test_util from '../test_util';
 import {MathTests} from '../test_util';
-import {Array4D, NDArray} from './ndarray';
+import {Array4D} from './ndarray';
 
 // math.depthwiseConv2D
 {
@@ -147,8 +148,8 @@ import {Array4D, NDArray} from './ndarray';
       const chMul = 3;
       const inDepth = 2;
 
-      const x = NDArray.zeros<'3'>([3, 3, inDepth]);
-      const w = NDArray.zeros<'4'>([fSize, fSize, inDepth, chMul]);
+      const x = dl.zeros<'3'>([3, 3, inDepth]);
+      const w = dl.zeros<'4'>([fSize, fSize, inDepth, chMul]);
       const result = math.depthwiseConv2D(x, w, stride, pad);
       expect(result.shape).toEqual([3, 3, inDepth * chMul]);
     });

--- a/src/math/conv2d_depthwise_test.ts
+++ b/src/math/conv2d_depthwise_test.ts
@@ -17,7 +17,7 @@
 
 import * as test_util from '../test_util';
 import {MathTests} from '../test_util';
-import {Array3D, Array4D} from './ndarray';
+import {Array4D, NDArray} from './ndarray';
 
 // math.depthwiseConv2D
 {
@@ -147,8 +147,8 @@ import {Array3D, Array4D} from './ndarray';
       const chMul = 3;
       const inDepth = 2;
 
-      const x = Array3D.zeros([3, 3, inDepth]);
-      const w = Array4D.zeros([fSize, fSize, inDepth, chMul]);
+      const x = NDArray.zeros<'float32', '3'>([3, 3, inDepth]);
+      const w = NDArray.zeros<'float32', '4'>([fSize, fSize, inDepth, chMul]);
       const result = math.depthwiseConv2D(x, w, stride, pad);
       expect(result.shape).toEqual([3, 3, inDepth * chMul]);
     });

--- a/src/math/conv2d_depthwise_test.ts
+++ b/src/math/conv2d_depthwise_test.ts
@@ -19,6 +19,7 @@ import * as dl from '../index';
 import * as test_util from '../test_util';
 import {MathTests} from '../test_util';
 import {Array4D} from './ndarray';
+import {Rank} from './types';
 
 // math.depthwiseConv2D
 {
@@ -148,8 +149,8 @@ import {Array4D} from './ndarray';
       const chMul = 3;
       const inDepth = 2;
 
-      const x = dl.zeros<'3'>([3, 3, inDepth]);
-      const w = dl.zeros<'4'>([fSize, fSize, inDepth, chMul]);
+      const x = dl.zeros<Rank.R3>([3, 3, inDepth]);
+      const w = dl.zeros<Rank.R4>([fSize, fSize, inDepth, chMul]);
       const result = math.depthwiseConv2D(x, w, stride, pad);
       expect(result.shape).toEqual([3, 3, inDepth * chMul]);
     });

--- a/src/math/conv2d_test.ts
+++ b/src/math/conv2d_test.ts
@@ -19,6 +19,7 @@ import * as dl from '../index';
 import * as test_util from '../test_util';
 import {MathTests} from '../test_util';
 import {Array1D, Array2D, Array3D, Array4D} from './ndarray';
+import {Rank} from './types';
 
 // math.conv2d
 {
@@ -134,7 +135,7 @@ import {Array1D, Array2D, Array3D, Array4D} from './ndarray';
 
       const x = Array3D.new(inputShape, [1, 2, 3, 4]);
       const w =
-          dl.randNormal<'4'>([fSize, fSize, wrongInputDepth, outputDepth]);
+          dl.randNormal<Rank.R4>([fSize, fSize, wrongInputDepth, outputDepth]);
       const bias = Array1D.new([-1]);
 
       expect(() => math.conv2d(x, w, bias, stride, pad)).toThrowError();
@@ -150,7 +151,7 @@ import {Array1D, Array2D, Array3D, Array4D} from './ndarray';
       const dimRoundingMode = 'round';
 
       const x = Array3D.new(inputShape, [1, 2, 3, 4]);
-      const w = dl.randNormal<'4'>([fSize, fSize, inputDepth, outputDepth]);
+      const w = dl.randNormal<Rank.R4>([fSize, fSize, inputDepth, outputDepth]);
       const bias = Array1D.new([-1]);
 
       expect(() => math.conv2d(x, w, bias, stride, pad, dimRoundingMode))
@@ -167,7 +168,7 @@ import {Array1D, Array2D, Array3D, Array4D} from './ndarray';
 
       const filterShape: [number, number, number, number] =
           [filterSize, filterSize, inputDepth, outputDepth];
-      const filter = dl.ones<'4'>(filterShape);
+      const filter = dl.ones<Rank.R4>(filterShape);
       const bias = Array1D.new([-1]);
 
       const x = Array3D.new(inputShape, [1, 2, 3, 4, 5, 6, 7, 8, 9]);
@@ -199,7 +200,7 @@ import {Array1D, Array2D, Array3D, Array4D} from './ndarray';
 
       const filterShape: [number, number, number, number] =
           [filterSize, filterSize, inputDepth, outputDepth];
-      const filter = dl.ones<'4'>(filterShape);
+      const filter = dl.ones<Rank.R4>(filterShape);
 
       const bias = Array1D.new([-1]);
 

--- a/src/math/conv2d_test.ts
+++ b/src/math/conv2d_test.ts
@@ -133,8 +133,8 @@ import {Array1D, Array2D, Array3D, Array4D, NDArray} from './ndarray';
       const stride = 1;
 
       const x = Array3D.new(inputShape, [1, 2, 3, 4]);
-      const w = NDArray.randNormal<'float32', '4'>(
-          [fSize, fSize, wrongInputDepth, outputDepth]);
+      const w =
+          NDArray.randNormal<'4'>([fSize, fSize, wrongInputDepth, outputDepth]);
       const bias = Array1D.new([-1]);
 
       expect(() => math.conv2d(x, w, bias, stride, pad)).toThrowError();
@@ -150,8 +150,8 @@ import {Array1D, Array2D, Array3D, Array4D, NDArray} from './ndarray';
       const dimRoundingMode = 'round';
 
       const x = Array3D.new(inputShape, [1, 2, 3, 4]);
-      const w = NDArray.randNormal<'float32', '4'>(
-          [fSize, fSize, inputDepth, outputDepth]);
+      const w =
+          NDArray.randNormal<'4'>([fSize, fSize, inputDepth, outputDepth]);
       const bias = Array1D.new([-1]);
 
       expect(() => math.conv2d(x, w, bias, stride, pad, dimRoundingMode))
@@ -168,7 +168,7 @@ import {Array1D, Array2D, Array3D, Array4D, NDArray} from './ndarray';
 
       const filterShape: [number, number, number, number] =
           [filterSize, filterSize, inputDepth, outputDepth];
-      const filter = NDArray.ones<'float32', '4'>(filterShape);
+      const filter = NDArray.ones<'4'>(filterShape);
       const bias = Array1D.new([-1]);
 
       const x = Array3D.new(inputShape, [1, 2, 3, 4, 5, 6, 7, 8, 9]);
@@ -200,7 +200,7 @@ import {Array1D, Array2D, Array3D, Array4D, NDArray} from './ndarray';
 
       const filterShape: [number, number, number, number] =
           [filterSize, filterSize, inputDepth, outputDepth];
-      const filter = NDArray.ones<'float32', '4'>(filterShape);
+      const filter = NDArray.ones<'4'>(filterShape);
 
       const bias = Array1D.new([-1]);
 

--- a/src/math/conv2d_test.ts
+++ b/src/math/conv2d_test.ts
@@ -18,7 +18,7 @@
 import * as test_util from '../test_util';
 import {MathTests} from '../test_util';
 
-import {Array1D, Array2D, Array3D, Array4D} from './ndarray';
+import {Array1D, Array2D, Array3D, Array4D, NDArray} from './ndarray';
 
 // math.conv2d
 {
@@ -133,8 +133,8 @@ import {Array1D, Array2D, Array3D, Array4D} from './ndarray';
       const stride = 1;
 
       const x = Array3D.new(inputShape, [1, 2, 3, 4]);
-      const w =
-          Array4D.randNormal([fSize, fSize, wrongInputDepth, outputDepth]);
+      const w = NDArray.randNormal<'float32', '4'>(
+          [fSize, fSize, wrongInputDepth, outputDepth]);
       const bias = Array1D.new([-1]);
 
       expect(() => math.conv2d(x, w, bias, stride, pad)).toThrowError();
@@ -150,7 +150,8 @@ import {Array1D, Array2D, Array3D, Array4D} from './ndarray';
       const dimRoundingMode = 'round';
 
       const x = Array3D.new(inputShape, [1, 2, 3, 4]);
-      const w = Array4D.randNormal([fSize, fSize, inputDepth, outputDepth]);
+      const w = NDArray.randNormal<'float32', '4'>(
+          [fSize, fSize, inputDepth, outputDepth]);
       const bias = Array1D.new([-1]);
 
       expect(() => math.conv2d(x, w, bias, stride, pad, dimRoundingMode))
@@ -167,7 +168,7 @@ import {Array1D, Array2D, Array3D, Array4D} from './ndarray';
 
       const filterShape: [number, number, number, number] =
           [filterSize, filterSize, inputDepth, outputDepth];
-      const filter = Array4D.ones(filterShape);
+      const filter = NDArray.ones<'float32', '4'>(filterShape);
       const bias = Array1D.new([-1]);
 
       const x = Array3D.new(inputShape, [1, 2, 3, 4, 5, 6, 7, 8, 9]);
@@ -199,7 +200,7 @@ import {Array1D, Array2D, Array3D, Array4D} from './ndarray';
 
       const filterShape: [number, number, number, number] =
           [filterSize, filterSize, inputDepth, outputDepth];
-      const filter = Array4D.ones(filterShape);
+      const filter = NDArray.ones<'float32', '4'>(filterShape);
 
       const bias = Array1D.new([-1]);
 

--- a/src/math/conv2d_test.ts
+++ b/src/math/conv2d_test.ts
@@ -15,10 +15,10 @@
  * =============================================================================
  */
 
+import * as dl from '../index';
 import * as test_util from '../test_util';
 import {MathTests} from '../test_util';
-
-import {Array1D, Array2D, Array3D, Array4D, NDArray} from './ndarray';
+import {Array1D, Array2D, Array3D, Array4D} from './ndarray';
 
 // math.conv2d
 {
@@ -134,7 +134,7 @@ import {Array1D, Array2D, Array3D, Array4D, NDArray} from './ndarray';
 
       const x = Array3D.new(inputShape, [1, 2, 3, 4]);
       const w =
-          NDArray.randNormal<'4'>([fSize, fSize, wrongInputDepth, outputDepth]);
+          dl.randNormal<'4'>([fSize, fSize, wrongInputDepth, outputDepth]);
       const bias = Array1D.new([-1]);
 
       expect(() => math.conv2d(x, w, bias, stride, pad)).toThrowError();
@@ -150,8 +150,7 @@ import {Array1D, Array2D, Array3D, Array4D, NDArray} from './ndarray';
       const dimRoundingMode = 'round';
 
       const x = Array3D.new(inputShape, [1, 2, 3, 4]);
-      const w =
-          NDArray.randNormal<'4'>([fSize, fSize, inputDepth, outputDepth]);
+      const w = dl.randNormal<'4'>([fSize, fSize, inputDepth, outputDepth]);
       const bias = Array1D.new([-1]);
 
       expect(() => math.conv2d(x, w, bias, stride, pad, dimRoundingMode))
@@ -168,7 +167,7 @@ import {Array1D, Array2D, Array3D, Array4D, NDArray} from './ndarray';
 
       const filterShape: [number, number, number, number] =
           [filterSize, filterSize, inputDepth, outputDepth];
-      const filter = NDArray.ones<'4'>(filterShape);
+      const filter = dl.ones<'4'>(filterShape);
       const bias = Array1D.new([-1]);
 
       const x = Array3D.new(inputShape, [1, 2, 3, 4, 5, 6, 7, 8, 9]);
@@ -200,7 +199,7 @@ import {Array1D, Array2D, Array3D, Array4D, NDArray} from './ndarray';
 
       const filterShape: [number, number, number, number] =
           [filterSize, filterSize, inputDepth, outputDepth];
-      const filter = NDArray.ones<'4'>(filterShape);
+      const filter = dl.ones<'4'>(filterShape);
 
       const bias = Array1D.new([-1]);
 

--- a/src/math/conv2d_transpose_test.ts
+++ b/src/math/conv2d_transpose_test.ts
@@ -15,10 +15,10 @@
  * =============================================================================
  */
 
+import * as dl from '../index';
 import * as test_util from '../test_util';
 import {MathTests} from '../test_util';
-
-import {Array2D, Array3D, Array4D, NDArray} from './ndarray';
+import {Array2D, Array3D, Array4D} from './ndarray';
 
 // math.conv2dTranspose
 {
@@ -106,7 +106,7 @@ import {Array2D, Array3D, Array4D, NDArray} from './ndarray';
          const origStride = 1;
 
          const x = Array3D.new(inputShape, [2, 2]);
-         const w = NDArray.randNormal<'4'>(
+         const w = dl.randNormal<'4'>(
              [fSize, fSize, origInputDepth, wrongOrigOutputDepth]);
 
          expect(

--- a/src/math/conv2d_transpose_test.ts
+++ b/src/math/conv2d_transpose_test.ts
@@ -19,6 +19,7 @@ import * as dl from '../index';
 import * as test_util from '../test_util';
 import {MathTests} from '../test_util';
 import {Array2D, Array3D, Array4D} from './ndarray';
+import {Rank} from './types';
 
 // math.conv2dTranspose
 {
@@ -106,7 +107,7 @@ import {Array2D, Array3D, Array4D} from './ndarray';
          const origStride = 1;
 
          const x = Array3D.new(inputShape, [2, 2]);
-         const w = dl.randNormal<'4'>(
+         const w = dl.randNormal<Rank.R4>(
              [fSize, fSize, origInputDepth, wrongOrigOutputDepth]);
 
          expect(

--- a/src/math/conv2d_transpose_test.ts
+++ b/src/math/conv2d_transpose_test.ts
@@ -106,7 +106,7 @@ import {Array2D, Array3D, Array4D, NDArray} from './ndarray';
          const origStride = 1;
 
          const x = Array3D.new(inputShape, [2, 2]);
-         const w = NDArray.randNormal<'float32', '4'>(
+         const w = NDArray.randNormal<'4'>(
              [fSize, fSize, origInputDepth, wrongOrigOutputDepth]);
 
          expect(

--- a/src/math/conv2d_transpose_test.ts
+++ b/src/math/conv2d_transpose_test.ts
@@ -18,7 +18,7 @@
 import * as test_util from '../test_util';
 import {MathTests} from '../test_util';
 
-import {Array2D, Array3D, Array4D} from './ndarray';
+import {Array2D, Array3D, Array4D, NDArray} from './ndarray';
 
 // math.conv2dTranspose
 {
@@ -106,7 +106,7 @@ import {Array2D, Array3D, Array4D} from './ndarray';
          const origStride = 1;
 
          const x = Array3D.new(inputShape, [2, 2]);
-         const w = Array4D.randNormal(
+         const w = NDArray.randNormal<'float32', '4'>(
              [fSize, fSize, origInputDepth, wrongOrigOutputDepth]);
 
          expect(

--- a/src/math/lstm_test.ts
+++ b/src/math/lstm_test.ts
@@ -47,15 +47,15 @@ import {Array1D, Array2D, NDArray, Scalar} from './ndarray';
           math.basicLSTMCell.bind(math, forgetBias, lstmKernel2, lstmBias2);
 
       const c = [
-        NDArray.zeros<'float32', '2'>([1, lstmBias1.shape[0] / 4]),
-        NDArray.zeros<'float32', '2'>([1, lstmBias2.shape[0] / 4])
+        NDArray.zeros<'2'>([1, lstmBias1.shape[0] / 4]),
+        NDArray.zeros<'2'>([1, lstmBias2.shape[0] / 4])
       ];
       const h = [
-        NDArray.zeros<'float32', '2'>([1, lstmBias1.shape[0] / 4]),
-        NDArray.zeros<'float32', '2'>([1, lstmBias2.shape[0] / 4])
+        NDArray.zeros<'2'>([1, lstmBias1.shape[0] / 4]),
+        NDArray.zeros<'2'>([1, lstmBias2.shape[0] / 4])
       ];
 
-      const onehot = NDArray.zeros<'float32', '2'>([1, 2]);
+      const onehot = NDArray.zeros<'2'>([1, 2]);
       onehot.set(1.0, 0, 0);
 
       const output = math.multiRNNCell([lstm1, lstm2], onehot, c, h);
@@ -67,15 +67,15 @@ import {Array1D, Array2D, NDArray, Scalar} from './ndarray';
     });
 
     it('basicLSTMCell with batch=2', math => {
-      const lstmKernel = NDArray.randNormal<'float32', '2'>([3, 4]);
-      const lstmBias = NDArray.randNormal<'float32', '1'>([4]);
+      const lstmKernel = NDArray.randNormal<'2'>([3, 4]);
+      const lstmBias = NDArray.randNormal<'1'>([4]);
       const forgetBias = Scalar.new(1.0);
 
-      const data = NDArray.randNormal<'float32', '2'>([1, 2]);
+      const data = NDArray.randNormal<'2'>([1, 2]);
       const batchedData = math.concat2D(data, data, 0);  // 2x2
-      const c = NDArray.randNormal<'float32', '2'>([1, 1]);
+      const c = NDArray.randNormal<'2'>([1, 1]);
       const batchedC = math.concat2D(c, c, 0);  // 2x1
-      const h = NDArray.randNormal<'float32', '2'>([1, 1]);
+      const h = NDArray.randNormal<'2'>([1, 1]);
       const batchedH = math.concat2D(h, h, 0);  // 2x1
       const [newC, newH] = math.basicLSTMCell(
           forgetBias, lstmKernel, lstmBias, batchedData, batchedC, batchedH);

--- a/src/math/lstm_test.ts
+++ b/src/math/lstm_test.ts
@@ -15,10 +15,10 @@
  * =============================================================================
  */
 
+import * as dl from '../index';
 import * as test_util from '../test_util';
 import {MathTests} from '../test_util';
-
-import {Array1D, Array2D, NDArray, Scalar} from './ndarray';
+import {Array1D, Array2D, Scalar} from './ndarray';
 
 // math.basicLSTMCell
 {
@@ -47,15 +47,15 @@ import {Array1D, Array2D, NDArray, Scalar} from './ndarray';
           math.basicLSTMCell.bind(math, forgetBias, lstmKernel2, lstmBias2);
 
       const c = [
-        NDArray.zeros<'2'>([1, lstmBias1.shape[0] / 4]),
-        NDArray.zeros<'2'>([1, lstmBias2.shape[0] / 4])
+        dl.zeros<'2'>([1, lstmBias1.shape[0] / 4]),
+        dl.zeros<'2'>([1, lstmBias2.shape[0] / 4])
       ];
       const h = [
-        NDArray.zeros<'2'>([1, lstmBias1.shape[0] / 4]),
-        NDArray.zeros<'2'>([1, lstmBias2.shape[0] / 4])
+        dl.zeros<'2'>([1, lstmBias1.shape[0] / 4]),
+        dl.zeros<'2'>([1, lstmBias2.shape[0] / 4])
       ];
 
-      const onehot = NDArray.zeros<'2'>([1, 2]);
+      const onehot = dl.zeros<'2'>([1, 2]);
       onehot.set(1.0, 0, 0);
 
       const output = math.multiRNNCell([lstm1, lstm2], onehot, c, h);
@@ -67,15 +67,15 @@ import {Array1D, Array2D, NDArray, Scalar} from './ndarray';
     });
 
     it('basicLSTMCell with batch=2', math => {
-      const lstmKernel = NDArray.randNormal<'2'>([3, 4]);
-      const lstmBias = NDArray.randNormal<'1'>([4]);
+      const lstmKernel = dl.randNormal<'2'>([3, 4]);
+      const lstmBias = dl.randNormal<'1'>([4]);
       const forgetBias = Scalar.new(1.0);
 
-      const data = NDArray.randNormal<'2'>([1, 2]);
+      const data = dl.randNormal<'2'>([1, 2]);
       const batchedData = math.concat2D(data, data, 0);  // 2x2
-      const c = NDArray.randNormal<'2'>([1, 1]);
+      const c = dl.randNormal<'2'>([1, 1]);
       const batchedC = math.concat2D(c, c, 0);  // 2x1
-      const h = NDArray.randNormal<'2'>([1, 1]);
+      const h = dl.randNormal<'2'>([1, 1]);
       const batchedH = math.concat2D(h, h, 0);  // 2x1
       const [newC, newH] = math.basicLSTMCell(
           forgetBias, lstmKernel, lstmBias, batchedData, batchedC, batchedH);

--- a/src/math/lstm_test.ts
+++ b/src/math/lstm_test.ts
@@ -19,6 +19,7 @@ import * as dl from '../index';
 import * as test_util from '../test_util';
 import {MathTests} from '../test_util';
 import {Array1D, Array2D, Scalar} from './ndarray';
+import {Rank} from './types';
 
 // math.basicLSTMCell
 {
@@ -47,15 +48,15 @@ import {Array1D, Array2D, Scalar} from './ndarray';
           math.basicLSTMCell.bind(math, forgetBias, lstmKernel2, lstmBias2);
 
       const c = [
-        dl.zeros<'2'>([1, lstmBias1.shape[0] / 4]),
-        dl.zeros<'2'>([1, lstmBias2.shape[0] / 4])
+        dl.zeros<Rank.R2>([1, lstmBias1.shape[0] / 4]),
+        dl.zeros<Rank.R2>([1, lstmBias2.shape[0] / 4])
       ];
       const h = [
-        dl.zeros<'2'>([1, lstmBias1.shape[0] / 4]),
-        dl.zeros<'2'>([1, lstmBias2.shape[0] / 4])
+        dl.zeros<Rank.R2>([1, lstmBias1.shape[0] / 4]),
+        dl.zeros<Rank.R2>([1, lstmBias2.shape[0] / 4])
       ];
 
-      const onehot = dl.zeros<'2'>([1, 2]);
+      const onehot = dl.zeros<Rank.R2>([1, 2]);
       onehot.set(1.0, 0, 0);
 
       const output = math.multiRNNCell([lstm1, lstm2], onehot, c, h);
@@ -67,15 +68,15 @@ import {Array1D, Array2D, Scalar} from './ndarray';
     });
 
     it('basicLSTMCell with batch=2', math => {
-      const lstmKernel = dl.randNormal<'2'>([3, 4]);
-      const lstmBias = dl.randNormal<'1'>([4]);
+      const lstmKernel = dl.randNormal<Rank.R2>([3, 4]);
+      const lstmBias = dl.randNormal<Rank.R1>([4]);
       const forgetBias = Scalar.new(1.0);
 
-      const data = dl.randNormal<'2'>([1, 2]);
+      const data = dl.randNormal<Rank.R2>([1, 2]);
       const batchedData = math.concat2D(data, data, 0);  // 2x2
-      const c = dl.randNormal<'2'>([1, 1]);
+      const c = dl.randNormal<Rank.R2>([1, 1]);
       const batchedC = math.concat2D(c, c, 0);  // 2x1
-      const h = dl.randNormal<'2'>([1, 1]);
+      const h = dl.randNormal<Rank.R2>([1, 1]);
       const batchedH = math.concat2D(h, h, 0);  // 2x1
       const [newC, newH] = math.basicLSTMCell(
           forgetBias, lstmKernel, lstmBias, batchedData, batchedC, batchedH);

--- a/src/math/lstm_test.ts
+++ b/src/math/lstm_test.ts
@@ -18,7 +18,7 @@
 import * as test_util from '../test_util';
 import {MathTests} from '../test_util';
 
-import {Array1D, Array2D, Scalar} from './ndarray';
+import {Array1D, Array2D, NDArray, Scalar} from './ndarray';
 
 // math.basicLSTMCell
 {
@@ -47,15 +47,15 @@ import {Array1D, Array2D, Scalar} from './ndarray';
           math.basicLSTMCell.bind(math, forgetBias, lstmKernel2, lstmBias2);
 
       const c = [
-        Array2D.zeros([1, lstmBias1.shape[0] / 4]),
-        Array2D.zeros([1, lstmBias2.shape[0] / 4])
+        NDArray.zeros<'float32', '2'>([1, lstmBias1.shape[0] / 4]),
+        NDArray.zeros<'float32', '2'>([1, lstmBias2.shape[0] / 4])
       ];
       const h = [
-        Array2D.zeros([1, lstmBias1.shape[0] / 4]),
-        Array2D.zeros([1, lstmBias2.shape[0] / 4])
+        NDArray.zeros<'float32', '2'>([1, lstmBias1.shape[0] / 4]),
+        NDArray.zeros<'float32', '2'>([1, lstmBias2.shape[0] / 4])
       ];
 
-      const onehot = Array2D.zeros([1, 2]);
+      const onehot = NDArray.zeros<'float32', '2'>([1, 2]);
       onehot.set(1.0, 0, 0);
 
       const output = math.multiRNNCell([lstm1, lstm2], onehot, c, h);
@@ -67,15 +67,15 @@ import {Array1D, Array2D, Scalar} from './ndarray';
     });
 
     it('basicLSTMCell with batch=2', math => {
-      const lstmKernel = Array2D.randNormal([3, 4]);
-      const lstmBias = Array1D.randNormal([4]);
+      const lstmKernel = NDArray.randNormal<'float32', '2'>([3, 4]);
+      const lstmBias = NDArray.randNormal<'float32', '1'>([4]);
       const forgetBias = Scalar.new(1.0);
 
-      const data = Array2D.randNormal([1, 2]);
+      const data = NDArray.randNormal<'float32', '2'>([1, 2]);
       const batchedData = math.concat2D(data, data, 0);  // 2x2
-      const c = Array2D.randNormal([1, 1]);
+      const c = NDArray.randNormal<'float32', '2'>([1, 1]);
       const batchedC = math.concat2D(c, c, 0);  // 2x1
-      const h = Array2D.randNormal([1, 1]);
+      const h = NDArray.randNormal<'float32', '2'>([1, 1]);
       const batchedH = math.concat2D(h, h, 0);  // 2x1
       const [newC, newH] = math.basicLSTMCell(
           forgetBias, lstmKernel, lstmBias, batchedData, batchedC, batchedH);

--- a/src/math/math.ts
+++ b/src/math/math.ts
@@ -221,13 +221,13 @@ export class NDArrayMath implements NDArrayManager {
       numChannels: number): void {
     this.backend.writePixels(dataId, pixels, numChannels);
   }
-  write<D extends DataType>(dataId: number, values: DataTypeMap[D]): void {
+  write(dataId: number, values: DataTypeMap[D]): void {
     this.backend.write(dataId, values);
   }
-  readSync<D extends DataType>(dataId: number): DataTypeMap[D] {
+  readSync(dataId: number): DataTypeMap[D] {
     return this.backend.readSync(dataId);
   }
-  read<D extends DataType>(dataId: number): Promise<DataTypeMap[D]> {
+  read(dataId: number): Promise<DataTypeMap[D]> {
     return this.backend.read(dataId);
   }
 
@@ -361,46 +361,43 @@ export class NDArrayMath implements NDArrayManager {
    * Clones an NDArray of any shape.
    * @param x The NDArray to clone.
    */
-  clone<D extends DataType, R extends Rank>(x: NDArray<D, R>): NDArray<D, R> {
-    return this.engine.executeKernel('Clone', {inputs: {x}}) as NDArray<D, R>;
+  clone<R extends Rank>(x: NDArray<R>): NDArray<R> {
+    return this.engine.executeKernel('Clone', {inputs: {x}}) as NDArray<R>;
   }
 
   /** Reshapes the array. */
-  reshape<D extends DataType, R extends Rank>(
-      x: NDArray<D>, newShape: number[]): NDArray<D, R> {
+  reshape<R extends Rank>(x: NDArray, newShape: number[]): NDArray<R> {
     newShape = util.inferFromImplicitShape(newShape, x.size);
     util.assert(
         x.size === util.sizeFromShape(newShape),
         'new shape and old shape must have the same number of elements.');
 
-    const grad = (dy: NDArray<'float32'>, y: NDArray) => {
+    const grad = (dy: NDArray, y: NDArray) => {
       return {x: () => dy.reshape(x.shape)};
     };
     return this.engine.executeKernel(
-               'Reshape', {inputs: {x}, args: {newShape}}, grad) as
-        NDArray<D, R>;
+               'Reshape', {inputs: {x}, args: {newShape}}, grad) as NDArray<R>;
   }
 
   /**
    * Casts a tensor to a new type. If the new type matches the old type,
    * this is a no-op.
    */
-  cast<D extends DataType, R extends Rank>(
-      x: NDArray<DataType, R>, newDType: D): NDArray<D, R> {
-    const grad = (dy: NDArray<'float32'>, y: NDArray) => {
+  cast<R extends Rank>(x: NDArray<R>, newDType: D): NDArray<R> {
+    const grad = (dy: NDArray, y: NDArray) => {
       return {x: () => dy.reshape(dy.shape)};
     };
     return this.engine.executeKernel(
-               'Cast', {inputs: {x}, args: {newDType}}, grad) as NDArray<D, R>;
+               'Cast', {inputs: {x}, args: {newDType}}, grad) as NDArray<R>;
   }
 
   /**
    * Returns the truth value of a AND b element-wise. Supports broadcasting.
    *
-   * @param a The first input `NDArray<'bool'>`.
-   * @param b The second input `NDArray<'bool'>`.
+   * @param a The first input `NDArray`.
+   * @param b The second input `NDArray`.
    */
-  logicalAnd(a: NDArray<'bool'>, b: NDArray<'bool'>): NDArray<'bool'> {
+  logicalAnd(a: NDArray, b: NDArray): NDArray {
     util.assert(
         a.dtype === 'bool' && b.dtype === 'bool',
         'Error Array must be of type bool.');
@@ -411,10 +408,10 @@ export class NDArrayMath implements NDArrayManager {
   /**
    * Returns the truth value of a OR b element-wise. Supports broadcasting.
    *
-   * @param a The first input `NDArray<'bool'>`.
-   * @param b The second input `NDArray<'bool'>`.
+   * @param a The first input `NDArray`.
+   * @param b The second input `NDArray`.
    */
-  logicalOr(a: NDArray<'bool'>, b: NDArray<'bool'>): NDArray<'bool'> {
+  logicalOr(a: NDArray, b: NDArray): NDArray {
     util.assert(
         a.dtype === 'bool' && b.dtype === 'bool',
         'Error Array must be of type bool.');
@@ -432,7 +429,7 @@ export class NDArrayMath implements NDArrayManager {
    * @param b Input as `NDArray` with the same shape and type as `a`.
    * @return An `NDArray` with the same type and shape as `a` and `b`.
    */
-  where<T extends NDArray>(condition: NDArray<'bool'>, a: T, b: T): T {
+  where<T extends NDArray>(condition: NDArray, a: T, b: T): T {
     util.assert(
         condition.dtype === 'bool' || a.dtype === 'bool' || b.dtype === 'bool',
         'Error Array must be of type bool.');
@@ -463,13 +460,13 @@ export class NDArrayMath implements NDArrayManager {
    * @param x The input NDArray.
    * @param k How many top values to compute.
    */
-  topK(x: NDArray, k: number): {values: Array1D, indices: Array1D<'int32'>} {
+  topK(x: NDArray, k: number): {values: Array1D, indices: Array1D} {
     util.assert(
         k <= x.size,
         `Error in topK: k value (${k}) must be less than size of input ` +
             `ndarray, got shape ${x.shape}.`);
     let values: Array1D;
-    let indices: Array1D<'int32'>;
+    let indices: Array1D;
     this.scope('topK', () => {
       values =
           this.engine.executeKernel('TopKValues', {inputs: {x}, args: {k}});
@@ -487,8 +484,8 @@ export class NDArrayMath implements NDArrayManager {
    * @param dim The dimension softmax would be performed on. Defaults to -1
    *     which indicates the last dimension.
    */
-  softmax<D extends DataType, R extends Rank, T extends NDArray<'float32', R>>(
-      logits: NDArray<D, R>, dim = -1): NDArray<'float32', R> {
+  softmax<R extends Rank, T extends NDArray<R>>(logits: NDArray<R>, dim = -1):
+      NDArray<'float32', R> {
     if (dim === -1) {
       dim = logits.rank - 1;
     }
@@ -506,7 +503,7 @@ export class NDArrayMath implements NDArrayManager {
           return this.subtract(
                      dyTimesY,
                      this.multiply(this.sum(dyTimesY, [dim], keepDims), y)) as
-              NDArray<'float32', R>;
+              NDArray<R>;
         }
       };
     };
@@ -520,7 +517,7 @@ export class NDArrayMath implements NDArrayManager {
         const logResult = this.subtract(logits.asType('float32'), lse);
         const value = this.exp(logResult) as T;
         return {value, gradients};
-      }, {logits}, 'softmax') as NDArray<'float32', R>;
+      }, {logits}, 'softmax') as NDArray<R>;
     });
   }
 
@@ -548,9 +545,8 @@ export class NDArrayMath implements NDArrayManager {
    * @param dim The dimension softmax would be performed on. Defaults to -1
    *     which indicates the last dimension.
    */
-  softmaxCrossEntropyWithLogits<
-      R extends Rank, A extends NDArray<DataType, R>, B extends
-          NDArray<DataType, R>, O extends NDArray<'float32'>>(
+  softmaxCrossEntropyWithLogits<R extends Rank, A extends NDArray<R>, B extends
+                                    NDArray<R>, O extends NDArray>(
       labels: A, logits: B, dim = -1): O {
     util.assertShapesMatch(
         labels.shape, logits.shape, 'Error in softmaxCrossEntropyWithLogits: ');
@@ -596,8 +592,7 @@ export class NDArrayMath implements NDArrayManager {
   //////////////////////
 
   /** @deprecated Use math.transpose() instead. */
-  switchDim<D extends DataType, R extends Rank>(
-      x: NDArray<D, R>, perm?: number[]): NDArray<D, R> {
+  switchDim<R extends Rank>(x: NDArray<R>, perm?: number[]): NDArray<R> {
     return this.transpose(x, perm);
   }
 
@@ -613,7 +608,7 @@ export class NDArrayMath implements NDArrayManager {
    * @param x The array to transpose.
    * @param reps Determines the number of replications per dimension.
    */
-  tile<D extends DataType, T extends NDArray<D>>(x: T, reps: number[]): T {
+  tile<T extends NDArray>(x: T, reps: number[]): T {
     util.assert(
         x.rank === reps.length,
         `Error in transpose: rank of input ${x.rank} ` +
@@ -674,8 +669,7 @@ export class NDArrayMath implements NDArrayManager {
    * @param indices The indices of the values to extract.
    * @param axis Optional. The axis over which to select values. Defaults to 0.
    */
-  gather<D extends DataType, T extends NDArray<D>>(
-      x: T, indices: Array1D<'int32'>, axis = 0): T {
+  gather<T extends NDArray>(x: T, indices: Array1D, axis = 0): T {
     return this.engine.executeKernel(
                'Gather', {inputs: {x, indices}, args: {axis}}) as T;
   }
@@ -699,7 +693,7 @@ export class NDArrayMath implements NDArrayManager {
   }
 
   /** @deprecated Use math.sub(A, c) instead. */
-  arrayMinusScalar<T extends NDArray>(a: T, c: Scalar): T {
+  arrayMinusScalar(a: T, c: Scalar): T {
     util.assert(
         c.size === 1,
         `Error in arrayMinusScalar: second argument must be rank 0, but ` +
@@ -933,7 +927,7 @@ export class NDArrayMath implements NDArrayManager {
    */
   multinomial(
       probabilities: Array1D|Array2D, numSamples: number,
-      seed?: number): Array1D<'int32'>|Array2D<'int32'> {
+      seed?: number): Array1D|Array2D {
     const numOutcomes = probabilities.size;
     if (numOutcomes < 2) {
       throw new Error(
@@ -995,7 +989,7 @@ export class NDArrayMath implements NDArrayManager {
    * @return An object with two keys: `mean` and `variance`.
    */
   moments(x: NDArray, axis: number|number[] = null, keepDims = false):
-      {mean: NDArray<'float32'>, variance: NDArray<'float32'>} {
+      {mean: NDArray, variance: NDArray} {
     const axes = axis_util.parseAxisParam(axis, x.shape);
     const result = this.scope('moments', () => {
       const mean = this.mean(x, axes, keepDims);
@@ -1024,7 +1018,7 @@ export class NDArrayMath implements NDArrayManager {
    * method will return an object of the same shape.
    */
   vjp<T extends NDArray|NamedArrayMap, R extends Rank>(
-      f: () => NDArray<DataType, R>, x: T, dy: NDArray<'float32', R>): T {
+      f: () => NDArray<R>, x: T, dy: NDArray<R>): T {
     const keys = x instanceof NDArray ? null : Object.keys(x);
     const xs = util.flattenNameArrayMap(x, keys);
 
@@ -1049,7 +1043,7 @@ export class NDArrayMath implements NDArrayManager {
    * method will return an object of the same shape.
    */
   gradients<T extends NDArray|NamedArrayMap, D extends DataType>(
-      f: () => Scalar<D>, x: T): T {
+      f: () => Scalar, x: T): T {
     const keys = x instanceof NDArray ? null : Object.keys(x);
     const xs = util.flattenNameArrayMap(x, keys);
 
@@ -1071,9 +1065,8 @@ export class NDArrayMath implements NDArrayManager {
    * @param varList An optional list of variables to provide gradients with
    * respect to. Defaults to all trainable variables.
    */
-  variableGradients<D extends DataType>(
-      f: () => Scalar<D>,
-      varList?: Variable[]): {value: Scalar<D>, gradients: NamedArrayMap} {
+  variableGradients(f: () => Scalar, varList?: Variable[]):
+      {value: Scalar, gradients: NamedArrayMap} {
     if (varList == null) {
       // Get all of the trainable variables.
       varList = [];
@@ -1105,7 +1098,7 @@ export class NDArrayMath implements NDArrayManager {
    * this method will return an object of the same shape.
    */
   valueAndGradients<T extends NDArray|NamedArrayMap, D extends DataType>(
-      f: () => Scalar<D>, x: T): {value: Scalar, gradients: T} {
+      f: () => Scalar, x: T): {value: Scalar, gradients: T} {
     const keys = x instanceof NDArray ? null : Object.keys(x);
     const xs = util.flattenNameArrayMap(x, keys);
 
@@ -1133,13 +1126,13 @@ export class NDArrayMath implements NDArrayManager {
    * @param name An optional name for the customGradient method. Used for
    * debugging.
    */
-  customGradient<D extends DataType, R extends Rank>(
+  customGradient<R extends Rank>(
       f: () => {
-        value: NDArray<D, R>,
-        gradients: (dy: NDArray<'float32', R>, y: NDArray<D, R>) =>
-            TapeNodeInputGradientArrays
+        value: NDArray<R>,
+        gradients:
+            (dy: NDArray<R>, y: NDArray<R>) => TapeNodeInputGradientArrays
       },
-      inputs: NamedArrayMap, name?: string): NDArray<D, R> {
+      inputs: NamedArrayMap, name?: string): NDArray<R> {
     return this.engine.customGradient(f, inputs, name == null ? '' : name);
   }
 

--- a/src/math/math.ts
+++ b/src/math/math.ts
@@ -40,7 +40,7 @@ import * as reverse from './reverse';
 import * as slice from './slice';
 import * as transpose from './transpose';
 import * as types from './types';
-import {DataType, DataVal, Rank} from './types';
+import {DataType, Rank, TypedArray} from './types';
 import * as unary_ops from './unary_ops';
 
 export interface LSTMCell {
@@ -221,13 +221,13 @@ export class NDArrayMath implements NDArrayManager {
       numChannels: number): void {
     this.backend.writePixels(dataId, pixels, numChannels);
   }
-  write(dataId: number, values: DataVal): void {
+  write(dataId: number, values: TypedArray): void {
     this.backend.write(dataId, values);
   }
-  readSync(dataId: number): DataVal {
+  readSync(dataId: number): TypedArray {
     return this.backend.readSync(dataId);
   }
-  read(dataId: number): Promise<DataVal> {
+  read(dataId: number): Promise<TypedArray> {
     return this.backend.read(dataId);
   }
 

--- a/src/math/math.ts
+++ b/src/math/math.ts
@@ -40,7 +40,7 @@ import * as reverse from './reverse';
 import * as slice from './slice';
 import * as transpose from './transpose';
 import * as types from './types';
-import {DataType, DataTypeMap, Rank} from './types';
+import {DataType, DataVal, Rank} from './types';
 import * as unary_ops from './unary_ops';
 
 export interface LSTMCell {
@@ -221,13 +221,13 @@ export class NDArrayMath implements NDArrayManager {
       numChannels: number): void {
     this.backend.writePixels(dataId, pixels, numChannels);
   }
-  write(dataId: number, values: DataTypeMap[D]): void {
+  write(dataId: number, values: DataVal): void {
     this.backend.write(dataId, values);
   }
-  readSync(dataId: number): DataTypeMap[D] {
+  readSync(dataId: number): DataVal {
     return this.backend.readSync(dataId);
   }
-  read(dataId: number): Promise<DataTypeMap[D]> {
+  read(dataId: number): Promise<DataVal> {
     return this.backend.read(dataId);
   }
 
@@ -383,7 +383,7 @@ export class NDArrayMath implements NDArrayManager {
    * Casts a tensor to a new type. If the new type matches the old type,
    * this is a no-op.
    */
-  cast<R extends Rank>(x: NDArray<R>, newDType: D): NDArray<R> {
+  cast<R extends Rank>(x: NDArray<R>, newDType: DataType): NDArray<R> {
     const grad = (dy: NDArray, y: NDArray) => {
       return {x: () => dy.reshape(dy.shape)};
     };
@@ -485,7 +485,7 @@ export class NDArrayMath implements NDArrayManager {
    *     which indicates the last dimension.
    */
   softmax<R extends Rank, T extends NDArray<R>>(logits: NDArray<R>, dim = -1):
-      NDArray<'float32', R> {
+      NDArray<R> {
     if (dim === -1) {
       dim = logits.rank - 1;
     }
@@ -693,7 +693,7 @@ export class NDArrayMath implements NDArrayManager {
   }
 
   /** @deprecated Use math.sub(A, c) instead. */
-  arrayMinusScalar(a: T, c: Scalar): T {
+  arrayMinusScalar<T extends NDArray>(a: T, c: Scalar): T {
     util.assert(
         c.size === 1,
         `Error in arrayMinusScalar: second argument must be rank 0, but ` +
@@ -1042,8 +1042,7 @@ export class NDArrayMath implements NDArrayManager {
    * an object mapping a string to an NDArray. If using the object mode, this
    * method will return an object of the same shape.
    */
-  gradients<T extends NDArray|NamedArrayMap, D extends DataType>(
-      f: () => Scalar, x: T): T {
+  gradients<T extends NDArray|NamedArrayMap>(f: () => Scalar, x: T): T {
     const keys = x instanceof NDArray ? null : Object.keys(x);
     const xs = util.flattenNameArrayMap(x, keys);
 
@@ -1097,8 +1096,8 @@ export class NDArrayMath implements NDArrayManager {
    * an object mapping a string to an NDArray. If using the object mode,
    * this method will return an object of the same shape.
    */
-  valueAndGradients<T extends NDArray|NamedArrayMap, D extends DataType>(
-      f: () => Scalar, x: T): {value: Scalar, gradients: T} {
+  valueAndGradients<T extends NDArray|NamedArrayMap>(f: () => Scalar, x: T):
+      {value: Scalar, gradients: T} {
     const keys = x instanceof NDArray ? null : Object.keys(x);
     const xs = util.flattenNameArrayMap(x, keys);
 

--- a/src/math/math.ts
+++ b/src/math/math.ts
@@ -22,14 +22,26 @@ import {MathBackend} from './backends/backend';
 import {BackendEngine} from './backends/backend_engine';
 import {TapeNodeInputGradientArrays} from './backends/tape_types';
 import {ScopeFn, ScopeResult, ScopeResultImmediate} from './backends/tape_util';
+import * as batchnorm from './batchnorm';
+import * as binary_ops from './binary_ops';
 import * as broadcast_util from './broadcast_util';
+import * as compare from './compare';
+import * as concat from './concat';
+import * as conv from './conv';
+import * as matmul from './matmul';
 // tslint:disable-next-line:max-line-length
 import {Array1D, Array2D, Array3D, Array4D, NDArray, Scalar, Variable} from './ndarray';
 import * as norm from './norm';
 import * as ops from './ops';
+import * as pool from './pool';
+import * as reduction_ops from './reduction_ops';
+import * as reverse from './reverse';
+import * as slice from './slice';
+import * as transpose from './transpose';
 import * as types from './types';
 import {NamedArrayMap, NamedVariableMap} from './types';
 import {DataType, Rank, TypedArray} from './types';
+import * as unary_ops from './unary_ops';
 
 export interface LSTMCell {
   (data: Array2D, c: Array2D, h: Array2D): [Array2D, Array2D];
@@ -47,130 +59,130 @@ export class NDArrayMath implements NDArrayManager {
   private backend: MathBackend;
   private customBackend = false;
 
-  // ops.
-  matMul = ops.matMul;
-  vectorTimesMatrix = ops.vectorTimesMatrix;
-  outerProduct = ops.outerProduct;
-  matrixTimesVector = ops.matrixTimesVector;
-  dotProduct = ops.dotProduct;
+  // Ops.
+  matMul = matmul.Ops.matMul;
+  vectorTimesMatrix = matmul.Ops.vectorTimesMatrix;
+  outerProduct = matmul.Ops.outerProduct;
+  matrixTimesVector = matmul.Ops.matrixTimesVector;
+  dotProduct = matmul.Ops.dotProduct;
 
-  slice = ops.slice;
-  slice1D = ops.slice1D;
-  slice2D = ops.slice2D;
-  slice3D = ops.slice3D;
-  slice4D = ops.slice4D;
+  slice = slice.Ops.slice;
+  slice1D = slice.Ops.slice1D;
+  slice2D = slice.Ops.slice2D;
+  slice3D = slice.Ops.slice3D;
+  slice4D = slice.Ops.slice4D;
 
-  reverse = ops.reverse;
-  reverse1D = ops.reverse1D;
-  reverse2D = ops.reverse2D;
-  reverse3D = ops.reverse3D;
-  reverse4D = ops.reverse4D;
+  reverse = reverse.Ops.reverse;
+  reverse1D = reverse.Ops.reverse1D;
+  reverse2D = reverse.Ops.reverse2D;
+  reverse3D = reverse.Ops.reverse3D;
+  reverse4D = reverse.Ops.reverse4D;
 
-  concat = ops.concat;
-  concat1D = ops.concat1D;
-  concat2D = ops.concat2D;
-  concat3D = ops.concat3D;
-  concat4D = ops.concat4D;
+  concat = concat.Ops.concat;
+  concat1D = concat.Ops.concat1D;
+  concat2D = concat.Ops.concat2D;
+  concat3D = concat.Ops.concat3D;
+  concat4D = concat.Ops.concat4D;
 
-  batchNormalization = ops.batchNormalization;
-  batchNormalization2D = ops.batchNormalization2D;
-  batchNormalization3D = ops.batchNormalization3D;
-  batchNormalization4D = ops.batchNormalization4D;
+  batchNormalization = batchnorm.Ops.batchNormalization;
+  batchNormalization2D = batchnorm.Ops.batchNormalization2D;
+  batchNormalization3D = batchnorm.Ops.batchNormalization3D;
+  batchNormalization4D = batchnorm.Ops.batchNormalization4D;
 
-  avgPool = ops.avgPool;
-  maxPool = ops.maxPool;
-  minPool = ops.minPool;
+  avgPool = pool.Ops.avgPool;
+  maxPool = pool.Ops.maxPool;
+  minPool = pool.Ops.minPool;
   /** @deprecated */
-  maxPoolBackprop = ops.maxPoolBackprop;
+  maxPoolBackprop = pool.Ops.maxPoolBackprop;
 
-  conv1d = ops.conv1d;
-  conv2d = ops.conv2d;
-  conv2dTranspose = ops.conv2dTranspose;
-  depthwiseConv2D = ops.depthwiseConv2D;
+  conv1d = conv.Ops.conv1d;
+  conv2d = conv.Ops.conv2d;
+  conv2dTranspose = conv.Ops.conv2dTranspose;
+  depthwiseConv2D = conv.Ops.depthwiseConv2D;
   /** @deprecated */
-  conv2dDerBias = ops.conv2dDerBias;
+  conv2dDerBias = conv.Ops.conv2dDerBias;
   /** @deprecated */
-  conv2dDerFilter = ops.conv2dDerFilter;
+  conv2dDerFilter = conv.Ops.conv2dDerFilter;
   /** @deprecated */
-  conv2dDerInput = ops.conv2dDerInput;
+  conv2dDerInput = conv.Ops.conv2dDerInput;
 
-  argMax = ops.argMax;
-  argMaxEquals = ops.argMaxEquals;
-  argMin = ops.argMin;
-  logSumExp = ops.logSumExp;
-  max = ops.max;
-  mean = ops.mean;
-  min = ops.min;
-  sum = ops.sum;
+  argMax = reduction_ops.Ops.argMax;
+  argMaxEquals = reduction_ops.Ops.argMaxEquals;
+  argMin = reduction_ops.Ops.argMin;
+  logSumExp = reduction_ops.Ops.logSumExp;
+  max = reduction_ops.Ops.max;
+  mean = reduction_ops.Ops.mean;
+  min = reduction_ops.Ops.min;
+  sum = reduction_ops.Ops.sum;
 
-  add = ops.add;
-  addStrict = ops.addStrict;
+  add = binary_ops.Ops.add;
+  addStrict = binary_ops.Ops.addStrict;
   /** @deprecated */
-  arrayDividedByScalar = ops.arrayDividedByScalar;
-  div = ops.div;
+  arrayDividedByScalar = binary_ops.Ops.arrayDividedByScalar;
+  div = binary_ops.Ops.div;
   divide = this.div;  // Alias.
-  divStrict = ops.divStrict;
+  divStrict = binary_ops.Ops.divStrict;
   divideStrict = this.divStrict;  // Alias.
   /** @deprecated */
-  elementWiseMul = ops.elementWiseMul;
-  maximum = ops.maximum;
-  maximumStrict = ops.maximumStrict;
-  minimum = ops.minimum;
-  minimumStrict = ops.minimumStrict;
-  mul = ops.mul;
+  elementWiseMul = binary_ops.Ops.elementWiseMul;
+  maximum = binary_ops.Ops.maximum;
+  maximumStrict = binary_ops.Ops.maximumStrict;
+  minimum = binary_ops.Ops.minimum;
+  minimumStrict = binary_ops.Ops.minimumStrict;
+  mul = binary_ops.Ops.mul;
   multiply = this.mul;  // Alias.
-  mulStrict = ops.mulStrict;
+  mulStrict = binary_ops.Ops.mulStrict;
   multiplyStrict = this.mulStrict;  // Alias.
-  pow = ops.pow;
-  powStrict = ops.powStrict;
+  pow = binary_ops.Ops.pow;
+  powStrict = binary_ops.Ops.powStrict;
   /** @deprecated */
-  scalarDividedByArray = ops.scalarDividedByArray;
-  sub = ops.sub;
+  scalarDividedByArray = binary_ops.Ops.scalarDividedByArray;
+  sub = binary_ops.Ops.sub;
   subtract = this.sub;  // Alias.
-  subStrict = ops.subStrict;
+  subStrict = binary_ops.Ops.subStrict;
 
-  transpose = transpose.ops.transpose;
+  transpose = transpose.Ops.transpose;
 
-  equal = ops.equal;
-  equalStrict = ops.equalStrict;
-  greater = ops.greater;
-  greaterStrict = ops.greaterStrict;
-  greaterEqual = ops.greaterEqual;
-  greaterEqualStrict = ops.greaterEqualStrict;
-  less = ops.less;
-  lessStrict = ops.lessStrict;
-  lessEqual = ops.lessEqual;
-  lessEqualStrict = ops.lessEqualStrict;
-  notEqual = ops.notEqual;
-  notEqualStrict = ops.notEqualStrict;
+  equal = compare.Ops.equal;
+  equalStrict = compare.Ops.equalStrict;
+  greater = compare.Ops.greater;
+  greaterStrict = compare.Ops.greaterStrict;
+  greaterEqual = compare.Ops.greaterEqual;
+  greaterEqualStrict = compare.Ops.greaterEqualStrict;
+  less = compare.Ops.less;
+  lessStrict = compare.Ops.lessStrict;
+  lessEqual = compare.Ops.lessEqual;
+  lessEqualStrict = compare.Ops.lessEqualStrict;
+  notEqual = compare.Ops.notEqual;
+  notEqualStrict = compare.Ops.notEqualStrict;
 
-  abs = ops.abs;
-  acos = ops.acos;
-  asin = ops.asin;
-  atan = ops.atan;
-  ceil = ops.ceil;
-  clip = ops.clip;
-  cos = ops.cos;
-  cosh = ops.cosh;
-  elu = ops.elu;
-  exp = ops.exp;
-  floor = ops.floor;
-  leakyRelu = ops.leakyRelu;
-  log = ops.log;
-  neg = ops.neg;
-  prelu = ops.prelu;
-  relu = ops.relu;
-  selu = ops.selu;
-  sigmoid = ops.sigmoid;
-  sin = ops.sin;
-  sinh = ops.sinh;
-  sqrt = ops.sqrt;
-  square = ops.square;
-  step = ops.step;
-  tan = ops.tan;
-  tanh = ops.tanh;
+  abs = unary_ops.Ops.abs;
+  acos = unary_ops.Ops.acos;
+  asin = unary_ops.Ops.asin;
+  atan = unary_ops.Ops.atan;
+  ceil = unary_ops.Ops.ceil;
+  clip = unary_ops.Ops.clip;
+  cos = unary_ops.Ops.cos;
+  cosh = unary_ops.Ops.cosh;
+  elu = unary_ops.Ops.elu;
+  exp = unary_ops.Ops.exp;
+  floor = unary_ops.Ops.floor;
+  leakyRelu = unary_ops.Ops.leakyRelu;
+  log = unary_ops.Ops.log;
+  neg = unary_ops.Ops.neg;
+  prelu = unary_ops.Ops.prelu;
+  relu = unary_ops.Ops.relu;
+  selu = unary_ops.Ops.selu;
+  sigmoid = unary_ops.Ops.sigmoid;
+  sin = unary_ops.Ops.sin;
+  sinh = unary_ops.Ops.sinh;
+  sqrt = unary_ops.Ops.sqrt;
+  square = unary_ops.Ops.square;
+  step = unary_ops.Ops.step;
+  tan = unary_ops.Ops.tan;
+  tanh = unary_ops.Ops.tanh;
 
-  norm = ops.norm;
+  norm = norm.Ops.norm;
 
   // Public since optimizers will use it.
   registeredVariables: NamedVariableMap = {};
@@ -581,7 +593,7 @@ export class NDArrayMath implements NDArrayManager {
 
   /** @deprecated Use math.transpose() instead. */
   switchDim<R extends Rank>(x: NDArray<R>, perm?: number[]): NDArray<R> {
-    return this.transpose(x, perm);
+    return ops.transpose<R>(x, perm);
   }
 
   /**
@@ -1113,13 +1125,12 @@ export class NDArrayMath implements NDArrayManager {
    * @param name An optional name for the customGradient method. Used for
    * debugging.
    */
-  customGradient<R extends Rank>(
+  customGradient<R extends Rank, T extends NDArray<R>>(
       f: () => {
-        value: NDArray<R>,
-        gradients:
-            (dy: NDArray<R>, y: NDArray<R>) => TapeNodeInputGradientArrays
+        value: T,
+        gradients: (dy: T, y: T) => TapeNodeInputGradientArrays
       },
-      inputs: NamedArrayMap, name?: string): NDArray<R> {
+      inputs: NamedArrayMap, name?: string): T {
     return this.engine.customGradient(f, inputs, name == null ? '' : name);
   }
 

--- a/src/math/math.ts
+++ b/src/math/math.ts
@@ -17,31 +17,19 @@
 
 import {BackendType, ENV} from '../environment';
 import * as util from '../util';
-import {NamedArrayMap, NamedVariableMap} from '../util';
-
 import * as axis_util from './axis_util';
 import {MathBackend} from './backends/backend';
 import {BackendEngine} from './backends/backend_engine';
 import {TapeNodeInputGradientArrays} from './backends/tape_types';
 import {ScopeFn, ScopeResult, ScopeResultImmediate} from './backends/tape_util';
-import * as batchnorm from './batchnorm';
-import * as binary_ops from './binary_ops';
 import * as broadcast_util from './broadcast_util';
-import * as compare from './compare';
-import * as concat from './concat';
-import * as conv from './conv';
-import * as matmul from './matmul';
 // tslint:disable-next-line:max-line-length
 import {Array1D, Array2D, Array3D, Array4D, NDArray, Scalar, Variable} from './ndarray';
 import * as norm from './norm';
-import * as pool from './pool';
-import * as reduction_ops from './reduction_ops';
-import * as reverse from './reverse';
-import * as slice from './slice';
-import * as transpose from './transpose';
+import * as ops from './ops';
 import * as types from './types';
+import {NamedArrayMap, NamedVariableMap} from './types';
 import {DataType, Rank, TypedArray} from './types';
-import * as unary_ops from './unary_ops';
 
 export interface LSTMCell {
   (data: Array2D, c: Array2D, h: Array2D): [Array2D, Array2D];
@@ -59,130 +47,130 @@ export class NDArrayMath implements NDArrayManager {
   private backend: MathBackend;
   private customBackend = false;
 
-  // Ops.
-  matMul = matmul.Ops.matMul;
-  vectorTimesMatrix = matmul.Ops.vectorTimesMatrix;
-  outerProduct = matmul.Ops.outerProduct;
-  matrixTimesVector = matmul.Ops.matrixTimesVector;
-  dotProduct = matmul.Ops.dotProduct;
+  // ops.
+  matMul = ops.matMul;
+  vectorTimesMatrix = ops.vectorTimesMatrix;
+  outerProduct = ops.outerProduct;
+  matrixTimesVector = ops.matrixTimesVector;
+  dotProduct = ops.dotProduct;
 
-  slice = slice.Ops.slice;
-  slice1D = slice.Ops.slice1D;
-  slice2D = slice.Ops.slice2D;
-  slice3D = slice.Ops.slice3D;
-  slice4D = slice.Ops.slice4D;
+  slice = ops.slice;
+  slice1D = ops.slice1D;
+  slice2D = ops.slice2D;
+  slice3D = ops.slice3D;
+  slice4D = ops.slice4D;
 
-  reverse = reverse.Ops.reverse;
-  reverse1D = reverse.Ops.reverse1D;
-  reverse2D = reverse.Ops.reverse2D;
-  reverse3D = reverse.Ops.reverse3D;
-  reverse4D = reverse.Ops.reverse4D;
+  reverse = ops.reverse;
+  reverse1D = ops.reverse1D;
+  reverse2D = ops.reverse2D;
+  reverse3D = ops.reverse3D;
+  reverse4D = ops.reverse4D;
 
-  concat = concat.Ops.concat;
-  concat1D = concat.Ops.concat1D;
-  concat2D = concat.Ops.concat2D;
-  concat3D = concat.Ops.concat3D;
-  concat4D = concat.Ops.concat4D;
+  concat = ops.concat;
+  concat1D = ops.concat1D;
+  concat2D = ops.concat2D;
+  concat3D = ops.concat3D;
+  concat4D = ops.concat4D;
 
-  batchNormalization = batchnorm.Ops.batchNormalization;
-  batchNormalization2D = batchnorm.Ops.batchNormalization2D;
-  batchNormalization3D = batchnorm.Ops.batchNormalization3D;
-  batchNormalization4D = batchnorm.Ops.batchNormalization4D;
+  batchNormalization = ops.batchNormalization;
+  batchNormalization2D = ops.batchNormalization2D;
+  batchNormalization3D = ops.batchNormalization3D;
+  batchNormalization4D = ops.batchNormalization4D;
 
-  avgPool = pool.Ops.avgPool;
-  maxPool = pool.Ops.maxPool;
-  minPool = pool.Ops.minPool;
+  avgPool = ops.avgPool;
+  maxPool = ops.maxPool;
+  minPool = ops.minPool;
   /** @deprecated */
-  maxPoolBackprop = pool.Ops.maxPoolBackprop;
+  maxPoolBackprop = ops.maxPoolBackprop;
 
-  conv1d = conv.Ops.conv1d;
-  conv2d = conv.Ops.conv2d;
-  conv2dTranspose = conv.Ops.conv2dTranspose;
-  depthwiseConv2D = conv.Ops.depthwiseConv2D;
+  conv1d = ops.conv1d;
+  conv2d = ops.conv2d;
+  conv2dTranspose = ops.conv2dTranspose;
+  depthwiseConv2D = ops.depthwiseConv2D;
   /** @deprecated */
-  conv2dDerBias = conv.Ops.conv2dDerBias;
+  conv2dDerBias = ops.conv2dDerBias;
   /** @deprecated */
-  conv2dDerFilter = conv.Ops.conv2dDerFilter;
+  conv2dDerFilter = ops.conv2dDerFilter;
   /** @deprecated */
-  conv2dDerInput = conv.Ops.conv2dDerInput;
+  conv2dDerInput = ops.conv2dDerInput;
 
-  argMax = reduction_ops.Ops.argMax;
-  argMaxEquals = reduction_ops.Ops.argMaxEquals;
-  argMin = reduction_ops.Ops.argMin;
-  logSumExp = reduction_ops.Ops.logSumExp;
-  max = reduction_ops.Ops.max;
-  mean = reduction_ops.Ops.mean;
-  min = reduction_ops.Ops.min;
-  sum = reduction_ops.Ops.sum;
+  argMax = ops.argMax;
+  argMaxEquals = ops.argMaxEquals;
+  argMin = ops.argMin;
+  logSumExp = ops.logSumExp;
+  max = ops.max;
+  mean = ops.mean;
+  min = ops.min;
+  sum = ops.sum;
 
-  add = binary_ops.Ops.add;
-  addStrict = binary_ops.Ops.addStrict;
+  add = ops.add;
+  addStrict = ops.addStrict;
   /** @deprecated */
-  arrayDividedByScalar = binary_ops.Ops.arrayDividedByScalar;
-  div = binary_ops.Ops.div;
+  arrayDividedByScalar = ops.arrayDividedByScalar;
+  div = ops.div;
   divide = this.div;  // Alias.
-  divStrict = binary_ops.Ops.divStrict;
+  divStrict = ops.divStrict;
   divideStrict = this.divStrict;  // Alias.
   /** @deprecated */
-  elementWiseMul = binary_ops.Ops.elementWiseMul;
-  maximum = binary_ops.Ops.maximum;
-  maximumStrict = binary_ops.Ops.maximumStrict;
-  minimum = binary_ops.Ops.minimum;
-  minimumStrict = binary_ops.Ops.minimumStrict;
-  mul = binary_ops.Ops.mul;
+  elementWiseMul = ops.elementWiseMul;
+  maximum = ops.maximum;
+  maximumStrict = ops.maximumStrict;
+  minimum = ops.minimum;
+  minimumStrict = ops.minimumStrict;
+  mul = ops.mul;
   multiply = this.mul;  // Alias.
-  mulStrict = binary_ops.Ops.mulStrict;
+  mulStrict = ops.mulStrict;
   multiplyStrict = this.mulStrict;  // Alias.
-  pow = binary_ops.Ops.pow;
-  powStrict = binary_ops.Ops.powStrict;
+  pow = ops.pow;
+  powStrict = ops.powStrict;
   /** @deprecated */
-  scalarDividedByArray = binary_ops.Ops.scalarDividedByArray;
-  sub = binary_ops.Ops.sub;
+  scalarDividedByArray = ops.scalarDividedByArray;
+  sub = ops.sub;
   subtract = this.sub;  // Alias.
-  subStrict = binary_ops.Ops.subStrict;
+  subStrict = ops.subStrict;
 
-  transpose = transpose.Ops.transpose;
+  transpose = transpose.ops.transpose;
 
-  equal = compare.Ops.equal;
-  equalStrict = compare.Ops.equalStrict;
-  greater = compare.Ops.greater;
-  greaterStrict = compare.Ops.greaterStrict;
-  greaterEqual = compare.Ops.greaterEqual;
-  greaterEqualStrict = compare.Ops.greaterEqualStrict;
-  less = compare.Ops.less;
-  lessStrict = compare.Ops.lessStrict;
-  lessEqual = compare.Ops.lessEqual;
-  lessEqualStrict = compare.Ops.lessEqualStrict;
-  notEqual = compare.Ops.notEqual;
-  notEqualStrict = compare.Ops.notEqualStrict;
+  equal = ops.equal;
+  equalStrict = ops.equalStrict;
+  greater = ops.greater;
+  greaterStrict = ops.greaterStrict;
+  greaterEqual = ops.greaterEqual;
+  greaterEqualStrict = ops.greaterEqualStrict;
+  less = ops.less;
+  lessStrict = ops.lessStrict;
+  lessEqual = ops.lessEqual;
+  lessEqualStrict = ops.lessEqualStrict;
+  notEqual = ops.notEqual;
+  notEqualStrict = ops.notEqualStrict;
 
-  abs = unary_ops.Ops.abs;
-  acos = unary_ops.Ops.acos;
-  asin = unary_ops.Ops.asin;
-  atan = unary_ops.Ops.atan;
-  ceil = unary_ops.Ops.ceil;
-  clip = unary_ops.Ops.clip;
-  cos = unary_ops.Ops.cos;
-  cosh = unary_ops.Ops.cosh;
-  elu = unary_ops.Ops.elu;
-  exp = unary_ops.Ops.exp;
-  floor = unary_ops.Ops.floor;
-  leakyRelu = unary_ops.Ops.leakyRelu;
-  log = unary_ops.Ops.log;
-  neg = unary_ops.Ops.neg;
-  prelu = unary_ops.Ops.prelu;
-  relu = unary_ops.Ops.relu;
-  selu = unary_ops.Ops.selu;
-  sigmoid = unary_ops.Ops.sigmoid;
-  sin = unary_ops.Ops.sin;
-  sinh = unary_ops.Ops.sinh;
-  sqrt = unary_ops.Ops.sqrt;
-  square = unary_ops.Ops.square;
-  step = unary_ops.Ops.step;
-  tan = unary_ops.Ops.tan;
-  tanh = unary_ops.Ops.tanh;
+  abs = ops.abs;
+  acos = ops.acos;
+  asin = ops.asin;
+  atan = ops.atan;
+  ceil = ops.ceil;
+  clip = ops.clip;
+  cos = ops.cos;
+  cosh = ops.cosh;
+  elu = ops.elu;
+  exp = ops.exp;
+  floor = ops.floor;
+  leakyRelu = ops.leakyRelu;
+  log = ops.log;
+  neg = ops.neg;
+  prelu = ops.prelu;
+  relu = ops.relu;
+  selu = ops.selu;
+  sigmoid = ops.sigmoid;
+  sin = ops.sin;
+  sinh = ops.sinh;
+  sqrt = ops.sqrt;
+  square = ops.square;
+  step = ops.step;
+  tan = ops.tan;
+  tanh = ops.tanh;
 
-  norm = norm.Ops.norm;
+  norm = ops.norm;
 
   // Public since optimizers will use it.
   registeredVariables: NamedVariableMap = {};

--- a/src/math/math_test.ts
+++ b/src/math/math_test.ts
@@ -18,9 +18,8 @@
 import * as test_util from '../test_util';
 import {MathTests} from '../test_util';
 import * as util from '../util';
-
 import {MatrixOrientation} from './backends/types/matmul';
-import {Array1D, Array2D, Array3D, NDArray, Scalar} from './ndarray';
+import {Array1D, Array2D, NDArray, Scalar} from './ndarray';
 
 // math.scope
 {
@@ -268,7 +267,7 @@ import {Array1D, Array2D, Array3D, NDArray, Scalar} from './ndarray';
         pixels.data[i] = 250;
       }
 
-      const a = Array3D.fromPixels(pixels, 4);
+      const a = NDArray.fromPixels(pixels, 4);
       const b = Scalar.new(20, 'int32');
 
       const res = math.add(a, b);

--- a/src/math/math_test.ts
+++ b/src/math/math_test.ts
@@ -640,7 +640,7 @@ import {Array1D, Array2D, NDArray, Scalar} from './ndarray';
         return math.customGradient(() => {
           const value = math.pow(a, b);
 
-          const gradients = (dy: NDArray<'float32'>, y: NDArray) => {
+          const gradients = (dy: NDArray, y: NDArray) => {
             return {a: () => math.multiply(dy, Scalar.new(3))};
           };
 
@@ -663,7 +663,7 @@ import {Array1D, Array2D, NDArray, Scalar} from './ndarray';
         return math.vjp(() => {
           return math.customGradient(() => {
             const value = math.pow(a, b);
-            const gradients = (dy: NDArray<'float32'>, y: NDArray) => {
+            const gradients = (dy: NDArray, y: NDArray) => {
               return {a: () => math.multiply(dy, a)};
             };
 

--- a/src/math/matmul.ts
+++ b/src/math/matmul.ts
@@ -20,7 +20,6 @@ import * as util from '../util';
 import {MatrixOrientation} from './backends/types/matmul';
 import {operation} from './decorators';
 import {Array1D, Array2D, Scalar} from './ndarray';
-import {DataType} from './types';
 
 export class Ops {
   /**
@@ -35,9 +34,9 @@ export class Ops {
    * compute A * B^T.
    */
   @operation
-  static matMul<D extends DataType>(
-      a: Array2D<D>, b: Array2D<D>, aOrientation = MatrixOrientation.REGULAR,
-      bOrientation = MatrixOrientation.REGULAR): Array2D<D> {
+  static matMul(
+      a: Array2D, b: Array2D, aOrientation = MatrixOrientation.REGULAR,
+      bOrientation = MatrixOrientation.REGULAR): Array2D {
     const innerShapeA =
         (aOrientation === MatrixOrientation.REGULAR) ? a.shape[1] : a.shape[0];
     const innerShapeB =
@@ -57,22 +56,21 @@ export class Ops {
 
     return ENV.engine.executeKernel(
                'MatMul', {inputs: {a, b}, args: {aOrientation, bOrientation}},
-               (dy: Array2D<'float32'>, y: Array2D) => {
+               (dy: Array2D, y: Array2D) => {
                  if (aOrientation === MatrixOrientation.TRANSPOSED ||
                      bOrientation === MatrixOrientation.TRANSPOSED) {
                    throw new Error(
                        `Backprop for transposed MatMul not yet implemented.`);
                  }
                  return {
-                   a: () =>
-                       dy.matMul(
-                           b.asType('float32'), MatrixOrientation.REGULAR,
-                           MatrixOrientation.TRANSPOSED) as Array2D<'float32'>,
+                   a: () => dy.matMul(
+                                b.asType('float32'), MatrixOrientation.REGULAR,
+                                MatrixOrientation.TRANSPOSED) as Array2D,
                    b: () => a.asType('float32').matMul(
                                 dy, MatrixOrientation.TRANSPOSED,
-                                MatrixOrientation.REGULAR) as Array2D<'float32'>
+                                MatrixOrientation.REGULAR) as Array2D
                  };
-               }) as Array2D<D>;
+               }) as Array2D;
   }
 
   /**

--- a/src/math/matmul_test.ts
+++ b/src/math/matmul_test.ts
@@ -20,6 +20,7 @@ import * as test_util from '../test_util';
 import {MathTests} from '../test_util';
 import {MatrixOrientation} from './backends/types/matmul';
 import {Array1D, Array2D, Array3D} from './ndarray';
+import {Rank} from './types';
 
 const commonTests: MathTests = it => {
   it('A x B', math => {
@@ -66,8 +67,8 @@ const commonTests: MathTests = it => {
   });
 
   it('A x B^t shapes do not match', math => {
-    const a = dl.zeros<'2'>([2, 3]);
-    const b = dl.zeros<'2'>([3, 2]);
+    const a = dl.zeros<Rank.R2>([2, 3]);
+    const b = dl.zeros<Rank.R2>([3, 2]);
 
     const f = () => {
       math.matMul(
@@ -77,8 +78,8 @@ const commonTests: MathTests = it => {
   });
 
   it('A^t x B shapes do not match', math => {
-    const a = dl.zeros<'2'>([2, 3]);
-    const b = dl.zeros<'2'>([3, 2]);
+    const a = dl.zeros<Rank.R2>([2, 3]);
+    const b = dl.zeros<Rank.R2>([3, 2]);
 
     const f = () => {
       math.matMul(
@@ -88,8 +89,8 @@ const commonTests: MathTests = it => {
   });
 
   it('A^t x B^t shapes do not match', math => {
-    const a = dl.zeros<'2'>([3, 2]);
-    const b = dl.zeros<'2'>([3, 2]);
+    const a = dl.zeros<Rank.R2>([3, 2]);
+    const b = dl.zeros<Rank.R2>([3, 2]);
 
     const f = () => {
       math.matMul(
@@ -271,11 +272,11 @@ const gpuTests: MathTests = it => {
   it('Matrix times vector, large matrix', math => {
     const maxTexSize = 16000;
     const sharedDim = maxTexSize + 4;
-    const matrix = dl.zeros<'2'>([2, sharedDim]);
+    const matrix = dl.zeros<Rank.R2>([2, sharedDim]);
     matrix.set(1, 0, sharedDim - 3);
     matrix.set(1, 0, sharedDim - 2);
 
-    const v = dl.zeros<'1'>([sharedDim]);
+    const v = dl.zeros<Rank.R1>([sharedDim]);
     v.set(1, sharedDim - 3);
     v.set(1, sharedDim - 2);
 

--- a/src/math/matmul_test.ts
+++ b/src/math/matmul_test.ts
@@ -65,8 +65,8 @@ const commonTests: MathTests = it => {
   });
 
   it('A x B^t shapes do not match', math => {
-    const a = NDArray.zeros<'float32', '2'>([2, 3]);
-    const b = NDArray.zeros<'float32', '2'>([3, 2]);
+    const a = NDArray.zeros<'2'>([2, 3]);
+    const b = NDArray.zeros<'2'>([3, 2]);
 
     const f = () => {
       math.matMul(
@@ -76,8 +76,8 @@ const commonTests: MathTests = it => {
   });
 
   it('A^t x B shapes do not match', math => {
-    const a = NDArray.zeros<'float32', '2'>([2, 3]);
-    const b = NDArray.zeros<'float32', '2'>([3, 2]);
+    const a = NDArray.zeros<'2'>([2, 3]);
+    const b = NDArray.zeros<'2'>([3, 2]);
 
     const f = () => {
       math.matMul(
@@ -87,8 +87,8 @@ const commonTests: MathTests = it => {
   });
 
   it('A^t x B^t shapes do not match', math => {
-    const a = NDArray.zeros<'float32', '2'>([3, 2]);
-    const b = NDArray.zeros<'float32', '2'>([3, 2]);
+    const a = NDArray.zeros<'2'>([3, 2]);
+    const b = NDArray.zeros<'2'>([3, 2]);
 
     const f = () => {
       math.matMul(
@@ -270,11 +270,11 @@ const gpuTests: MathTests = it => {
   it('Matrix times vector, large matrix', math => {
     const maxTexSize = 16000;
     const sharedDim = maxTexSize + 4;
-    const matrix = NDArray.zeros<'float32', '2'>([2, sharedDim]);
+    const matrix = NDArray.zeros<'2'>([2, sharedDim]);
     matrix.set(1, 0, sharedDim - 3);
     matrix.set(1, 0, sharedDim - 2);
 
-    const v = NDArray.zeros<'float32', '1'>([sharedDim]);
+    const v = NDArray.zeros<'1'>([sharedDim]);
     v.set(1, sharedDim - 3);
     v.set(1, sharedDim - 2);
 

--- a/src/math/matmul_test.ts
+++ b/src/math/matmul_test.ts
@@ -18,7 +18,7 @@
 import * as test_util from '../test_util';
 import {MathTests} from '../test_util';
 import {MatrixOrientation} from './backends/types/matmul';
-import {Array1D, Array2D, Array3D} from './ndarray';
+import {Array1D, Array2D, Array3D, NDArray} from './ndarray';
 
 const commonTests: MathTests = it => {
   it('A x B', math => {
@@ -65,8 +65,8 @@ const commonTests: MathTests = it => {
   });
 
   it('A x B^t shapes do not match', math => {
-    const a = Array2D.zeros([2, 3]);
-    const b = Array2D.zeros([3, 2]);
+    const a = NDArray.zeros<'float32', '2'>([2, 3]);
+    const b = NDArray.zeros<'float32', '2'>([3, 2]);
 
     const f = () => {
       math.matMul(
@@ -76,8 +76,8 @@ const commonTests: MathTests = it => {
   });
 
   it('A^t x B shapes do not match', math => {
-    const a = Array2D.zeros([2, 3]);
-    const b = Array2D.zeros([3, 2]);
+    const a = NDArray.zeros<'float32', '2'>([2, 3]);
+    const b = NDArray.zeros<'float32', '2'>([3, 2]);
 
     const f = () => {
       math.matMul(
@@ -87,8 +87,8 @@ const commonTests: MathTests = it => {
   });
 
   it('A^t x B^t shapes do not match', math => {
-    const a = Array2D.zeros([3, 2]);
-    const b = Array2D.zeros([3, 2]);
+    const a = NDArray.zeros<'float32', '2'>([3, 2]);
+    const b = NDArray.zeros<'float32', '2'>([3, 2]);
 
     const f = () => {
       math.matMul(
@@ -270,11 +270,11 @@ const gpuTests: MathTests = it => {
   it('Matrix times vector, large matrix', math => {
     const maxTexSize = 16000;
     const sharedDim = maxTexSize + 4;
-    const matrix = Array2D.zeros([2, sharedDim]);
+    const matrix = NDArray.zeros<'float32', '2'>([2, sharedDim]);
     matrix.set(1, 0, sharedDim - 3);
     matrix.set(1, 0, sharedDim - 2);
 
-    const v = Array1D.zeros([sharedDim]);
+    const v = NDArray.zeros<'float32', '1'>([sharedDim]);
     v.set(1, sharedDim - 3);
     v.set(1, sharedDim - 2);
 

--- a/src/math/matmul_test.ts
+++ b/src/math/matmul_test.ts
@@ -15,10 +15,11 @@
  * =============================================================================
  */
 
+import * as dl from '../index';
 import * as test_util from '../test_util';
 import {MathTests} from '../test_util';
 import {MatrixOrientation} from './backends/types/matmul';
-import {Array1D, Array2D, Array3D, NDArray} from './ndarray';
+import {Array1D, Array2D, Array3D} from './ndarray';
 
 const commonTests: MathTests = it => {
   it('A x B', math => {
@@ -65,8 +66,8 @@ const commonTests: MathTests = it => {
   });
 
   it('A x B^t shapes do not match', math => {
-    const a = NDArray.zeros<'2'>([2, 3]);
-    const b = NDArray.zeros<'2'>([3, 2]);
+    const a = dl.zeros<'2'>([2, 3]);
+    const b = dl.zeros<'2'>([3, 2]);
 
     const f = () => {
       math.matMul(
@@ -76,8 +77,8 @@ const commonTests: MathTests = it => {
   });
 
   it('A^t x B shapes do not match', math => {
-    const a = NDArray.zeros<'2'>([2, 3]);
-    const b = NDArray.zeros<'2'>([3, 2]);
+    const a = dl.zeros<'2'>([2, 3]);
+    const b = dl.zeros<'2'>([3, 2]);
 
     const f = () => {
       math.matMul(
@@ -87,8 +88,8 @@ const commonTests: MathTests = it => {
   });
 
   it('A^t x B^t shapes do not match', math => {
-    const a = NDArray.zeros<'2'>([3, 2]);
-    const b = NDArray.zeros<'2'>([3, 2]);
+    const a = dl.zeros<'2'>([3, 2]);
+    const b = dl.zeros<'2'>([3, 2]);
 
     const f = () => {
       math.matMul(
@@ -270,11 +271,11 @@ const gpuTests: MathTests = it => {
   it('Matrix times vector, large matrix', math => {
     const maxTexSize = 16000;
     const sharedDim = maxTexSize + 4;
-    const matrix = NDArray.zeros<'2'>([2, sharedDim]);
+    const matrix = dl.zeros<'2'>([2, sharedDim]);
     matrix.set(1, 0, sharedDim - 3);
     matrix.set(1, 0, sharedDim - 2);
 
-    const v = NDArray.zeros<'1'>([sharedDim]);
+    const v = dl.zeros<'1'>([sharedDim]);
     v.set(1, sharedDim - 3);
     v.set(1, sharedDim - 2);
 

--- a/src/math/multinomial_test.ts
+++ b/src/math/multinomial_test.ts
@@ -58,7 +58,7 @@ const tests: MathTests = it => {
 
   it('Flip a ten-sided coin and check bounds', math => {
     const numOutcomes = 10;
-    const probs = NDArray.zeros<'float32', '1'>([numOutcomes]);
+    const probs = NDArray.zeros<'1'>([numOutcomes]);
     for (let i = 0; i < numOutcomes; ++i) {
       probs.set(1 / numOutcomes, i);
     }

--- a/src/math/multinomial_test.ts
+++ b/src/math/multinomial_test.ts
@@ -58,7 +58,7 @@ const tests: MathTests = it => {
 
   it('Flip a ten-sided coin and check bounds', math => {
     const numOutcomes = 10;
-    const probs = Array1D.zeros([numOutcomes]);
+    const probs = NDArray.zeros<'float32', '1'>([numOutcomes]);
     for (let i = 0; i < numOutcomes; ++i) {
       probs.set(1 / numOutcomes, i);
     }
@@ -91,7 +91,6 @@ const tests: MathTests = it => {
     outcomeProbs =
         computeProbs(result.dataSync().slice(2 * NUM_SAMPLES), numOutcomes);
     test_util.expectArraysClose(outcomeProbs, [1, 0, 0], EPSILON);
-
   });
 
   it('passing Array3D throws error', math => {

--- a/src/math/multinomial_test.ts
+++ b/src/math/multinomial_test.ts
@@ -19,6 +19,7 @@ import * as dl from '../index';
 import * as test_util from '../test_util';
 import {MathTests} from '../test_util';
 import {Array1D, Array2D} from './ndarray';
+import {Rank} from './types';
 
 const tests: MathTests = it => {
   const NUM_SAMPLES = 10000;
@@ -59,7 +60,7 @@ const tests: MathTests = it => {
 
   it('Flip a ten-sided coin and check bounds', math => {
     const numOutcomes = 10;
-    const probs = dl.zeros<'1'>([numOutcomes]);
+    const probs = dl.zeros<Rank.R1>([numOutcomes]);
     for (let i = 0; i < numOutcomes; ++i) {
       probs.set(1 / numOutcomes, i);
     }

--- a/src/math/multinomial_test.ts
+++ b/src/math/multinomial_test.ts
@@ -15,9 +15,10 @@
  * =============================================================================
  */
 
+import * as dl from '../index';
 import * as test_util from '../test_util';
 import {MathTests} from '../test_util';
-import {Array1D, Array2D, NDArray} from './ndarray';
+import {Array1D, Array2D} from './ndarray';
 
 const tests: MathTests = it => {
   const NUM_SAMPLES = 10000;
@@ -58,7 +59,7 @@ const tests: MathTests = it => {
 
   it('Flip a ten-sided coin and check bounds', math => {
     const numOutcomes = 10;
-    const probs = NDArray.zeros<'1'>([numOutcomes]);
+    const probs = dl.zeros<'1'>([numOutcomes]);
     for (let i = 0; i < numOutcomes; ++i) {
       probs.set(1 / numOutcomes, i);
     }
@@ -94,7 +95,7 @@ const tests: MathTests = it => {
   });
 
   it('passing Array3D throws error', math => {
-    const probs = NDArray.zeros([3, 2, 2]) as Array1D;
+    const probs = dl.zeros([3, 2, 2]) as Array1D;
     expect(() => math.multinomial(probs, 3)).toThrowError();
   });
 

--- a/src/math/ndarray.ts
+++ b/src/math/ndarray.ts
@@ -46,7 +46,7 @@ export class NDArray<R extends Rank = Rank> {
   size: number;
   /** The data type for the array. */
   dtype: DataType;
-  /** The rank type for the array ('0','1','2','3','4','higher'). */
+  /** The rank type for the array (see `Rank` enum). */
   rankType: R;
 
   /**
@@ -183,27 +183,27 @@ export class NDArray<R extends Rank = Rank> {
   asScalar(): Scalar {
     this.throwIfDisposed();
     util.assert(this.size === 1, 'The array must have only 1 element.');
-    return this.reshape<'0'>([]);
+    return this.reshape<Rank.R0>([]);
   }
 
   as1D(): Array1D {
     this.throwIfDisposed();
-    return this.reshape<'1'>([this.size]);
+    return this.reshape<Rank.R1>([this.size]);
   }
 
   as2D(rows: number, columns: number): Array2D {
     this.throwIfDisposed();
-    return this.reshape<'2'>([rows, columns]);
+    return this.reshape<Rank.R2>([rows, columns]);
   }
 
   as3D(rows: number, columns: number, depth: number): Array3D {
     this.throwIfDisposed();
-    return this.reshape<'3'>([rows, columns, depth]);
+    return this.reshape<Rank.R3>([rows, columns, depth]);
   }
 
   as4D(rows: number, columns: number, depth: number, depth2: number): Array4D {
     this.throwIfDisposed();
-    return this.reshape<'4'>([rows, columns, depth, depth2]);
+    return this.reshape<Rank.R4>([rows, columns, depth, depth2]);
   }
 
   asType<D2 extends DataType>(dtype: D2): NDArray<R> {
@@ -376,7 +376,7 @@ export class NDArray<R extends Rank = Rank> {
       pad: 'valid'|'same'|number,
       dimRoundingMode?: 'floor'|'round'|'ceil'): NDArray<R> {
     return ops.avgPool(
-               this as NDArray<'3'|'4'>, filterSize, strides, pad,
+               this as NDArray<Rank.R3|Rank.R4>, filterSize, strides, pad,
                dimRoundingMode) as NDArray<R>;
   }
   maxPool(
@@ -384,7 +384,7 @@ export class NDArray<R extends Rank = Rank> {
       pad: 'valid'|'same'|number,
       dimRoundingMode?: 'floor'|'round'|'ceil'): NDArray<R> {
     return ops.maxPool(
-               this as NDArray<'3'|'4'>, filterSize, strides, pad,
+               this as NDArray<Rank.R3|Rank.R4>, filterSize, strides, pad,
                dimRoundingMode) as NDArray<R>;
   }
   minPool(
@@ -392,7 +392,7 @@ export class NDArray<R extends Rank = Rank> {
       pad: 'valid'|'same'|number,
       dimRoundingMode?: 'floor'|'round'|'ceil'): NDArray<R> {
     return ops.minPool(
-               this as NDArray<'3'|'4'>, filterSize, strides, pad,
+               this as NDArray<Rank.R3|Rank.R4>, filterSize, strides, pad,
                dimRoundingMode) as NDArray<R>;
   }
   clone(): NDArray<R> {
@@ -592,14 +592,14 @@ export class NDArray<R extends Rank = Rank> {
   }
 }
 
-export class Scalar extends NDArray<'0'> {
+export class Scalar extends NDArray<Rank.R0> {
   static new(value: number|boolean, dtype?: DataType): Scalar {
     const values = [value] as number[] | boolean[];
     return new Scalar([], dtype, toTypedArray(values, dtype));
   }
 }
 
-export class Array1D extends NDArray<'1'> {
+export class Array1D extends NDArray<Rank.R1> {
   static new<D extends DataType = 'float32'>(
       values: DataTypeMap[D]|number[]|boolean[], dtype?: D): Array1D {
     if (!instanceofTypedArray(values)) {
@@ -613,7 +613,7 @@ export class Array1D extends NDArray<'1'> {
   }
 }
 
-export class Array2D extends NDArray<'2'> {
+export class Array2D extends NDArray<Rank.R2> {
   static new<D extends DataType = 'float32'>(
       shape: [number, number],
       values: DataTypeMap[D]|number[]|number[][]|boolean[]|boolean[][],
@@ -632,7 +632,7 @@ export class Array2D extends NDArray<'2'> {
   }
 }
 
-export class Array3D extends NDArray<'3'> {
+export class Array3D extends NDArray<Rank.R3> {
   static new<D extends DataType = 'float32'>(
       shape: [number, number, number],
       values: DataTypeMap[D]|number[]|number[][][]|boolean[]|boolean[][][],
@@ -651,7 +651,7 @@ export class Array3D extends NDArray<'3'> {
   }
 }
 
-export class Array4D extends NDArray<'4'> {
+export class Array4D extends NDArray<Rank.R4> {
   static new<D extends DataType = 'float32'>(
       shape: [number, number, number, number],
       values: DataTypeMap[D]|number[]|number[][][][]|boolean[]|boolean[][][][],

--- a/src/math/ndarray.ts
+++ b/src/math/ndarray.ts
@@ -149,16 +149,15 @@ export class NDArray<R extends Rank = Rank> {
   }
 
   /** @deprecated Please use dl.randTruncatedNormal() */
-  static randTruncatedNormal<D extends keyof RandNormalDataTypes,
-                                       R extends Rank>(
-      shape: ShapeMap[R], mean = 0, stdDev = 1, dtype?: D,
-      seed?: number): NDArray<R> {
+  static randTruncatedNormal<R extends Rank>(
+      shape: ShapeMap[R], mean = 0, stdDev = 1,
+      dtype?: keyof RandNormalDataTypes, seed?: number): NDArray<R> {
     return array_ops.Ops.randTruncatedNormal(shape, mean, stdDev, dtype, seed);
   }
 
   /** @deprecated Please use dl.randUniform() */
-  static randUniform<D extends DataType, R extends Rank>(
-      shape: ShapeMap[R], a: number, b: number, dtype?: D): NDArray<R> {
+  static randUniform<R extends Rank>(
+      shape: ShapeMap[R], a: number, b: number, dtype?: DataType): NDArray<R> {
     return array_ops.Ops.randUniform(shape, a, b, dtype);
   }
 

--- a/src/math/ndarray.ts
+++ b/src/math/ndarray.ts
@@ -17,14 +17,12 @@
 
 import {ENV} from '../environment';
 import * as util from '../util';
-import {ArrayData} from '../util';
-
 import * as array_ops from './array_ops';
 import {MatrixOrientation} from './backends/types/matmul';
 import * as ops from './ops';
 import {RandNormalDataTypes} from './rand';
 // tslint:disable-next-line:max-line-length
-import {DataType, DataTypeMap, Rank, ShapeMap, TypedArray} from './types';
+import {ArrayData, DataType, DataTypeMap, Rank, ShapeMap, TypedArray} from './types';
 
 /** @hidden */
 export interface NDArrayData {

--- a/src/math/ndarray.ts
+++ b/src/math/ndarray.ts
@@ -17,7 +17,6 @@
 
 import {ENV} from '../environment';
 import * as util from '../util';
-import * as array_ops from './array_ops';
 import {MatrixOrientation} from './backends/types/matmul';
 import * as ops from './ops';
 import {RandNormalDataTypes} from './rand';
@@ -94,28 +93,28 @@ export class NDArray<R extends Rank = Rank> {
   /** @deprecated Please use dl.ones() */
   static ones<R extends Rank>(shape: ShapeMap[R], dtype?: DataType):
       NDArray<R> {
-    return array_ops.Ops.ones(shape, dtype);
+    return ops.ones(shape, dtype);
   }
 
   /** @deprecated Please use dl.zeros() */
   static zeros<R extends Rank>(shape: ShapeMap[R], dtype?: DataType):
       NDArray<R> {
-    return array_ops.Ops.zeros(shape, dtype);
+    return ops.zeros(shape, dtype);
   }
 
   /** @deprecated Please use dl.onesLike() */
   static onesLike<T extends NDArray>(x: T): T {
-    return array_ops.Ops.onesLike(x);
+    return ops.onesLike(x);
   }
 
   /** @deprecated Please use dl.zerosLike() */
   static zerosLike<T extends NDArray>(x: T): T {
-    return array_ops.Ops.zerosLike(x);
+    return ops.zerosLike(x);
   }
 
   /** @deprecated Please use dl.clone() */
   static like<R extends Rank>(x: NDArray<R>): NDArray<R> {
-    return array_ops.Ops.clone(x);
+    return ops.clone(x);
   }
 
   /**
@@ -131,33 +130,33 @@ export class NDArray<R extends Rank = Rank> {
   static fromPixels(
       pixels: ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement,
       numChannels = 3): Array3D {
-    return array_ops.Ops.fromPixels(pixels, numChannels);
+    return ops.fromPixels(pixels, numChannels);
   }
 
   /** @deprecated Please use dl.rand() */
   static rand<D extends DataType, R extends Rank>(
       shape: ShapeMap[R], randFunction: () => number, dtype?: D): NDArray<R> {
-    return array_ops.Ops.rand(shape, randFunction, dtype);
+    return ops.rand(shape, randFunction, dtype);
   }
 
   /** @deprecated Please use dl.randNormal() */
   static randNormal<R extends Rank>(
       shape: ShapeMap[R], mean = 0, stdDev = 1,
       dtype?: keyof RandNormalDataTypes, seed?: number): NDArray<R> {
-    return array_ops.Ops.randNormal(shape, mean, stdDev, dtype, seed);
+    return ops.randNormal(shape, mean, stdDev, dtype, seed);
   }
 
   /** @deprecated Please use dl.randTruncatedNormal() */
   static randTruncatedNormal<R extends Rank>(
       shape: ShapeMap[R], mean = 0, stdDev = 1,
       dtype?: keyof RandNormalDataTypes, seed?: number): NDArray<R> {
-    return array_ops.Ops.randTruncatedNormal(shape, mean, stdDev, dtype, seed);
+    return ops.randTruncatedNormal(shape, mean, stdDev, dtype, seed);
   }
 
   /** @deprecated Please use dl.randUniform() */
   static randUniform<R extends Rank>(
       shape: ShapeMap[R], a: number, b: number, dtype?: DataType): NDArray<R> {
-    return array_ops.Ops.randUniform(shape, a, b, dtype);
+    return ops.randUniform(shape, a, b, dtype);
   }
 
   /** Reshapes the current ndarray into the provided shape. */

--- a/src/math/ndarray_test.ts
+++ b/src/math/ndarray_test.ts
@@ -19,7 +19,7 @@ import * as dl from '../index';
 import * as test_util from '../test_util';
 import {MathTests} from '../test_util';
 import {Array1D, Array2D, Array3D, Array4D, NDArray, Scalar} from './ndarray';
-import {DType} from './types';
+import {DType, Rank} from './types';
 
 const tests: MathTests = it => {
   it('NDArrays of arbitrary size', () => {
@@ -79,7 +79,7 @@ const tests: MathTests = it => {
     test_util.expectNumbersClose(t4Like.get(0, 0, 0, 1), 2);
 
     // NDArray of ones.
-    const x = dl.ones<'3'>([3, 4, 2]);
+    const x = dl.ones<Rank.R3>([3, 4, 2]);
     expect(x.rank).toBe(3);
     expect(x.size).toBe(24);
     for (let i = 0; i < 3; i++) {
@@ -91,7 +91,7 @@ const tests: MathTests = it => {
     }
 
     // NDArray of zeros.
-    const z = dl.zeros<'3'>([3, 4, 2]);
+    const z = dl.zeros<Rank.R3>([3, 4, 2]);
     expect(z.rank).toBe(3);
     expect(z.size).toBe(24);
     for (let i = 0; i < 3; i++) {
@@ -138,7 +138,7 @@ const tests: MathTests = it => {
     const a = Scalar.new(0);
     expect(a.indexToLoc(0)).toEqual([]);
 
-    const b = dl.zeros<'0'>([]);
+    const b = dl.zeros<Rank.R0>([]);
     expect(b.indexToLoc(0)).toEqual([]);
   });
 
@@ -148,7 +148,7 @@ const tests: MathTests = it => {
     expect(a.indexToLoc(1)).toEqual([1]);
     expect(a.indexToLoc(2)).toEqual([2]);
 
-    const b = dl.zeros<'1'>([3]);
+    const b = dl.zeros<Rank.R1>([3]);
     expect(b.indexToLoc(0)).toEqual([0]);
     expect(b.indexToLoc(1)).toEqual([1]);
     expect(b.indexToLoc(2)).toEqual([2]);
@@ -163,7 +163,7 @@ const tests: MathTests = it => {
     expect(a.indexToLoc(4)).toEqual([2, 0]);
     expect(a.indexToLoc(5)).toEqual([2, 1]);
 
-    const b = dl.zeros<'2'>([3, 2]);
+    const b = dl.zeros<Rank.R2>([3, 2]);
     expect(b.indexToLoc(0)).toEqual([0, 0]);
     expect(b.indexToLoc(1)).toEqual([0, 1]);
     expect(b.indexToLoc(2)).toEqual([1, 0]);
@@ -182,7 +182,7 @@ const tests: MathTests = it => {
     expect(a.indexToLoc(5)).toEqual([1, 0, 1]);
     expect(a.indexToLoc(11)).toEqual([2, 1, 1]);
 
-    const b = dl.zeros<'3'>([3, 2, 2]);
+    const b = dl.zeros<Rank.R3>([3, 2, 2]);
     expect(b.indexToLoc(0)).toEqual([0, 0, 0]);
     expect(b.indexToLoc(1)).toEqual([0, 0, 1]);
     expect(b.indexToLoc(2)).toEqual([0, 1, 0]);
@@ -205,24 +205,24 @@ const tests: MathTests = it => {
     const a = Scalar.new(0);
     expect(a.locToIndex([])).toEqual(0);
 
-    const b = dl.zeros<'0'>([]);
+    const b = dl.zeros<Rank.R0>([]);
     expect(b.locToIndex([])).toEqual(0);
   });
 
   it('locToIndex Array1D', () => {
-    const a = dl.zeros<'1'>([3]);
+    const a = dl.zeros<Rank.R1>([3]);
     expect(a.locToIndex([0])).toEqual(0);
     expect(a.locToIndex([1])).toEqual(1);
     expect(a.locToIndex([2])).toEqual(2);
 
-    const b = dl.zeros<'1'>([3]);
+    const b = dl.zeros<Rank.R1>([3]);
     expect(b.locToIndex([0])).toEqual(0);
     expect(b.locToIndex([1])).toEqual(1);
     expect(b.locToIndex([2])).toEqual(2);
   });
 
   it('locToIndex Array2D', () => {
-    const a = dl.zeros<'2'>([3, 2]);
+    const a = dl.zeros<Rank.R2>([3, 2]);
     expect(a.locToIndex([0, 0])).toEqual(0);
     expect(a.locToIndex([0, 1])).toEqual(1);
     expect(a.locToIndex([1, 0])).toEqual(2);
@@ -230,7 +230,7 @@ const tests: MathTests = it => {
     expect(a.locToIndex([2, 0])).toEqual(4);
     expect(a.locToIndex([2, 1])).toEqual(5);
 
-    const b = dl.zeros<'2'>([3, 2]);
+    const b = dl.zeros<Rank.R2>([3, 2]);
     expect(b.locToIndex([0, 0])).toEqual(0);
     expect(b.locToIndex([0, 1])).toEqual(1);
     expect(b.locToIndex([1, 0])).toEqual(2);
@@ -240,7 +240,7 @@ const tests: MathTests = it => {
   });
 
   it('locToIndex Array3D', () => {
-    const a = dl.zeros<'3'>([3, 2, 2]);
+    const a = dl.zeros<Rank.R3>([3, 2, 2]);
     expect(a.locToIndex([0, 0, 0])).toEqual(0);
     expect(a.locToIndex([0, 0, 1])).toEqual(1);
     expect(a.locToIndex([0, 1, 0])).toEqual(2);
@@ -249,7 +249,7 @@ const tests: MathTests = it => {
     expect(a.locToIndex([1, 0, 1])).toEqual(5);
     expect(a.locToIndex([2, 1, 1])).toEqual(11);
 
-    const b = dl.zeros<'3'>([3, 2, 2]);
+    const b = dl.zeros<Rank.R3>([3, 2, 2]);
     expect(b.locToIndex([0, 0, 0])).toEqual(0);
     expect(b.locToIndex([0, 0, 1])).toEqual(1);
     expect(b.locToIndex([0, 1, 0])).toEqual(2);
@@ -261,23 +261,23 @@ const tests: MathTests = it => {
 
   it('NDArray<math>', () => {
     // This test asserts compilation, not doing any run-time assertion.
-    const a: NDArray<'0'> = null;
+    const a: NDArray<Rank.R0> = null;
     const b: Scalar = a;
     expect(b).toBeNull();
 
-    const a1: NDArray<'1'> = null;
+    const a1: NDArray<Rank.R1> = null;
     const b1: Array1D = a1;
     expect(b1).toBeNull();
 
-    const a2: NDArray<'2'> = null;
+    const a2: NDArray<Rank.R2> = null;
     const b2: Array2D = a2;
     expect(b2).toBeNull();
 
-    const a3: NDArray<'3'> = null;
+    const a3: NDArray<Rank.R3> = null;
     const b3: Array3D = a3;
     expect(b3).toBeNull();
 
-    const a4: NDArray<'4'> = null;
+    const a4: NDArray<Rank.R4> = null;
     const b4: Array4D = a4;
     expect(b4).toBeNull();
   });
@@ -329,7 +329,7 @@ const testsNew: MathTests = it => {
 };
 const testsFill: MathTests = it => {
   it('1D fill', () => {
-    const a = dl.zeros<'1'>([3]);
+    const a = dl.zeros<Rank.R1>([3]);
     a.fill(2);
 
     expect(a.dtype).toBe('float32');
@@ -338,7 +338,7 @@ const testsFill: MathTests = it => {
   });
 
   it('2D fill', () => {
-    const a = dl.zeros<'1'>([3, 2]);
+    const a = dl.zeros<Rank.R1>([3, 2]);
     a.fill(2);
 
     expect(a.dtype).toBe('float32');
@@ -347,7 +347,7 @@ const testsFill: MathTests = it => {
   });
 
   it('3D fill', () => {
-    const a = dl.zeros<'1'>([3, 2, 1]);
+    const a = dl.zeros<Rank.R1>([3, 2, 1]);
     a.fill(2);
 
     expect(a.dtype).toBe('float32');
@@ -356,7 +356,7 @@ const testsFill: MathTests = it => {
   });
 
   it('4D fill', () => {
-    const a = dl.zeros<'1'>([3, 2, 1, 2]);
+    const a = dl.zeros<Rank.R1>([3, 2, 1, 2]);
     a.fill(2);
 
     expect(a.dtype).toBe('float32');

--- a/src/math/ndarray_test.ts
+++ b/src/math/ndarray_test.ts
@@ -63,9 +63,7 @@ const tests: MathTests = it => {
     expect(t.shape).toEqual([3]);
     test_util.expectNumbersClose(t.get(1), 3);
 
-    expect(() => Array3D.new([1, 2, 3, 5], [
-      1, 2
-    ])).toThrowError('Shape should be of length 3');
+    expect(() => Array3D.new([1, 2, 3, 5], [1, 2])).toThrowError();
 
     const t4 = Array4D.new([1, 2, 1, 2], [1, 2, 3, 4]);
     test_util.expectNumbersClose(t4.get(0, 0, 0, 0), 1);

--- a/src/math/ndarray_test.ts
+++ b/src/math/ndarray_test.ts
@@ -81,7 +81,7 @@ const tests: MathTests = it => {
     test_util.expectNumbersClose(t4Like.get(0, 0, 0, 1), 2);
 
     // NDArray of ones.
-    const x = dl.ones<'float32', '3'>([3, 4, 2]);
+    const x = dl.ones<'3'>([3, 4, 2]);
     expect(x.rank).toBe(3);
     expect(x.size).toBe(24);
     for (let i = 0; i < 3; i++) {
@@ -93,7 +93,7 @@ const tests: MathTests = it => {
     }
 
     // NDArray of zeros.
-    const z = dl.zeros<'float32', '3'>([3, 4, 2]);
+    const z = dl.zeros<'3'>([3, 4, 2]);
     expect(z.rank).toBe(3);
     expect(z.size).toBe(24);
     for (let i = 0; i < 3; i++) {
@@ -140,7 +140,7 @@ const tests: MathTests = it => {
     const a = Scalar.new(0);
     expect(a.indexToLoc(0)).toEqual([]);
 
-    const b = dl.zeros<'float32', '0'>([]);
+    const b = dl.zeros<'0'>([]);
     expect(b.indexToLoc(0)).toEqual([]);
   });
 
@@ -150,7 +150,7 @@ const tests: MathTests = it => {
     expect(a.indexToLoc(1)).toEqual([1]);
     expect(a.indexToLoc(2)).toEqual([2]);
 
-    const b = dl.zeros<'float32', '1'>([3]);
+    const b = dl.zeros<'1'>([3]);
     expect(b.indexToLoc(0)).toEqual([0]);
     expect(b.indexToLoc(1)).toEqual([1]);
     expect(b.indexToLoc(2)).toEqual([2]);
@@ -165,7 +165,7 @@ const tests: MathTests = it => {
     expect(a.indexToLoc(4)).toEqual([2, 0]);
     expect(a.indexToLoc(5)).toEqual([2, 1]);
 
-    const b = dl.zeros<'float32', '2'>([3, 2]);
+    const b = dl.zeros<'2'>([3, 2]);
     expect(b.indexToLoc(0)).toEqual([0, 0]);
     expect(b.indexToLoc(1)).toEqual([0, 1]);
     expect(b.indexToLoc(2)).toEqual([1, 0]);
@@ -184,7 +184,7 @@ const tests: MathTests = it => {
     expect(a.indexToLoc(5)).toEqual([1, 0, 1]);
     expect(a.indexToLoc(11)).toEqual([2, 1, 1]);
 
-    const b = dl.zeros<'float32', '3'>([3, 2, 2]);
+    const b = dl.zeros<'3'>([3, 2, 2]);
     expect(b.indexToLoc(0)).toEqual([0, 0, 0]);
     expect(b.indexToLoc(1)).toEqual([0, 0, 1]);
     expect(b.indexToLoc(2)).toEqual([0, 1, 0]);
@@ -207,24 +207,24 @@ const tests: MathTests = it => {
     const a = Scalar.new(0);
     expect(a.locToIndex([])).toEqual(0);
 
-    const b = dl.zeros<'float32', '0'>([]);
+    const b = dl.zeros<'0'>([]);
     expect(b.locToIndex([])).toEqual(0);
   });
 
   it('locToIndex Array1D', () => {
-    const a = dl.zeros<'float32', '1'>([3]);
+    const a = dl.zeros<'1'>([3]);
     expect(a.locToIndex([0])).toEqual(0);
     expect(a.locToIndex([1])).toEqual(1);
     expect(a.locToIndex([2])).toEqual(2);
 
-    const b = dl.zeros<'float32', '1'>([3]);
+    const b = dl.zeros<'1'>([3]);
     expect(b.locToIndex([0])).toEqual(0);
     expect(b.locToIndex([1])).toEqual(1);
     expect(b.locToIndex([2])).toEqual(2);
   });
 
   it('locToIndex Array2D', () => {
-    const a = dl.zeros<'float32', '2'>([3, 2]);
+    const a = dl.zeros<'2'>([3, 2]);
     expect(a.locToIndex([0, 0])).toEqual(0);
     expect(a.locToIndex([0, 1])).toEqual(1);
     expect(a.locToIndex([1, 0])).toEqual(2);
@@ -232,7 +232,7 @@ const tests: MathTests = it => {
     expect(a.locToIndex([2, 0])).toEqual(4);
     expect(a.locToIndex([2, 1])).toEqual(5);
 
-    const b = dl.zeros<'float32', '2'>([3, 2]);
+    const b = dl.zeros<'2'>([3, 2]);
     expect(b.locToIndex([0, 0])).toEqual(0);
     expect(b.locToIndex([0, 1])).toEqual(1);
     expect(b.locToIndex([1, 0])).toEqual(2);
@@ -242,7 +242,7 @@ const tests: MathTests = it => {
   });
 
   it('locToIndex Array3D', () => {
-    const a = dl.zeros<'float32', '3'>([3, 2, 2]);
+    const a = dl.zeros<'3'>([3, 2, 2]);
     expect(a.locToIndex([0, 0, 0])).toEqual(0);
     expect(a.locToIndex([0, 0, 1])).toEqual(1);
     expect(a.locToIndex([0, 1, 0])).toEqual(2);
@@ -251,7 +251,7 @@ const tests: MathTests = it => {
     expect(a.locToIndex([1, 0, 1])).toEqual(5);
     expect(a.locToIndex([2, 1, 1])).toEqual(11);
 
-    const b = dl.zeros<'float32', '3'>([3, 2, 2]);
+    const b = dl.zeros<'3'>([3, 2, 2]);
     expect(b.locToIndex([0, 0, 0])).toEqual(0);
     expect(b.locToIndex([0, 0, 1])).toEqual(1);
     expect(b.locToIndex([0, 1, 0])).toEqual(2);
@@ -261,26 +261,26 @@ const tests: MathTests = it => {
     expect(b.locToIndex([2, 1, 1])).toEqual(11);
   });
 
-  it('NDArray<D, X> is assignable to Scalar/ArrayXD', math => {
+  it('NDArray<math>', () => {
     // This test asserts compilation, not doing any run-time assertion.
-    const a: NDArray<'float32', '0'> = null;
-    const b: Scalar<'float32'> = a;
+    const a: NDArray<'0'> = null;
+    const b: Scalar = a;
     expect(b).toBeNull();
 
-    const a1: NDArray<'float32', '1'> = null;
-    const b1: Array1D<'float32'> = a1;
+    const a1: NDArray<'1'> = null;
+    const b1: Array1D = a1;
     expect(b1).toBeNull();
 
-    const a2: NDArray<'float32', '2'> = null;
-    const b2: Array2D<'float32'> = a2;
+    const a2: NDArray<'2'> = null;
+    const b2: Array2D = a2;
     expect(b2).toBeNull();
 
-    const a3: NDArray<'float32', '3'> = null;
-    const b3: Array3D<'float32'> = a3;
+    const a3: NDArray<'3'> = null;
+    const b3: Array3D = a3;
     expect(b3).toBeNull();
 
-    const a4: NDArray<'float32', '4'> = null;
-    const b4: Array4D<'float32'> = a4;
+    const a4: NDArray<'4'> = null;
+    const b4: Array4D = a4;
     expect(b4).toBeNull();
   });
 };
@@ -331,7 +331,7 @@ const testsNew: MathTests = it => {
 };
 const testsFill: MathTests = it => {
   it('1D fill', () => {
-    const a = dl.zeros<'float32', '1'>([3]);
+    const a = dl.zeros<'1'>([3]);
     a.fill(2);
 
     expect(a.dtype).toBe('float32');
@@ -340,7 +340,7 @@ const testsFill: MathTests = it => {
   });
 
   it('2D fill', () => {
-    const a = dl.zeros<'float32', '1'>([3, 2]);
+    const a = dl.zeros<'1'>([3, 2]);
     a.fill(2);
 
     expect(a.dtype).toBe('float32');
@@ -349,7 +349,7 @@ const testsFill: MathTests = it => {
   });
 
   it('3D fill', () => {
-    const a = dl.zeros<'float32', '1'>([3, 2, 1]);
+    const a = dl.zeros<'1'>([3, 2, 1]);
     a.fill(2);
 
     expect(a.dtype).toBe('float32');
@@ -358,7 +358,7 @@ const testsFill: MathTests = it => {
   });
 
   it('4D fill', () => {
-    const a = dl.zeros<'float32', '1'>([3, 2, 1, 2]);
+    const a = dl.zeros<'1'>([3, 2, 1, 2]);
     a.fill(2);
 
     expect(a.dtype).toBe('float32');

--- a/src/math/norm.ts
+++ b/src/math/norm.ts
@@ -18,7 +18,6 @@
 import * as axis_util from './axis_util';
 import {operation} from './decorators';
 import {NDArray, Scalar} from './ndarray';
-import {DataType, SumTypes} from './types';
 
 export class Ops {
   /**
@@ -50,9 +49,9 @@ export class Ops {
    * as the input.
    */
   @operation
-  static norm<D extends DataType>(
-      x: NDArray<D>, ord: number|'euclidean'|'fro' = 'euclidean',
-      axis: number|number[] = null, keepDims = false): NDArray<D|SumTypes[D]> {
+  static norm(
+      x: NDArray, ord: number|'euclidean'|'fro' = 'euclidean',
+      axis: number|number[] = null, keepDims = false): NDArray {
     const norm = normInternal(x, ord, axis);
     let keepDimsShape = norm.shape;
     if (keepDims) {
@@ -63,9 +62,8 @@ export class Ops {
   }
 }
 
-function normInternal<D extends DataType>(
-    x: NDArray<D>, p: number|string,
-    axis: number|number[] = null): NDArray<D|SumTypes[D]> {
+function normInternal(
+    x: NDArray, p: number|string, axis: number|number[] = null): NDArray {
   // scalar
   if (x.rank === 0) {
     return x.abs();
@@ -90,8 +88,7 @@ function normInternal<D extends DataType>(
     }
     if (p === 'euclidean' || p === 2) {
       // norm(x, 2) = sum(abs(xi) ^ 2) ^ 1/2
-      return x.abs().pow(Scalar.new(2, 'int32')).sum(axis).sqrt() as
-          NDArray<D|SumTypes[D]>;
+      return x.abs().pow(Scalar.new(2, 'int32')).sum(axis).sqrt() as NDArray;
     }
 
     throw new Error(`Error in norm: invalid ord value: ${p}`);
@@ -110,8 +107,7 @@ function normInternal<D extends DataType>(
     }
     if (p === 'fro' || p === 'euclidean') {
       // norm(x) = sqrt(sum(pow(x, 2)))
-      return x.pow(Scalar.new(2, 'int32')).sum(axis).sqrt() as
-          NDArray<D|SumTypes[D]>;
+      return x.pow(Scalar.new(2, 'int32')).sum(axis).sqrt() as NDArray;
     }
 
     throw new Error(`Error in norm: invalid ord value: ${p}`);

--- a/src/math/optimizers/optimizer.ts
+++ b/src/math/optimizers/optimizer.ts
@@ -23,7 +23,6 @@ import * as session_util from '../../graph/session_util';
 import {SummedTensorArrayMap, TensorArrayMap} from '../../graph/tensor_array_map';
 import {NDArrayMath} from '../../math/math';
 import {NDArray, Scalar, Variable} from '../../math/ndarray';
-import {DataType} from '../../math/types';
 import {NamedArrayMap} from '../../util';
 
 export abstract class Optimizer {
@@ -48,9 +47,8 @@ export abstract class Optimizer {
    * the trainable variables in varList will be updated by minimize. Defaults to
    * all trainable variables.
    */
-  minimize<D extends DataType>(
-      f: () => Scalar<D>, returnCost = false,
-      varList?: Variable[]): Scalar<D>|null {
+  minimize(f: () => Scalar, returnCost = false, varList?: Variable[]): Scalar
+      |null {
     const {value, gradients} = this.computeGradients(f, varList);
 
     this.applyGradients(gradients);
@@ -60,7 +58,7 @@ export abstract class Optimizer {
     varNames.forEach(varName => gradients[varName].dispose());
 
     if (returnCost) {
-      return value as Scalar<D>;
+      return value as Scalar;
     } else {
       value.dispose();
       return null;
@@ -77,9 +75,8 @@ export abstract class Optimizer {
    * respect to. If specified, only the trainable variables in varList will have
    * gradients computed with respect to. Defaults to all trainable variables.
    */
-  computeGradients<D extends DataType>(
-      f: () => Scalar<D>,
-      varList?: Variable[]): {value: Scalar<D>, gradients: NamedArrayMap} {
+  computeGradients(f: () => Scalar, varList?: Variable[]):
+      {value: Scalar, gradients: NamedArrayMap} {
     return ENV.math.variableGradients(f, varList);
   }
 

--- a/src/math/optimizers/optimizer.ts
+++ b/src/math/optimizers/optimizer.ts
@@ -23,7 +23,7 @@ import * as session_util from '../../graph/session_util';
 import {SummedTensorArrayMap, TensorArrayMap} from '../../graph/tensor_array_map';
 import {NDArrayMath} from '../../math/math';
 import {NDArray, Scalar, Variable} from '../../math/ndarray';
-import {NamedArrayMap} from '../../util';
+import {NamedArrayMap} from '../types';
 
 export abstract class Optimizer {
   protected variableNodes: VariableNode[];

--- a/src/math/optimizers/sgd_optimizer.ts
+++ b/src/math/optimizers/sgd_optimizer.ts
@@ -21,9 +21,8 @@ import {SessionRuntime} from '../../graph/session';
 // tslint:disable-next-line:max-line-length
 import {SummedTensorArrayMap, TensorArrayMap} from '../../graph/tensor_array_map';
 import {NDArrayMath} from '../../math/math';
-import {NamedArrayMap} from '../../util';
 import {Scalar} from '../ndarray';
-
+import {NamedArrayMap} from '../types';
 import {Optimizer} from './optimizer';
 
 export class SGDOptimizer extends Optimizer {

--- a/src/math/pool.ts
+++ b/src/math/pool.ts
@@ -43,7 +43,7 @@ export class Ops {
    *     is of fractional size.
    */
   @operation
-  static maxPool<R extends '3'|'4', T extends NDArray<R>>(
+  static maxPool<R extends Rank.R3|Rank.R4, T extends NDArray<R>>(
       x: T, filterSize: [number, number]|number,
       strides: [number, number]|number, pad: 'valid'|'same'|number,
       dimRoundingMode?: 'floor'|'round'|'ceil'): T {
@@ -157,7 +157,7 @@ export class Ops {
    *     is of fractional size.
    */
   @operation
-  static minPool<R extends '3'|'4', T extends NDArray<R>>(
+  static minPool<R extends Rank.R3|Rank.R4, T extends NDArray<R>>(
       input: T, filterSize: [number, number]|number,
       strides: [number, number]|number, pad: 'valid'|'same'|number,
       dimRoundingMode?: 'floor'|'round'|'ceil'): T {
@@ -206,7 +206,7 @@ export class Ops {
    *     is of fractional size.
    */
   @operation
-  static avgPool<R extends '3'|'4', T extends NDArray<R>>(
+  static avgPool<R extends Rank.R3|Rank.R4, T extends NDArray<R>>(
       x: T, filterSize: [number, number]|number,
       strides: [number, number]|number, pad: 'valid'|'same'|number,
       dimRoundingMode?: 'floor'|'round'|'ceil'): T {
@@ -255,7 +255,7 @@ export class Ops {
    *     used in the forward prop of the op.
    */
   @operation
-  static avgPoolBackprop<R extends '3'|'4', T extends NDArray<R>>(
+  static avgPoolBackprop<R extends Rank.R3|Rank.R4, T extends NDArray<R>>(
       dy: T, input: T, filterSize: [number, number]|number,
       strides: [number, number]|number, pad: 'valid'|'same'|number): T {
     util.assert(

--- a/src/math/pool.ts
+++ b/src/math/pool.ts
@@ -20,7 +20,7 @@ import * as util from '../util';
 import * as conv_util from './conv_util';
 import {operation} from './decorators';
 import {Array4D, NDArray} from './ndarray';
-import {DataType, Rank, RankMap} from './types';
+import {DataType, Rank} from './types';
 
 export class Ops {
   /**
@@ -46,7 +46,7 @@ export class Ops {
   static maxPool<D extends DataType, R extends '3'|'4'>(
       x: NDArray<D, R>, filterSize: [number, number]|number,
       strides: [number, number]|number, pad: 'valid'|'same'|number,
-      dimRoundingMode?: 'floor'|'round'|'ceil'): RankMap<D>[R] {
+      dimRoundingMode?: 'floor'|'round'|'ceil'): NDArray<D, R> {
     let x4D = x as Array4D;
     let reshapedTo4D = false;
     if (x.rank === 3) {
@@ -72,9 +72,9 @@ export class Ops {
         'MaxPool', {inputs: {x: x4D}, args: {convInfo}}, gradients);
     if (reshapedTo4D) {
       return res.as3D(res.shape[1], res.shape[2], res.shape[3]) as
-          RankMap<D>[R];
+          NDArray<D, R>;
     }
-    return res as RankMap<D>[R];
+    return res as NDArray<D, R>;
   }
 
   /**
@@ -97,7 +97,7 @@ export class Ops {
    */
   @operation
   static maxPoolBackprop<
-      D extends DataType, R extends Rank, T extends RankMap<'float32'>[R]>(
+      D extends DataType, R extends Rank, T extends NDArray<'float32', R>>(
       dy: NDArray<'float32', R>, input: NDArray<D, R>,
       filterSize: [number, number]|number, strides: [number, number]|number,
       pad: 'valid'|'same'|number, dimRoundingMode?: 'floor'|'round'|'ceil'): T {
@@ -162,7 +162,7 @@ export class Ops {
   static minPool<D extends DataType, R extends '3'|'4'>(
       input: NDArray<D, R>, filterSize: [number, number]|number,
       strides: [number, number]|number, pad: 'valid'|'same'|number,
-      dimRoundingMode?: 'floor'|'round'|'ceil'): RankMap<D>[R] {
+      dimRoundingMode?: 'floor'|'round'|'ceil'): NDArray<D, R> {
     let input4D = input as Array4D;
     let reshapedTo4D = false;
     if (input.rank === 3) {
@@ -184,9 +184,9 @@ export class Ops {
         'MinPool', {inputs: {x: input4D}, args: {convInfo}});
     if (reshapedTo4D) {
       return res.as3D(res.shape[1], res.shape[2], res.shape[3]) as
-          RankMap<D>[R];
+          NDArray<D, R>;
     }
-    return res as RankMap<D>[R];
+    return res as NDArray<D, R>;
   }
 
   /**
@@ -212,7 +212,7 @@ export class Ops {
   static avgPool<R extends '3'|'4'>(
       x: NDArray<'int32'|'float32', R>, filterSize: [number, number]|number,
       strides: [number, number]|number, pad: 'valid'|'same'|number,
-      dimRoundingMode?: 'floor'|'round'|'ceil'): RankMap<'float32'>[R] {
+      dimRoundingMode?: 'floor'|'round'|'ceil'): NDArray<'float32', R> {
     let x4D = x as Array4D;
     let reshapedTo4D = false;
     if (x.rank === 3) {
@@ -239,9 +239,9 @@ export class Ops {
         'AvgPool', {inputs: {x: x4D}, args: {convInfo}}, gradients);
     if (reshapedTo4D) {
       return res.as3D(res.shape[1], res.shape[2], res.shape[3]) as
-          RankMap<'float32'>[R];
+          NDArray<'float32', R>;
     }
-    return res as RankMap<'float32'>[R];
+    return res as NDArray<'float32', R>;
   }
 
   /**
@@ -260,7 +260,7 @@ export class Ops {
    */
   @operation
   static avgPoolBackprop<D extends DataType, R extends
-                         '3'|'4', T extends RankMap<'float32'>[R]>(
+                         '3'|'4', T extends NDArray<'float32', R>>(
       dy: NDArray<'float32', R>, input: NDArray<D, R>,
       filterSize: [number, number]|number, strides: [number, number]|number,
       pad: 'valid'|'same'|number): T {

--- a/src/math/pool.ts
+++ b/src/math/pool.ts
@@ -20,7 +20,7 @@ import * as util from '../util';
 import * as conv_util from './conv_util';
 import {operation} from './decorators';
 import {Array4D, NDArray} from './ndarray';
-import {DataType, Rank} from './types';
+import {Rank} from './types';
 
 export class Ops {
   /**
@@ -43,10 +43,10 @@ export class Ops {
    *     is of fractional size.
    */
   @operation
-  static maxPool<D extends DataType, R extends '3'|'4'>(
-      x: NDArray<D, R>, filterSize: [number, number]|number,
+  static maxPool<R extends '3'|'4'>(
+      x: NDArray<R>, filterSize: [number, number]|number,
       strides: [number, number]|number, pad: 'valid'|'same'|number,
-      dimRoundingMode?: 'floor'|'round'|'ceil'): NDArray<D, R> {
+      dimRoundingMode?: 'floor'|'round'|'ceil'): NDArray<R> {
     let x4D = x as Array4D;
     let reshapedTo4D = false;
     if (x.rank === 3) {
@@ -65,16 +65,15 @@ export class Ops {
     const convInfo = conv_util.computePool2DInfo(
         x4D.shape, filterSize, strides, pad, dimRoundingMode);
 
-    const gradients = (dy: Array4D<'float32'>, y: Array4D) => {
+    const gradients = (dy: Array4D, y: Array4D) => {
       return {x: () => Ops.maxPoolBackprop(dy, x4D, filterSize, strides, pad)};
     };
     const res = ENV.engine.executeKernel(
         'MaxPool', {inputs: {x: x4D}, args: {convInfo}}, gradients);
     if (reshapedTo4D) {
-      return res.as3D(res.shape[1], res.shape[2], res.shape[3]) as
-          NDArray<D, R>;
+      return res.as3D(res.shape[1], res.shape[2], res.shape[3]) as NDArray<R>;
     }
-    return res as NDArray<D, R>;
+    return res as NDArray<R>;
   }
 
   /**
@@ -96,11 +95,10 @@ export class Ops {
    *     is of fractional size.
    */
   @operation
-  static maxPoolBackprop<
-      D extends DataType, R extends Rank, T extends NDArray<'float32', R>>(
-      dy: NDArray<'float32', R>, input: NDArray<D, R>,
-      filterSize: [number, number]|number, strides: [number, number]|number,
-      pad: 'valid'|'same'|number, dimRoundingMode?: 'floor'|'round'|'ceil'): T {
+  static maxPoolBackprop<R extends Rank, T extends NDArray<R>>(
+      dy: NDArray<R>, input: NDArray<R>, filterSize: [number, number]|number,
+      strides: [number, number]|number, pad: 'valid'|'same'|number,
+      dimRoundingMode?: 'floor'|'round'|'ceil'): T {
     util.assert(
         input.rank === dy.rank,
         `Rank of input (${input.rank}) does not match rank of dy (${dy.rank})`);
@@ -159,10 +157,10 @@ export class Ops {
    *     is of fractional size.
    */
   @operation
-  static minPool<D extends DataType, R extends '3'|'4'>(
-      input: NDArray<D, R>, filterSize: [number, number]|number,
+  static minPool<R extends '3'|'4'>(
+      input: NDArray<R>, filterSize: [number, number]|number,
       strides: [number, number]|number, pad: 'valid'|'same'|number,
-      dimRoundingMode?: 'floor'|'round'|'ceil'): NDArray<D, R> {
+      dimRoundingMode?: 'floor'|'round'|'ceil'): NDArray<R> {
     let input4D = input as Array4D;
     let reshapedTo4D = false;
     if (input.rank === 3) {
@@ -183,10 +181,9 @@ export class Ops {
     const res = ENV.engine.executeKernel(
         'MinPool', {inputs: {x: input4D}, args: {convInfo}});
     if (reshapedTo4D) {
-      return res.as3D(res.shape[1], res.shape[2], res.shape[3]) as
-          NDArray<D, R>;
+      return res.as3D(res.shape[1], res.shape[2], res.shape[3]) as NDArray<R>;
     }
-    return res as NDArray<D, R>;
+    return res as NDArray<R>;
   }
 
   /**
@@ -210,9 +207,9 @@ export class Ops {
    */
   @operation
   static avgPool<R extends '3'|'4'>(
-      x: NDArray<'int32'|'float32', R>, filterSize: [number, number]|number,
+      x: NDArray<R>, filterSize: [number, number]|number,
       strides: [number, number]|number, pad: 'valid'|'same'|number,
-      dimRoundingMode?: 'floor'|'round'|'ceil'): NDArray<'float32', R> {
+      dimRoundingMode?: 'floor'|'round'|'ceil'): NDArray<R> {
     let x4D = x as Array4D;
     let reshapedTo4D = false;
     if (x.rank === 3) {
@@ -232,16 +229,15 @@ export class Ops {
     const convInfo =
         conv_util.computePool2DInfo(x4D.shape, filterSize, strides, pad);
 
-    const gradients = (dy: Array4D<'float32'>, y: Array4D) => {
+    const gradients = (dy: Array4D, y: Array4D) => {
       return {x: () => Ops.avgPoolBackprop(dy, x4D, filterSize, strides, pad)};
     };
     const res = ENV.engine.executeKernel(
         'AvgPool', {inputs: {x: x4D}, args: {convInfo}}, gradients);
     if (reshapedTo4D) {
-      return res.as3D(res.shape[1], res.shape[2], res.shape[3]) as
-          NDArray<'float32', R>;
+      return res.as3D(res.shape[1], res.shape[2], res.shape[3]) as NDArray<R>;
     }
-    return res as NDArray<'float32', R>;
+    return res as NDArray<R>;
   }
 
   /**
@@ -259,11 +255,9 @@ export class Ops {
    *     used in the forward prop of the op.
    */
   @operation
-  static avgPoolBackprop<D extends DataType, R extends
-                         '3'|'4', T extends NDArray<'float32', R>>(
-      dy: NDArray<'float32', R>, input: NDArray<D, R>,
-      filterSize: [number, number]|number, strides: [number, number]|number,
-      pad: 'valid'|'same'|number): T {
+  static avgPoolBackprop<R extends '3'|'4', T extends NDArray<R>>(
+      dy: NDArray<R>, input: NDArray<R>, filterSize: [number, number]|number,
+      strides: [number, number]|number, pad: 'valid'|'same'|number): T {
     util.assert(
         input.rank === dy.rank,
         `Rank of input (${input.rank}) does not match rank of dy (${dy.rank})`);

--- a/src/math/pool.ts
+++ b/src/math/pool.ts
@@ -43,10 +43,10 @@ export class Ops {
    *     is of fractional size.
    */
   @operation
-  static maxPool<R extends '3'|'4'>(
-      x: NDArray<R>, filterSize: [number, number]|number,
+  static maxPool<R extends '3'|'4', T extends NDArray<R>>(
+      x: T, filterSize: [number, number]|number,
       strides: [number, number]|number, pad: 'valid'|'same'|number,
-      dimRoundingMode?: 'floor'|'round'|'ceil'): NDArray<R> {
+      dimRoundingMode?: 'floor'|'round'|'ceil'): T {
     let x4D = x as Array4D;
     let reshapedTo4D = false;
     if (x.rank === 3) {
@@ -71,9 +71,9 @@ export class Ops {
     const res = ENV.engine.executeKernel(
         'MaxPool', {inputs: {x: x4D}, args: {convInfo}}, gradients);
     if (reshapedTo4D) {
-      return res.as3D(res.shape[1], res.shape[2], res.shape[3]) as NDArray<R>;
+      return res.as3D(res.shape[1], res.shape[2], res.shape[3]) as T;
     }
-    return res as NDArray<R>;
+    return res as T;
   }
 
   /**
@@ -96,7 +96,7 @@ export class Ops {
    */
   @operation
   static maxPoolBackprop<R extends Rank, T extends NDArray<R>>(
-      dy: NDArray<R>, input: NDArray<R>, filterSize: [number, number]|number,
+      dy: T, input: T, filterSize: [number, number]|number,
       strides: [number, number]|number, pad: 'valid'|'same'|number,
       dimRoundingMode?: 'floor'|'round'|'ceil'): T {
     util.assert(
@@ -157,10 +157,10 @@ export class Ops {
    *     is of fractional size.
    */
   @operation
-  static minPool<R extends '3'|'4'>(
-      input: NDArray<R>, filterSize: [number, number]|number,
+  static minPool<R extends '3'|'4', T extends NDArray<R>>(
+      input: T, filterSize: [number, number]|number,
       strides: [number, number]|number, pad: 'valid'|'same'|number,
-      dimRoundingMode?: 'floor'|'round'|'ceil'): NDArray<R> {
+      dimRoundingMode?: 'floor'|'round'|'ceil'): T {
     let input4D = input as Array4D;
     let reshapedTo4D = false;
     if (input.rank === 3) {
@@ -181,9 +181,9 @@ export class Ops {
     const res = ENV.engine.executeKernel(
         'MinPool', {inputs: {x: input4D}, args: {convInfo}});
     if (reshapedTo4D) {
-      return res.as3D(res.shape[1], res.shape[2], res.shape[3]) as NDArray<R>;
+      return res.as3D(res.shape[1], res.shape[2], res.shape[3]) as T;
     }
-    return res as NDArray<R>;
+    return res as T;
   }
 
   /**
@@ -206,10 +206,10 @@ export class Ops {
    *     is of fractional size.
    */
   @operation
-  static avgPool<R extends '3'|'4'>(
-      x: NDArray<R>, filterSize: [number, number]|number,
+  static avgPool<R extends '3'|'4', T extends NDArray<R>>(
+      x: T, filterSize: [number, number]|number,
       strides: [number, number]|number, pad: 'valid'|'same'|number,
-      dimRoundingMode?: 'floor'|'round'|'ceil'): NDArray<R> {
+      dimRoundingMode?: 'floor'|'round'|'ceil'): T {
     let x4D = x as Array4D;
     let reshapedTo4D = false;
     if (x.rank === 3) {
@@ -235,9 +235,9 @@ export class Ops {
     const res = ENV.engine.executeKernel(
         'AvgPool', {inputs: {x: x4D}, args: {convInfo}}, gradients);
     if (reshapedTo4D) {
-      return res.as3D(res.shape[1], res.shape[2], res.shape[3]) as NDArray<R>;
+      return res.as3D(res.shape[1], res.shape[2], res.shape[3]) as T;
     }
-    return res as NDArray<R>;
+    return res as T;
   }
 
   /**
@@ -256,7 +256,7 @@ export class Ops {
    */
   @operation
   static avgPoolBackprop<R extends '3'|'4', T extends NDArray<R>>(
-      dy: NDArray<R>, input: NDArray<R>, filterSize: [number, number]|number,
+      dy: T, input: T, filterSize: [number, number]|number,
       strides: [number, number]|number, pad: 'valid'|'same'|number): T {
     util.assert(
         input.rank === dy.rank,

--- a/src/math/reverse.ts
+++ b/src/math/reverse.ts
@@ -21,7 +21,7 @@ import * as util from '../util';
 import * as axis_util from './axis_util';
 import {operation} from './decorators';
 import {Array1D, Array2D, Array3D, Array4D, NDArray} from './ndarray';
-import {DataType, Rank, RankMap} from './types';
+import {DataType, Rank} from './types';
 
 export class Ops {
   /**
@@ -97,17 +97,17 @@ export class Ops {
    */
   @operation
   static reverse<D extends DataType, R extends Rank>(
-      x: NDArray<D, R>, axis: number|number[]): RankMap<D>[R] {
+      x: NDArray<D, R>, axis: number|number[]): NDArray<D, R> {
     if (x.rank === 0) {
       return x.reshape(x.shape);
     } else if (x.rank === 1) {
-      return Ops.reverse1D(x as Array1D<D>);
+      return Ops.reverse1D(x as Array1D<D>) as NDArray<D, R>;
     } else if (x.rank === 2) {
-      return Ops.reverse2D(x as Array2D<D>, axis);
+      return Ops.reverse2D(x as Array2D<D>, axis) as NDArray<D, R>;
     } else if (x.rank === 3) {
-      return Ops.reverse3D(x as Array3D<D>, axis);
+      return Ops.reverse3D(x as Array3D<D>, axis) as NDArray<D, R>;
     } else if (x.rank === 4) {
-      return Ops.reverse4D(x as Array4D<D>, axis);
+      return Ops.reverse4D(x as Array4D<D>, axis) as NDArray<D, R>;
     } else {
       throw new Error(`Reverse for rank ${x.rank} is not yet implemented`);
     }

--- a/src/math/reverse.ts
+++ b/src/math/reverse.ts
@@ -21,7 +21,7 @@ import * as util from '../util';
 import * as axis_util from './axis_util';
 import {operation} from './decorators';
 import {Array1D, Array2D, Array3D, Array4D, NDArray} from './ndarray';
-import {DataType, Rank} from './types';
+import {Rank} from './types';
 
 export class Ops {
   /**
@@ -29,7 +29,7 @@ export class Ops {
    * @param x The input array.
    */
   @operation
-  static reverse1D<D extends DataType>(x: Array1D<D>): Array1D<D> {
+  static reverse1D(x: Array1D): Array1D {
     util.assert(x.rank === 1, `Error in reverse1D: x must be rank 1 but got
              rank ${x.rank}.`);
     const input4D = x.as4D(1, 1, 1, x.shape[0]);
@@ -44,8 +44,7 @@ export class Ops {
    *     range [-rank(x), rank(x)).
    */
   @operation
-  static reverse2D<D extends DataType>(x: Array2D<D>, axis: number|number[]):
-      Array2D<D> {
+  static reverse2D(x: Array2D, axis: number|number[]): Array2D {
     util.assert(x.rank === 2, `Error in reverse2D: x must be rank 2 but got
              rank ${x.rank}.`);
     const axisCleaned = axis_util.parseAxisParam(axis, x.shape).map(a => a + 2);
@@ -61,8 +60,7 @@ export class Ops {
    *     range [-rank(x), rank(x)).
    */
   @operation
-  static reverse3D<D extends DataType>(x: Array3D<D>, axis: number|number[]):
-      Array3D<D> {
+  static reverse3D(x: Array3D, axis: number|number[]): Array3D {
     util.assert(x.rank === 3, `Error in reverse3D: x must be rank 3 but got
              rank ${x.rank}.`);
     const axisCleaned = axis_util.parseAxisParam(axis, x.shape).map(a => a + 1);
@@ -78,14 +76,13 @@ export class Ops {
    *     range [-rank(x), rank(x)).
    */
   @operation
-  static reverse4D<D extends DataType>(x: Array4D<D>, axis: number|number[]):
-      Array4D<D> {
+  static reverse4D(x: Array4D, axis: number|number[]): Array4D {
     util.assert(x.rank === 4, `Error in reverse4D: x must be rank 4 but got
              rank ${x.rank}.`);
     const axisCleaned = axis_util.parseAxisParam(axis, x.shape);
     return ENV.engine.executeKernel(
                'Reverse4D', {inputs: {x}, args: {axis: axisCleaned}}) as
-        Array4D<D>;
+        Array4D;
   }
 
   /**
@@ -96,18 +93,18 @@ export class Ops {
    *     range [-rank(x), rank(x)).
    */
   @operation
-  static reverse<D extends DataType, R extends Rank>(
-      x: NDArray<D, R>, axis: number|number[]): NDArray<D, R> {
+  static reverse<R extends Rank>(x: NDArray<R>, axis: number|number[]):
+      NDArray<R> {
     if (x.rank === 0) {
       return x.reshape(x.shape);
     } else if (x.rank === 1) {
-      return Ops.reverse1D(x as Array1D<D>) as NDArray<D, R>;
+      return Ops.reverse1D(x as Array1D) as NDArray<R>;
     } else if (x.rank === 2) {
-      return Ops.reverse2D(x as Array2D<D>, axis) as NDArray<D, R>;
+      return Ops.reverse2D(x as Array2D, axis) as NDArray<R>;
     } else if (x.rank === 3) {
-      return Ops.reverse3D(x as Array3D<D>, axis) as NDArray<D, R>;
+      return Ops.reverse3D(x as Array3D, axis) as NDArray<R>;
     } else if (x.rank === 4) {
-      return Ops.reverse4D(x as Array4D<D>, axis) as NDArray<D, R>;
+      return Ops.reverse4D(x as Array4D, axis) as NDArray<R>;
     } else {
       throw new Error(`Reverse for rank ${x.rank} is not yet implemented`);
     }

--- a/src/math/slice.ts
+++ b/src/math/slice.ts
@@ -19,7 +19,7 @@ import {ENV} from '../environment';
 import {operation} from './decorators';
 import {Array1D, Array2D, Array3D, Array4D, NDArray} from './ndarray';
 import * as slice_util from './slice_util';
-import {DataType, Rank, ShapeMap} from './types';
+import {Rank, ShapeMap} from './types';
 
 export class Ops {
   /**
@@ -31,11 +31,10 @@ export class Ops {
    * @param size The size of the slice.
    */
   @operation
-  static slice1D<D extends DataType>(
-      x: Array1D<D>, begin: number, size: number): Array1D<D> {
+  static slice1D(x: Array1D, begin: number, size: number): Array1D {
     slice_util.assertParamsValid(x, [begin], [size]);
     return ENV.engine.executeKernel(
-               'Slice1D', {inputs: {x}, args: {begin, size}}) as Array1D<D>;
+               'Slice1D', {inputs: {x}, args: {begin, size}}) as Array1D;
   }
 
   /**
@@ -47,12 +46,11 @@ export class Ops {
    * @param size The size of the slice.
    */
   @operation
-  static slice2D<D extends DataType>(
-      x: Array2D<D>, begin: [number, number], size: [number, number]):
-      Array2D<D> {
+  static slice2D(x: Array2D, begin: [number, number], size: [number, number]):
+      Array2D {
     slice_util.assertParamsValid(x, begin, size);
     return ENV.engine.executeKernel(
-               'Slice2D', {inputs: {x}, args: {begin, size}}) as Array2D<D>;
+               'Slice2D', {inputs: {x}, args: {begin, size}}) as Array2D;
   }
 
   /**
@@ -64,12 +62,12 @@ export class Ops {
    * @param size The size of the slice.
    */
   @operation
-  static slice3D<D extends DataType>(
-      x: Array3D<D>, begin: [number, number, number],
-      size: [number, number, number]): Array3D<D> {
+  static slice3D(x: Array3D, begin: [number, number, number], size: [
+    number, number, number
+  ]): Array3D {
     slice_util.assertParamsValid(x, begin, size);
     return ENV.engine.executeKernel(
-               'Slice3D', {inputs: {x}, args: {begin, size}}) as Array3D<D>;
+               'Slice3D', {inputs: {x}, args: {begin, size}}) as Array3D;
   }
 
   /**
@@ -82,33 +80,33 @@ export class Ops {
    * @param size The size of the slice.
    */
   @operation
-  static slice4D<D extends DataType>(
-      x: Array4D<D>, begin: [number, number, number, number],
-      size: [number, number, number, number]): Array4D<D> {
+  static slice4D(x: Array4D, begin: [number, number, number, number], size: [
+    number, number, number, number
+  ]): Array4D {
     slice_util.assertParamsValid(x, begin, size);
     return ENV.engine.executeKernel(
-               'Slice4D', {inputs: {x}, args: {begin, size}}) as Array4D<D>;
+               'Slice4D', {inputs: {x}, args: {begin, size}}) as Array4D;
   }
 
   @operation
-  static slice<D extends DataType, R extends Rank>(
-      x: NDArray<D, R>, begin: ShapeMap[R], size: ShapeMap[R]): NDArray<D, R> {
+  static slice<R extends Rank>(
+      x: NDArray<R>, begin: ShapeMap[R], size: ShapeMap[R]): NDArray<R> {
     if (x.rank === 0) {
       throw new Error('Slicing scalar is not possible');
     } else if (x.rank === 1) {
-      return Ops.slice1D(x as Array1D<D>, begin[0], size[0]) as NDArray<D, R>;
+      return Ops.slice1D(x as Array1D, begin[0], size[0]) as NDArray<R>;
     } else if (x.rank === 2) {
       return Ops.slice2D(
-                 x as Array2D<D>, begin as [number, number],
-                 size as [number, number]) as NDArray<D, R>;
+                 x as Array2D, begin as [number, number],
+                 size as [number, number]) as NDArray<R>;
     } else if (x.rank === 3) {
       return Ops.slice3D(
-                 x as Array3D<D>, begin as [number, number, number],
-                 size as [number, number, number]) as NDArray<D, R>;
+                 x as Array3D, begin as [number, number, number],
+                 size as [number, number, number]) as NDArray<R>;
     } else if (x.rank === 4) {
       return Ops.slice4D(
-                 x as Array4D<D>, begin as [number, number, number, number],
-                 size as [number, number, number, number]) as NDArray<D, R>;
+                 x as Array4D, begin as [number, number, number, number],
+                 size as [number, number, number, number]) as NDArray<R>;
     } else {
       throw new Error(`Slicing for rank ${x.rank} not implemented yet`);
     }

--- a/src/math/slice.ts
+++ b/src/math/slice.ts
@@ -19,7 +19,7 @@ import {ENV} from '../environment';
 import {operation} from './decorators';
 import {Array1D, Array2D, Array3D, Array4D, NDArray} from './ndarray';
 import * as slice_util from './slice_util';
-import {DataType, Rank, RankMap, ShapeMap} from './types';
+import {DataType, Rank, ShapeMap} from './types';
 
 export class Ops {
   /**
@@ -92,22 +92,23 @@ export class Ops {
 
   @operation
   static slice<D extends DataType, R extends Rank>(
-      x: NDArray<D, R>, begin: ShapeMap[R], size: ShapeMap[R]): RankMap<D>[R] {
+      x: NDArray<D, R>, begin: ShapeMap[R], size: ShapeMap[R]): NDArray<D, R> {
     if (x.rank === 0) {
       throw new Error('Slicing scalar is not possible');
     } else if (x.rank === 1) {
-      return Ops.slice1D(x as Array1D<D>, begin[0], size[0]);
+      return Ops.slice1D(x as Array1D<D>, begin[0], size[0]) as NDArray<D, R>;
     } else if (x.rank === 2) {
       return Ops.slice2D(
-          x as Array2D<D>, begin as [number, number], size as [number, number]);
+                 x as Array2D<D>, begin as [number, number],
+                 size as [number, number]) as NDArray<D, R>;
     } else if (x.rank === 3) {
       return Ops.slice3D(
-          x as Array3D<D>, begin as [number, number, number],
-          size as [number, number, number]);
+                 x as Array3D<D>, begin as [number, number, number],
+                 size as [number, number, number]) as NDArray<D, R>;
     } else if (x.rank === 4) {
       return Ops.slice4D(
-          x as Array4D<D>, begin as [number, number, number, number],
-          size as [number, number, number, number]);
+                 x as Array4D<D>, begin as [number, number, number, number],
+                 size as [number, number, number, number]) as NDArray<D, R>;
     } else {
       throw new Error(`Slicing for rank ${x.rank} not implemented yet`);
     }

--- a/src/math/slice_test.ts
+++ b/src/math/slice_test.ts
@@ -19,6 +19,7 @@ import * as dl from '../index';
 import * as test_util from '../test_util';
 import {MathTests} from '../test_util';
 import {Array1D, Array2D, Array3D, Array4D} from './ndarray';
+import {Rank} from './types';
 
 // math.slice1D
 {
@@ -66,13 +67,13 @@ import {Array1D, Array2D, Array3D, Array4D} from './ndarray';
     });
 
     it('returns a ndarray of slice size', math => {
-      const a = dl.zeros<'2'>([100, 100]);
+      const a = dl.zeros<Rank.R2>([100, 100]);
       const b = math.slice2D(a, [0, 0], [12, 34]);
       expect(b.shape).toEqual([12, 34]);
     });
 
     it('returns the upper-left submatrix when begin is [0, 0]', math => {
-      const a = dl.randUniform<'2'>([10, 10], -1, 1);
+      const a = dl.randUniform<Rank.R2>([10, 10], -1, 1);
       const b = math.slice2D(a, [0, 0], [2, 2]);
       const aValues = a.dataSync();
 

--- a/src/math/slice_test.ts
+++ b/src/math/slice_test.ts
@@ -15,9 +15,10 @@
  * =============================================================================
  */
 
+import * as dl from '../index';
 import * as test_util from '../test_util';
 import {MathTests} from '../test_util';
-import {Array1D, Array2D, Array3D, Array4D, NDArray} from './ndarray';
+import {Array1D, Array2D, Array3D, Array4D} from './ndarray';
 
 // math.slice1D
 {
@@ -65,13 +66,13 @@ import {Array1D, Array2D, Array3D, Array4D, NDArray} from './ndarray';
     });
 
     it('returns a ndarray of slice size', math => {
-      const a = NDArray.zeros<'2'>([100, 100]);
+      const a = dl.zeros<'2'>([100, 100]);
       const b = math.slice2D(a, [0, 0], [12, 34]);
       expect(b.shape).toEqual([12, 34]);
     });
 
     it('returns the upper-left submatrix when begin is [0, 0]', math => {
-      const a = NDArray.randUniform<'2'>([10, 10], -1, 1);
+      const a = dl.randUniform<'2'>([10, 10], -1, 1);
       const b = math.slice2D(a, [0, 0], [2, 2]);
       const aValues = a.dataSync();
 

--- a/src/math/slice_test.ts
+++ b/src/math/slice_test.ts
@@ -65,13 +65,13 @@ import {Array1D, Array2D, Array3D, Array4D, NDArray} from './ndarray';
     });
 
     it('returns a ndarray of slice size', math => {
-      const a = NDArray.zeros<'float32', '2'>([100, 100]);
+      const a = NDArray.zeros<'2'>([100, 100]);
       const b = math.slice2D(a, [0, 0], [12, 34]);
       expect(b.shape).toEqual([12, 34]);
     });
 
     it('returns the upper-left submatrix when begin is [0, 0]', math => {
-      const a = NDArray.randUniform<'float32', '2'>([10, 10], -1, 1);
+      const a = NDArray.randUniform<'2'>([10, 10], -1, 1);
       const b = math.slice2D(a, [0, 0], [2, 2]);
       const aValues = a.dataSync();
 

--- a/src/math/slice_test.ts
+++ b/src/math/slice_test.ts
@@ -17,7 +17,7 @@
 
 import * as test_util from '../test_util';
 import {MathTests} from '../test_util';
-import {Array1D, Array2D, Array3D, Array4D} from './ndarray';
+import {Array1D, Array2D, Array3D, Array4D, NDArray} from './ndarray';
 
 // math.slice1D
 {
@@ -65,13 +65,13 @@ import {Array1D, Array2D, Array3D, Array4D} from './ndarray';
     });
 
     it('returns a ndarray of slice size', math => {
-      const a = Array2D.zeros([100, 100]);
+      const a = NDArray.zeros<'float32', '2'>([100, 100]);
       const b = math.slice2D(a, [0, 0], [12, 34]);
       expect(b.shape).toEqual([12, 34]);
     });
 
     it('returns the upper-left submatrix when begin is [0, 0]', math => {
-      const a = Array2D.randUniform([10, 10], -1, 1);
+      const a = NDArray.randUniform<'float32', '2'>([10, 10], -1, 1);
       const b = math.slice2D(a, [0, 0], [2, 2]);
       const aValues = a.dataSync();
 

--- a/src/math/transpose.ts
+++ b/src/math/transpose.ts
@@ -20,7 +20,7 @@ import * as util from '../util';
 import * as axis_util from './axis_util';
 import {operation} from './decorators';
 import {NDArray} from './ndarray';
-import {DataType, Rank} from './types';
+import {Rank} from './types';
 
 export class Ops {
   /**
@@ -35,12 +35,11 @@ export class Ops {
    * @param perm Optional. The permutation of the dimensions of a.
    */
   @operation
-  static transpose<D extends DataType, R extends Rank>(
-      x: NDArray<D, R>, perm?: number[]): NDArray<D, R> {
+  static transpose<R extends Rank>(x: NDArray<R>, perm?: number[]): NDArray<R> {
     if (perm == null) {
       perm = x.shape.map((s, i) => i).reverse();
     }
-    const der = (dy: NDArray<'float32'>) => {
+    const der = (dy: NDArray) => {
       const undoPerm = axis_util.getUndoAxesPermutation(perm);
       const derX = () => dy.transpose(undoPerm);
       return {x: derX};
@@ -50,6 +49,6 @@ export class Ops {
         `Error in transpose: rank of input ${x.rank} ` +
             `must match length of perm ${perm}.`);
     return ENV.engine.executeKernel(
-               'Transpose', {inputs: {x}, args: {perm}}, der) as NDArray<D, R>;
+               'Transpose', {inputs: {x}, args: {perm}}, der) as NDArray<R>;
   }
 }

--- a/src/math/transpose.ts
+++ b/src/math/transpose.ts
@@ -20,7 +20,7 @@ import * as util from '../util';
 import * as axis_util from './axis_util';
 import {operation} from './decorators';
 import {NDArray} from './ndarray';
-import {DataType, Rank, RankMap} from './types';
+import {DataType, Rank} from './types';
 
 export class Ops {
   /**
@@ -36,7 +36,7 @@ export class Ops {
    */
   @operation
   static transpose<D extends DataType, R extends Rank>(
-      x: NDArray<D, R>, perm?: number[]): RankMap<D>[R] {
+      x: NDArray<D, R>, perm?: number[]): NDArray<D, R> {
     if (perm == null) {
       perm = x.shape.map((s, i) => i).reverse();
     }
@@ -50,6 +50,6 @@ export class Ops {
         `Error in transpose: rank of input ${x.rank} ` +
             `must match length of perm ${perm}.`);
     return ENV.engine.executeKernel(
-               'Transpose', {inputs: {x}, args: {perm}}, der) as RankMap<D>[R];
+               'Transpose', {inputs: {x}, args: {perm}}, der) as NDArray<D, R>;
   }
 }

--- a/src/math/types.ts
+++ b/src/math/types.ts
@@ -37,61 +37,26 @@ export interface DataTypeMap {
   bool: Uint8Array;
 }
 export type DataType = keyof DataTypeMap;
+export type DataVal = DataTypeMap[DataType];
 
 export type Rank = '0'|'1'|'2'|'3'|'4'|'higher';
 
-export interface SumTypes {
-  float32: 'float32';
-  int32: 'int32';
-  bool: 'int32';
-}
-
-export enum SumTypesMap {
+enum UpcastInt32AndMap {
   float32 = 'float32',
   int32 = 'int32',
   bool = 'int32'
 }
 
-export interface UpcastInt32And {
-  float32: 'float32';
-  int32: 'int32';
-  bool: 'int32';
-}
-
-export enum UpcastInt32AndMap {
-  float32 = 'float32',
-  int32 = 'int32',
-  bool = 'int32'
-}
-
-export interface UpcastBoolAnd {
-  float32: 'float32';
-  int32: 'int32';
-  bool: 'bool';
-}
-
-export enum UpcastBoolAndMap {
+enum UpcastBoolAndMap {
   float32 = 'float32',
   int32 = 'int32',
   bool = 'bool'
 }
 
-export interface UpcastFloat32And {
-  float32: 'float32';
-  int32: 'float32';
-  bool: 'float32';
-}
-
-export enum UpcastFloat32AndMap {
+enum UpcastFloat32AndMap {
   float32 = 'float32',
   int32 = 'float32',
   bool = 'float32'
-}
-
-export interface UpcastType {
-  float32: UpcastFloat32And;
-  int32: UpcastInt32And;
-  bool: UpcastBoolAnd;
 }
 
 const upcastTypeMap = {

--- a/src/math/types.ts
+++ b/src/math/types.ts
@@ -37,7 +37,7 @@ export interface DataTypeMap {
   bool: Uint8Array;
 }
 export type DataType = keyof DataTypeMap;
-export type DataVal = DataTypeMap[DataType];
+export type TypedArray = DataTypeMap[DataType];
 
 export type Rank = '0'|'1'|'2'|'3'|'4'|'higher';
 

--- a/src/math/types.ts
+++ b/src/math/types.ts
@@ -24,12 +24,11 @@ export enum DType {
 }
 
 export interface ShapeMap {
-  0: number[];
-  1: [number];
-  2: [number, number];
-  3: [number, number, number];
-  4: [number, number, number, number];
-  higher: number[];
+  R0: number[];
+  R1: [number];
+  R2: [number, number];
+  R3: [number, number, number];
+  R4: [number, number, number, number];
 }
 
 /** @hidden */
@@ -41,8 +40,13 @@ export interface DataTypeMap {
 export type DataType = keyof DataTypeMap;
 export type TypedArray = DataTypeMap[DataType];
 
-// TODO(smilkov): Make this enum.
-export type Rank = '0'|'1'|'2'|'3'|'4'|'higher';
+export enum Rank {
+  R0 = 'R0',
+  R1 = 'R1',
+  R2 = 'R2',
+  R3 = 'R3',
+  R4 = 'R4'
+}
 
 export type FlatVector = boolean[]|number[]|TypedArray;
 export type RegularArray<T> = T[]|T[][]|T[][][]|T[][][][];

--- a/src/math/types.ts
+++ b/src/math/types.ts
@@ -41,6 +41,7 @@ export interface DataTypeMap {
 export type DataType = keyof DataTypeMap;
 export type TypedArray = DataTypeMap[DataType];
 
+// TODO(smilkov): Make this enum.
 export type Rank = '0'|'1'|'2'|'3'|'4'|'higher';
 
 export type FlatVector = boolean[]|number[]|TypedArray;
@@ -82,4 +83,9 @@ const upcastTypeMap = {
 
 export function upcastType(typeA: DataType, typeB: DataType): DataType {
   return upcastTypeMap[typeA][typeB];
+}
+
+/** Returns the output type after summation. */
+export function sumOutType(type: DataType) {
+  return upcastType(type, 'int32');
 }

--- a/src/math/types.ts
+++ b/src/math/types.ts
@@ -15,8 +15,6 @@
  * =============================================================================
  */
 
-import {Array1D, Array2D, Array3D, Array4D, NDArray, Scalar} from './ndarray';
-
 export enum DType {
   float32 = 'float32',
   int32 = 'int32',
@@ -40,16 +38,7 @@ export interface DataTypeMap {
 }
 export type DataType = keyof DataTypeMap;
 
-/** @hidden */
-export interface RankMap<D extends DataType> {
-  0: Scalar<D>;
-  1: Array1D<D>;
-  2: Array2D<D>;
-  3: Array3D<D>;
-  4: Array4D<D>;
-  higher: NDArray<D, 'higher'>;
-}
-export type Rank = keyof RankMap<DataType>;
+export type Rank = '0'|'1'|'2'|'3'|'4'|'higher';
 
 export interface SumTypes {
   float32: 'float32';

--- a/src/math/types.ts
+++ b/src/math/types.ts
@@ -15,6 +15,8 @@
  * =============================================================================
  */
 
+import {NDArray, Variable} from './ndarray';
+
 export enum DType {
   float32 = 'float32',
   int32 = 'int32',
@@ -40,6 +42,19 @@ export type DataType = keyof DataTypeMap;
 export type TypedArray = DataTypeMap[DataType];
 
 export type Rank = '0'|'1'|'2'|'3'|'4'|'higher';
+
+export type FlatVector = boolean[]|number[]|TypedArray;
+export type RegularArray<T> = T[]|T[][]|T[][][]|T[][][][];
+export type ArrayData<D extends DataType> =
+    DataTypeMap[D]|RegularArray<number>|RegularArray<boolean>;
+
+export type NamedArrayMap = {
+  [name: string]: NDArray
+};
+
+export type NamedVariableMap = {
+  [name: string]: Variable;
+};
 
 enum UpcastInt32AndMap {
   float32 = 'float32',

--- a/src/math/unary_ops.ts
+++ b/src/math/unary_ops.ts
@@ -19,7 +19,7 @@ import {ENV} from '../environment';
 import * as util from '../util';
 import {operation} from './decorators';
 import {NDArray, Scalar} from './ndarray';
-import {DataType, Rank} from './types';
+import {Rank} from './types';
 
 export class Ops {
   /**

--- a/src/math/unary_ops.ts
+++ b/src/math/unary_ops.ts
@@ -19,7 +19,7 @@ import {ENV} from '../environment';
 import * as util from '../util';
 import {operation} from './decorators';
 import {NDArray, Scalar} from './ndarray';
-import {DataType, Rank, RankMap} from './types';
+import {DataType, Rank} from './types';
 
 export class Ops {
   /**
@@ -28,8 +28,8 @@ export class Ops {
    */
   @operation
   static neg<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      RankMap<D>[R] {
-    return ENV.engine.executeKernel('Neg', {inputs: {x}}) as RankMap<D>[R];
+      NDArray<D, R> {
+    return ENV.engine.executeKernel('Neg', {inputs: {x}}) as NDArray<D, R>;
   }
 
   /**
@@ -40,8 +40,8 @@ export class Ops {
    */
   @operation
   static ceil<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      RankMap<D>[R] {
-    return ENV.engine.executeKernel('Ceil', {inputs: {x}}) as RankMap<D>[R];
+      NDArray<D, R> {
+    return ENV.engine.executeKernel('Ceil', {inputs: {x}}) as NDArray<D, R>;
   }
 
   /**
@@ -51,8 +51,8 @@ export class Ops {
    */
   @operation
   static floor<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      RankMap<D>[R] {
-    return ENV.engine.executeKernel('Floor', {inputs: {x}}) as RankMap<D>[R];
+      NDArray<D, R> {
+    return ENV.engine.executeKernel('Floor', {inputs: {x}}) as NDArray<D, R>;
   }
 
   /**
@@ -61,8 +61,8 @@ export class Ops {
    */
   @operation
   static exp<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      RankMap<D>[R] {
-    return ENV.engine.executeKernel('Exp', {inputs: {x}}) as RankMap<D>[R];
+      NDArray<D, R> {
+    return ENV.engine.executeKernel('Exp', {inputs: {x}}) as NDArray<D, R>;
   }
 
   /**
@@ -71,8 +71,8 @@ export class Ops {
    */
   @operation
   static log<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      RankMap<D>[R] {
-    return ENV.engine.executeKernel('Log', {inputs: {x}}) as RankMap<D>[R];
+      NDArray<D, R> {
+    return ENV.engine.executeKernel('Log', {inputs: {x}}) as NDArray<D, R>;
   }
 
   /**
@@ -81,7 +81,7 @@ export class Ops {
    */
   @operation
   static sqrt<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      RankMap<D>[R] {
+      NDArray<D, R> {
     return ENV.engine.executeKernel(
                'Sqrt', {inputs: {x}},
                (dy: NDArray<'float32', R>, y: NDArray<D, R>) => {
@@ -89,7 +89,7 @@ export class Ops {
                    x: () =>
                        dy.div(x.asType('float32').sqrt().mul(Scalar.new(2)))
                  };
-               }) as RankMap<D>[R];
+               }) as NDArray<D, R>;
   }
 
   /**
@@ -99,14 +99,14 @@ export class Ops {
    */
   @operation
   static square<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      RankMap<D>[R] {
+      NDArray<D, R> {
     return ENV.engine.executeKernel(
                'Square', {inputs: {x}},
-               (dy: NDArray<'float32', R>, y: RankMap<D>[R]) => {
+               (dy: NDArray<'float32', R>, y: NDArray<D, R>) => {
                  return {
                    x: () => dy.mul(x.asType('float32').mul(Scalar.new(2)))
                  };
-               }) as RankMap<D>[R];
+               }) as NDArray<D, R>;
   }
 
   /**
@@ -115,12 +115,12 @@ export class Ops {
    */
   @operation
   static abs<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      RankMap<D>[R] {
+      NDArray<D, R> {
     return ENV.engine.executeKernel(
                'Abs', {inputs: {x}},
                (dy: NDArray<'float32', R>, y: NDArray<D, R>) => {
                  return {x: () => dy.mul(x.toFloat().step(-1))};
-               }) as RankMap<D>[R];
+               }) as NDArray<D, R>;
   }
 
   /**
@@ -131,13 +131,13 @@ export class Ops {
    */
   @operation
   static clip<D extends DataType, R extends Rank>(
-      x: NDArray<D, R>, min: number, max: number): RankMap<D>[R] {
+      x: NDArray<D, R>, min: number, max: number): NDArray<D, R> {
     util.assert(
         (min <= max),
         `Error in clip: min (${min}) must be` +
             `less than or equal to max (${max}).`);
     return ENV.engine.executeKernel('Clip', {inputs: {x}, args: {min, max}}) as
-        RankMap<D>[R];
+        NDArray<D, R>;
   }
 
   /**
@@ -146,13 +146,13 @@ export class Ops {
    */
   @operation
   static relu<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      RankMap<D>[R] {
+      NDArray<D, R> {
     return ENV.engine.executeKernel(
                'Relu', {inputs: {x}},
-               (dy: NDArray<'float32', R>, y: RankMap<D>[R]) => {
+               (dy: NDArray<'float32', R>, y: NDArray<D, R>) => {
                  const stepRes = x.step() as NDArray<'float32'>;
                  return {x: () => dy.mul(stepRes.asType('float32'))};
-               }) as RankMap<D>[R];
+               }) as NDArray<D, R>;
   }
 
   /**
@@ -161,7 +161,7 @@ export class Ops {
    */
   @operation
   static elu<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      RankMap<D>[R] {
+      NDArray<D, R> {
     const der = (dy: NDArray<'float32'>) => {
       return {
         x: () => dy.mul(eluDer(x)),
@@ -172,7 +172,7 @@ export class Ops {
         }
       };
     };
-    return ENV.engine.executeKernel('Elu', {inputs: {x}}, der) as RankMap<D>[R];
+    return ENV.engine.executeKernel('Elu', {inputs: {x}}, der) as NDArray<D, R>;
   }
 
   /**
@@ -181,8 +181,8 @@ export class Ops {
    */
   @operation
   static selu<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      RankMap<D>[R] {
-    return ENV.engine.executeKernel('Selu', {inputs: {x}}) as RankMap<D>[R];
+      NDArray<D, R> {
+    return ENV.engine.executeKernel('Selu', {inputs: {x}}) as NDArray<D, R>;
   }
 
   /**
@@ -193,9 +193,9 @@ export class Ops {
    */
   @operation
   static leakyRelu<D extends DataType, R extends Rank>(
-      x: NDArray<D, R>, alpha = 0.2): RankMap<D>[R] {
+      x: NDArray<D, R>, alpha = 0.2): NDArray<D, R> {
     return ENV.engine.executeKernel(
-               'LeakyRelu', {inputs: {x}, args: {alpha}}) as RankMap<D>[R];
+               'LeakyRelu', {inputs: {x}, args: {alpha}}) as NDArray<D, R>;
   }
 
   /**
@@ -206,7 +206,7 @@ export class Ops {
    */
   @operation
   static prelu<D extends DataType, R extends Rank>(
-      x: NDArray<D, R>, alpha: NDArray<D, R>): RankMap<D>[R] {
+      x: NDArray<D, R>, alpha: NDArray<D, R>): NDArray<D, R> {
     const der = (dy: NDArray<'float32'>) => {
       return {
         x: () => dy.mul(preluDer(x, alpha)),
@@ -218,7 +218,7 @@ export class Ops {
       };
     };
     return ENV.engine.executeKernel('PReLU', {inputs: {x, alpha}}, der) as
-        RankMap<D>[R];
+        NDArray<D, R>;
   }
 
   /**
@@ -227,8 +227,8 @@ export class Ops {
    */
   @operation
   static sigmoid<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      RankMap<D>[R] {
-    return ENV.engine.executeKernel('Sigmoid', {inputs: {x}}) as RankMap<D>[R];
+      NDArray<D, R> {
+    return ENV.engine.executeKernel('Sigmoid', {inputs: {x}}) as NDArray<D, R>;
   }
 
   /**
@@ -237,8 +237,8 @@ export class Ops {
    */
   @operation
   static sin<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      RankMap<D>[R] {
-    return ENV.engine.executeKernel('Sin', {inputs: {x}}) as RankMap<D>[R];
+      NDArray<D, R> {
+    return ENV.engine.executeKernel('Sin', {inputs: {x}}) as NDArray<D, R>;
   }
 
   /**
@@ -247,8 +247,8 @@ export class Ops {
    */
   @operation
   static cos<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      RankMap<D>[R] {
-    return ENV.engine.executeKernel('Cos', {inputs: {x}}) as RankMap<D>[R];
+      NDArray<D, R> {
+    return ENV.engine.executeKernel('Cos', {inputs: {x}}) as NDArray<D, R>;
   }
 
   /**
@@ -257,8 +257,8 @@ export class Ops {
    */
   @operation
   static tan<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      RankMap<D>[R] {
-    return ENV.engine.executeKernel('Tan', {inputs: {x}}) as RankMap<D>[R];
+      NDArray<D, R> {
+    return ENV.engine.executeKernel('Tan', {inputs: {x}}) as NDArray<D, R>;
   }
 
   /**
@@ -267,8 +267,8 @@ export class Ops {
    */
   @operation
   static asin<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      RankMap<D>[R] {
-    return ENV.engine.executeKernel('Asin', {inputs: {x}}) as RankMap<D>[R];
+      NDArray<D, R> {
+    return ENV.engine.executeKernel('Asin', {inputs: {x}}) as NDArray<D, R>;
   }
 
   /**
@@ -277,8 +277,8 @@ export class Ops {
    */
   @operation
   static acos<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      RankMap<D>[R] {
-    return ENV.engine.executeKernel('Acos', {inputs: {x}}) as RankMap<D>[R];
+      NDArray<D, R> {
+    return ENV.engine.executeKernel('Acos', {inputs: {x}}) as NDArray<D, R>;
   }
 
   /**
@@ -287,8 +287,8 @@ export class Ops {
    */
   @operation
   static atan<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      RankMap<D>[R] {
-    return ENV.engine.executeKernel('Atan', {inputs: {x}}) as RankMap<D>[R];
+      NDArray<D, R> {
+    return ENV.engine.executeKernel('Atan', {inputs: {x}}) as NDArray<D, R>;
   }
 
   /**
@@ -297,8 +297,8 @@ export class Ops {
    */
   @operation
   static sinh<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      RankMap<D>[R] {
-    return ENV.engine.executeKernel('Sinh', {inputs: {x}}) as RankMap<D>[R];
+      NDArray<D, R> {
+    return ENV.engine.executeKernel('Sinh', {inputs: {x}}) as NDArray<D, R>;
   }
 
   /**
@@ -307,8 +307,8 @@ export class Ops {
    */
   @operation
   static cosh<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      RankMap<D>[R] {
-    return ENV.engine.executeKernel('Cosh', {inputs: {x}}) as RankMap<D>[R];
+      NDArray<D, R> {
+    return ENV.engine.executeKernel('Cosh', {inputs: {x}}) as NDArray<D, R>;
   }
 
   /**
@@ -317,8 +317,8 @@ export class Ops {
    */
   @operation
   static tanh<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      RankMap<D>[R] {
-    return ENV.engine.executeKernel('Tanh', {inputs: {x}}) as RankMap<D>[R];
+      NDArray<D, R> {
+    return ENV.engine.executeKernel('Tanh', {inputs: {x}}) as NDArray<D, R>;
   }
 
   /**
@@ -330,9 +330,9 @@ export class Ops {
    */
   @operation
   static step<D extends DataType, R extends Rank>(
-      x: NDArray<D, R>, alpha = 0.0): RankMap<D>[R] {
+      x: NDArray<D, R>, alpha = 0.0): NDArray<D, R> {
     return ENV.engine.executeKernel('Step', {inputs: {x}, args: {alpha}}) as
-        RankMap<D>[R];
+        NDArray<D, R>;
   }
 }
 

--- a/src/math/unary_ops.ts
+++ b/src/math/unary_ops.ts
@@ -27,9 +27,8 @@ export class Ops {
    * @param x The input array.
    */
   @operation
-  static neg<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      NDArray<D, R> {
-    return ENV.engine.executeKernel('Neg', {inputs: {x}}) as NDArray<D, R>;
+  static neg<R extends Rank>(x: NDArray<R>): NDArray<R> {
+    return ENV.engine.executeKernel('Neg', {inputs: {x}}) as NDArray<R>;
   }
 
   /**
@@ -39,9 +38,8 @@ export class Ops {
    * @param x The input NDArray.
    */
   @operation
-  static ceil<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      NDArray<D, R> {
-    return ENV.engine.executeKernel('Ceil', {inputs: {x}}) as NDArray<D, R>;
+  static ceil<R extends Rank>(x: NDArray<R>): NDArray<R> {
+    return ENV.engine.executeKernel('Ceil', {inputs: {x}}) as NDArray<R>;
   }
 
   /**
@@ -50,9 +48,8 @@ export class Ops {
    * @param x The input NDArray.
    */
   @operation
-  static floor<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      NDArray<D, R> {
-    return ENV.engine.executeKernel('Floor', {inputs: {x}}) as NDArray<D, R>;
+  static floor<R extends Rank>(x: NDArray<R>): NDArray<R> {
+    return ENV.engine.executeKernel('Floor', {inputs: {x}}) as NDArray<R>;
   }
 
   /**
@@ -60,9 +57,8 @@ export class Ops {
    * @param x The input NDArray.
    */
   @operation
-  static exp<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      NDArray<D, R> {
-    return ENV.engine.executeKernel('Exp', {inputs: {x}}) as NDArray<D, R>;
+  static exp<R extends Rank>(x: NDArray<R>): NDArray<R> {
+    return ENV.engine.executeKernel('Exp', {inputs: {x}}) as NDArray<R>;
   }
 
   /**
@@ -70,9 +66,8 @@ export class Ops {
    * @param x The input NDArray.
    */
   @operation
-  static log<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      NDArray<D, R> {
-    return ENV.engine.executeKernel('Log', {inputs: {x}}) as NDArray<D, R>;
+  static log<R extends Rank>(x: NDArray<R>): NDArray<R> {
+    return ENV.engine.executeKernel('Log', {inputs: {x}}) as NDArray<R>;
   }
 
   /**
@@ -80,16 +75,14 @@ export class Ops {
    * @param x The input NDArray.
    */
   @operation
-  static sqrt<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      NDArray<D, R> {
+  static sqrt<R extends Rank>(x: NDArray<R>): NDArray<R> {
     return ENV.engine.executeKernel(
-               'Sqrt', {inputs: {x}},
-               (dy: NDArray<'float32', R>, y: NDArray<D, R>) => {
+               'Sqrt', {inputs: {x}}, (dy: NDArray<R>, y: NDArray<R>) => {
                  return {
                    x: () =>
                        dy.div(x.asType('float32').sqrt().mul(Scalar.new(2)))
                  };
-               }) as NDArray<D, R>;
+               }) as NDArray<R>;
   }
 
   /**
@@ -98,15 +91,13 @@ export class Ops {
    * @param x The input array.
    */
   @operation
-  static square<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      NDArray<D, R> {
+  static square<R extends Rank>(x: NDArray<R>): NDArray<R> {
     return ENV.engine.executeKernel(
-               'Square', {inputs: {x}},
-               (dy: NDArray<'float32', R>, y: NDArray<D, R>) => {
+               'Square', {inputs: {x}}, (dy: NDArray<R>, y: NDArray<R>) => {
                  return {
                    x: () => dy.mul(x.asType('float32').mul(Scalar.new(2)))
                  };
-               }) as NDArray<D, R>;
+               }) as NDArray<R>;
   }
 
   /**
@@ -114,13 +105,11 @@ export class Ops {
    * @param x The input NDArray.
    */
   @operation
-  static abs<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      NDArray<D, R> {
+  static abs<R extends Rank>(x: NDArray<R>): NDArray<R> {
     return ENV.engine.executeKernel(
-               'Abs', {inputs: {x}},
-               (dy: NDArray<'float32', R>, y: NDArray<D, R>) => {
+               'Abs', {inputs: {x}}, (dy: NDArray<R>, y: NDArray<R>) => {
                  return {x: () => dy.mul(x.toFloat().step(-1))};
-               }) as NDArray<D, R>;
+               }) as NDArray<R>;
   }
 
   /**
@@ -130,14 +119,14 @@ export class Ops {
    * @param max Upper-bound of range to be clipped to.
    */
   @operation
-  static clip<D extends DataType, R extends Rank>(
-      x: NDArray<D, R>, min: number, max: number): NDArray<D, R> {
+  static clip<R extends Rank>(x: NDArray<R>, min: number, max: number):
+      NDArray<R> {
     util.assert(
         (min <= max),
         `Error in clip: min (${min}) must be` +
             `less than or equal to max (${max}).`);
     return ENV.engine.executeKernel('Clip', {inputs: {x}, args: {min, max}}) as
-        NDArray<D, R>;
+        NDArray<R>;
   }
 
   /**
@@ -145,14 +134,12 @@ export class Ops {
    * @param x The input NDArray.
    */
   @operation
-  static relu<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      NDArray<D, R> {
+  static relu<R extends Rank>(x: NDArray<R>): NDArray<R> {
     return ENV.engine.executeKernel(
-               'Relu', {inputs: {x}},
-               (dy: NDArray<'float32', R>, y: NDArray<D, R>) => {
-                 const stepRes = x.step() as NDArray<'float32'>;
+               'Relu', {inputs: {x}}, (dy: NDArray<R>, y: NDArray<R>) => {
+                 const stepRes = x.step() as NDArray;
                  return {x: () => dy.mul(stepRes.asType('float32'))};
-               }) as NDArray<D, R>;
+               }) as NDArray<R>;
   }
 
   /**
@@ -160,9 +147,8 @@ export class Ops {
    * @param x the input NDArray
    */
   @operation
-  static elu<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      NDArray<D, R> {
-    const der = (dy: NDArray<'float32'>) => {
+  static elu<R extends Rank>(x: NDArray<R>): NDArray<R> {
+    const der = (dy: NDArray) => {
       return {
         x: () => dy.mul(eluDer(x)),
         alpha: () => {
@@ -172,7 +158,7 @@ export class Ops {
         }
       };
     };
-    return ENV.engine.executeKernel('Elu', {inputs: {x}}, der) as NDArray<D, R>;
+    return ENV.engine.executeKernel('Elu', {inputs: {x}}, der) as NDArray<R>;
   }
 
   /**
@@ -180,9 +166,8 @@ export class Ops {
    * @hidden
    */
   @operation
-  static selu<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      NDArray<D, R> {
-    return ENV.engine.executeKernel('Selu', {inputs: {x}}) as NDArray<D, R>;
+  static selu<R extends Rank>(x: NDArray<R>): NDArray<R> {
+    return ENV.engine.executeKernel('Selu', {inputs: {x}}) as NDArray<R>;
   }
 
   /**
@@ -192,10 +177,9 @@ export class Ops {
    * @return {NDArray}
    */
   @operation
-  static leakyRelu<D extends DataType, R extends Rank>(
-      x: NDArray<D, R>, alpha = 0.2): NDArray<D, R> {
+  static leakyRelu<R extends Rank>(x: NDArray<R>, alpha = 0.2): NDArray<R> {
     return ENV.engine.executeKernel(
-               'LeakyRelu', {inputs: {x}, args: {alpha}}) as NDArray<D, R>;
+               'LeakyRelu', {inputs: {x}, args: {alpha}}) as NDArray<R>;
   }
 
   /**
@@ -205,9 +189,8 @@ export class Ops {
    * @return {NDArray}
    */
   @operation
-  static prelu<D extends DataType, R extends Rank>(
-      x: NDArray<D, R>, alpha: NDArray<D, R>): NDArray<D, R> {
-    const der = (dy: NDArray<'float32'>) => {
+  static prelu<R extends Rank>(x: NDArray<R>, alpha: NDArray<R>): NDArray<R> {
+    const der = (dy: NDArray) => {
       return {
         x: () => dy.mul(preluDer(x, alpha)),
         alpha: () => {
@@ -218,7 +201,7 @@ export class Ops {
       };
     };
     return ENV.engine.executeKernel('PReLU', {inputs: {x, alpha}}, der) as
-        NDArray<D, R>;
+        NDArray<R>;
   }
 
   /**
@@ -226,9 +209,8 @@ export class Ops {
    * @param x The input NDArray.
    */
   @operation
-  static sigmoid<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      NDArray<D, R> {
-    return ENV.engine.executeKernel('Sigmoid', {inputs: {x}}) as NDArray<D, R>;
+  static sigmoid<R extends Rank>(x: NDArray<R>): NDArray<R> {
+    return ENV.engine.executeKernel('Sigmoid', {inputs: {x}}) as NDArray<R>;
   }
 
   /**
@@ -236,9 +218,8 @@ export class Ops {
    * @param x The input NDArray.
    */
   @operation
-  static sin<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      NDArray<D, R> {
-    return ENV.engine.executeKernel('Sin', {inputs: {x}}) as NDArray<D, R>;
+  static sin<R extends Rank>(x: NDArray<R>): NDArray<R> {
+    return ENV.engine.executeKernel('Sin', {inputs: {x}}) as NDArray<R>;
   }
 
   /**
@@ -246,9 +227,8 @@ export class Ops {
    * @param x The input NDArray.
    */
   @operation
-  static cos<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      NDArray<D, R> {
-    return ENV.engine.executeKernel('Cos', {inputs: {x}}) as NDArray<D, R>;
+  static cos<R extends Rank>(x: NDArray<R>): NDArray<R> {
+    return ENV.engine.executeKernel('Cos', {inputs: {x}}) as NDArray<R>;
   }
 
   /**
@@ -256,9 +236,8 @@ export class Ops {
    * @param x The input NDArray.
    */
   @operation
-  static tan<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      NDArray<D, R> {
-    return ENV.engine.executeKernel('Tan', {inputs: {x}}) as NDArray<D, R>;
+  static tan<R extends Rank>(x: NDArray<R>): NDArray<R> {
+    return ENV.engine.executeKernel('Tan', {inputs: {x}}) as NDArray<R>;
   }
 
   /**
@@ -266,9 +245,8 @@ export class Ops {
    * @param x The input NDArray.
    */
   @operation
-  static asin<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      NDArray<D, R> {
-    return ENV.engine.executeKernel('Asin', {inputs: {x}}) as NDArray<D, R>;
+  static asin<R extends Rank>(x: NDArray<R>): NDArray<R> {
+    return ENV.engine.executeKernel('Asin', {inputs: {x}}) as NDArray<R>;
   }
 
   /**
@@ -276,9 +254,8 @@ export class Ops {
    * @param x The input NDArray.
    */
   @operation
-  static acos<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      NDArray<D, R> {
-    return ENV.engine.executeKernel('Acos', {inputs: {x}}) as NDArray<D, R>;
+  static acos<R extends Rank>(x: NDArray<R>): NDArray<R> {
+    return ENV.engine.executeKernel('Acos', {inputs: {x}}) as NDArray<R>;
   }
 
   /**
@@ -286,9 +263,8 @@ export class Ops {
    * @param x The input NDArray.
    */
   @operation
-  static atan<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      NDArray<D, R> {
-    return ENV.engine.executeKernel('Atan', {inputs: {x}}) as NDArray<D, R>;
+  static atan<R extends Rank>(x: NDArray<R>): NDArray<R> {
+    return ENV.engine.executeKernel('Atan', {inputs: {x}}) as NDArray<R>;
   }
 
   /**
@@ -296,9 +272,8 @@ export class Ops {
    * @param x The input NDArray.
    */
   @operation
-  static sinh<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      NDArray<D, R> {
-    return ENV.engine.executeKernel('Sinh', {inputs: {x}}) as NDArray<D, R>;
+  static sinh<R extends Rank>(x: NDArray<R>): NDArray<R> {
+    return ENV.engine.executeKernel('Sinh', {inputs: {x}}) as NDArray<R>;
   }
 
   /**
@@ -306,9 +281,8 @@ export class Ops {
    * @param x The input NDArray.
    */
   @operation
-  static cosh<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      NDArray<D, R> {
-    return ENV.engine.executeKernel('Cosh', {inputs: {x}}) as NDArray<D, R>;
+  static cosh<R extends Rank>(x: NDArray<R>): NDArray<R> {
+    return ENV.engine.executeKernel('Cosh', {inputs: {x}}) as NDArray<R>;
   }
 
   /**
@@ -316,9 +290,8 @@ export class Ops {
    * @param x The input NDArray.
    */
   @operation
-  static tanh<D extends DataType, R extends Rank>(x: NDArray<D, R>):
-      NDArray<D, R> {
-    return ENV.engine.executeKernel('Tanh', {inputs: {x}}) as NDArray<D, R>;
+  static tanh<R extends Rank>(x: NDArray<R>): NDArray<R> {
+    return ENV.engine.executeKernel('Tanh', {inputs: {x}}) as NDArray<R>;
   }
 
   /**
@@ -329,19 +302,16 @@ export class Ops {
    * @param alpha The gradient when input is negative.
    */
   @operation
-  static step<D extends DataType, R extends Rank>(
-      x: NDArray<D, R>, alpha = 0.0): NDArray<D, R> {
+  static step<R extends Rank>(x: NDArray<R>, alpha = 0.0): NDArray<R> {
     return ENV.engine.executeKernel('Step', {inputs: {x}, args: {alpha}}) as
-        NDArray<D, R>;
+        NDArray<R>;
   }
 }
 
-function preluDer(x: NDArray, alpha: NDArray): NDArray<'float32'> {
-  return ENV.engine.executeKernel('PReLUDer', {inputs: {x, alpha}}) as
-      NDArray<'float32'>;
+function preluDer(x: NDArray, alpha: NDArray): NDArray {
+  return ENV.engine.executeKernel('PReLUDer', {inputs: {x, alpha}}) as NDArray;
 }
 
-function eluDer(x: NDArray): NDArray<'float32'> {
-  return ENV.engine.executeKernel('EluDer', {inputs: {x}}) as
-      NDArray<'float32'>;
+function eluDer(x: NDArray): NDArray {
+  return ENV.engine.executeKernel('EluDer', {inputs: {x}}) as NDArray;
 }

--- a/src/math/unary_ops.ts
+++ b/src/math/unary_ops.ts
@@ -27,8 +27,8 @@ export class Ops {
    * @param x The input array.
    */
   @operation
-  static neg<R extends Rank>(x: NDArray<R>): NDArray<R> {
-    return ENV.engine.executeKernel('Neg', {inputs: {x}}) as NDArray<R>;
+  static neg<R extends Rank, T extends NDArray<R>>(x: T): T {
+    return ENV.engine.executeKernel('Neg', {inputs: {x}}) as T;
   }
 
   /**
@@ -38,8 +38,8 @@ export class Ops {
    * @param x The input NDArray.
    */
   @operation
-  static ceil<R extends Rank>(x: NDArray<R>): NDArray<R> {
-    return ENV.engine.executeKernel('Ceil', {inputs: {x}}) as NDArray<R>;
+  static ceil<R extends Rank, T extends NDArray<R>>(x: T): T {
+    return ENV.engine.executeKernel('Ceil', {inputs: {x}}) as T;
   }
 
   /**
@@ -48,8 +48,8 @@ export class Ops {
    * @param x The input NDArray.
    */
   @operation
-  static floor<R extends Rank>(x: NDArray<R>): NDArray<R> {
-    return ENV.engine.executeKernel('Floor', {inputs: {x}}) as NDArray<R>;
+  static floor<R extends Rank, T extends NDArray<R>>(x: T): T {
+    return ENV.engine.executeKernel('Floor', {inputs: {x}}) as T;
   }
 
   /**
@@ -57,8 +57,8 @@ export class Ops {
    * @param x The input NDArray.
    */
   @operation
-  static exp<R extends Rank>(x: NDArray<R>): NDArray<R> {
-    return ENV.engine.executeKernel('Exp', {inputs: {x}}) as NDArray<R>;
+  static exp<R extends Rank, T extends NDArray<R>>(x: T): T {
+    return ENV.engine.executeKernel('Exp', {inputs: {x}}) as T;
   }
 
   /**
@@ -66,8 +66,8 @@ export class Ops {
    * @param x The input NDArray.
    */
   @operation
-  static log<R extends Rank>(x: NDArray<R>): NDArray<R> {
-    return ENV.engine.executeKernel('Log', {inputs: {x}}) as NDArray<R>;
+  static log<R extends Rank, T extends NDArray<R>>(x: T): T {
+    return ENV.engine.executeKernel('Log', {inputs: {x}}) as T;
   }
 
   /**
@@ -75,14 +75,14 @@ export class Ops {
    * @param x The input NDArray.
    */
   @operation
-  static sqrt<R extends Rank>(x: NDArray<R>): NDArray<R> {
+  static sqrt<R extends Rank, T extends NDArray<R>>(x: T): T {
     return ENV.engine.executeKernel(
                'Sqrt', {inputs: {x}}, (dy: NDArray<R>, y: NDArray<R>) => {
                  return {
                    x: () =>
                        dy.div(x.asType('float32').sqrt().mul(Scalar.new(2)))
                  };
-               }) as NDArray<R>;
+               }) as T;
   }
 
   /**
@@ -91,13 +91,13 @@ export class Ops {
    * @param x The input array.
    */
   @operation
-  static square<R extends Rank>(x: NDArray<R>): NDArray<R> {
+  static square<R extends Rank, T extends NDArray<R>>(x: T): T {
     return ENV.engine.executeKernel(
                'Square', {inputs: {x}}, (dy: NDArray<R>, y: NDArray<R>) => {
                  return {
                    x: () => dy.mul(x.asType('float32').mul(Scalar.new(2)))
                  };
-               }) as NDArray<R>;
+               }) as T;
   }
 
   /**
@@ -105,11 +105,11 @@ export class Ops {
    * @param x The input NDArray.
    */
   @operation
-  static abs<R extends Rank>(x: NDArray<R>): NDArray<R> {
+  static abs<R extends Rank, T extends NDArray<R>>(x: T): T {
     return ENV.engine.executeKernel(
                'Abs', {inputs: {x}}, (dy: NDArray<R>, y: NDArray<R>) => {
                  return {x: () => dy.mul(x.toFloat().step(-1))};
-               }) as NDArray<R>;
+               }) as T;
   }
 
   /**
@@ -134,12 +134,12 @@ export class Ops {
    * @param x The input NDArray.
    */
   @operation
-  static relu<R extends Rank>(x: NDArray<R>): NDArray<R> {
+  static relu<R extends Rank, T extends NDArray<R>>(x: T): T {
     return ENV.engine.executeKernel(
                'Relu', {inputs: {x}}, (dy: NDArray<R>, y: NDArray<R>) => {
                  const stepRes = x.step() as NDArray;
                  return {x: () => dy.mul(stepRes.asType('float32'))};
-               }) as NDArray<R>;
+               }) as T;
   }
 
   /**
@@ -147,7 +147,7 @@ export class Ops {
    * @param x the input NDArray
    */
   @operation
-  static elu<R extends Rank>(x: NDArray<R>): NDArray<R> {
+  static elu<R extends Rank, T extends NDArray<R>>(x: T): T {
     const der = (dy: NDArray) => {
       return {
         x: () => dy.mul(eluDer(x)),
@@ -158,7 +158,7 @@ export class Ops {
         }
       };
     };
-    return ENV.engine.executeKernel('Elu', {inputs: {x}}, der) as NDArray<R>;
+    return ENV.engine.executeKernel('Elu', {inputs: {x}}, der) as T;
   }
 
   /**
@@ -166,8 +166,8 @@ export class Ops {
    * @hidden
    */
   @operation
-  static selu<R extends Rank>(x: NDArray<R>): NDArray<R> {
-    return ENV.engine.executeKernel('Selu', {inputs: {x}}) as NDArray<R>;
+  static selu<R extends Rank, T extends NDArray<R>>(x: T): T {
+    return ENV.engine.executeKernel('Selu', {inputs: {x}}) as T;
   }
 
   /**
@@ -177,9 +177,9 @@ export class Ops {
    * @return {NDArray}
    */
   @operation
-  static leakyRelu<R extends Rank>(x: NDArray<R>, alpha = 0.2): NDArray<R> {
+  static leakyRelu<R extends Rank, T extends NDArray<R>>(x: T, alpha = 0.2): T {
     return ENV.engine.executeKernel(
-               'LeakyRelu', {inputs: {x}, args: {alpha}}) as NDArray<R>;
+               'LeakyRelu', {inputs: {x}, args: {alpha}}) as T;
   }
 
   /**
@@ -209,8 +209,8 @@ export class Ops {
    * @param x The input NDArray.
    */
   @operation
-  static sigmoid<R extends Rank>(x: NDArray<R>): NDArray<R> {
-    return ENV.engine.executeKernel('Sigmoid', {inputs: {x}}) as NDArray<R>;
+  static sigmoid<R extends Rank, T extends NDArray<R>>(x: T): T {
+    return ENV.engine.executeKernel('Sigmoid', {inputs: {x}}) as T;
   }
 
   /**
@@ -218,8 +218,8 @@ export class Ops {
    * @param x The input NDArray.
    */
   @operation
-  static sin<R extends Rank>(x: NDArray<R>): NDArray<R> {
-    return ENV.engine.executeKernel('Sin', {inputs: {x}}) as NDArray<R>;
+  static sin<R extends Rank, T extends NDArray<R>>(x: T): T {
+    return ENV.engine.executeKernel('Sin', {inputs: {x}}) as T;
   }
 
   /**
@@ -227,8 +227,8 @@ export class Ops {
    * @param x The input NDArray.
    */
   @operation
-  static cos<R extends Rank>(x: NDArray<R>): NDArray<R> {
-    return ENV.engine.executeKernel('Cos', {inputs: {x}}) as NDArray<R>;
+  static cos<R extends Rank, T extends NDArray<R>>(x: T): T {
+    return ENV.engine.executeKernel('Cos', {inputs: {x}}) as T;
   }
 
   /**
@@ -236,8 +236,8 @@ export class Ops {
    * @param x The input NDArray.
    */
   @operation
-  static tan<R extends Rank>(x: NDArray<R>): NDArray<R> {
-    return ENV.engine.executeKernel('Tan', {inputs: {x}}) as NDArray<R>;
+  static tan<R extends Rank, T extends NDArray<R>>(x: T): T {
+    return ENV.engine.executeKernel('Tan', {inputs: {x}}) as T;
   }
 
   /**
@@ -245,8 +245,8 @@ export class Ops {
    * @param x The input NDArray.
    */
   @operation
-  static asin<R extends Rank>(x: NDArray<R>): NDArray<R> {
-    return ENV.engine.executeKernel('Asin', {inputs: {x}}) as NDArray<R>;
+  static asin<R extends Rank, T extends NDArray<R>>(x: T): T {
+    return ENV.engine.executeKernel('Asin', {inputs: {x}}) as T;
   }
 
   /**
@@ -254,8 +254,8 @@ export class Ops {
    * @param x The input NDArray.
    */
   @operation
-  static acos<R extends Rank>(x: NDArray<R>): NDArray<R> {
-    return ENV.engine.executeKernel('Acos', {inputs: {x}}) as NDArray<R>;
+  static acos<R extends Rank, T extends NDArray<R>>(x: T): T {
+    return ENV.engine.executeKernel('Acos', {inputs: {x}}) as T;
   }
 
   /**
@@ -263,8 +263,8 @@ export class Ops {
    * @param x The input NDArray.
    */
   @operation
-  static atan<R extends Rank>(x: NDArray<R>): NDArray<R> {
-    return ENV.engine.executeKernel('Atan', {inputs: {x}}) as NDArray<R>;
+  static atan<R extends Rank, T extends NDArray<R>>(x: T): T {
+    return ENV.engine.executeKernel('Atan', {inputs: {x}}) as T;
   }
 
   /**
@@ -272,8 +272,8 @@ export class Ops {
    * @param x The input NDArray.
    */
   @operation
-  static sinh<R extends Rank>(x: NDArray<R>): NDArray<R> {
-    return ENV.engine.executeKernel('Sinh', {inputs: {x}}) as NDArray<R>;
+  static sinh<R extends Rank, T extends NDArray<R>>(x: T): T {
+    return ENV.engine.executeKernel('Sinh', {inputs: {x}}) as T;
   }
 
   /**
@@ -281,8 +281,8 @@ export class Ops {
    * @param x The input NDArray.
    */
   @operation
-  static cosh<R extends Rank>(x: NDArray<R>): NDArray<R> {
-    return ENV.engine.executeKernel('Cosh', {inputs: {x}}) as NDArray<R>;
+  static cosh<R extends Rank, T extends NDArray<R>>(x: T): T {
+    return ENV.engine.executeKernel('Cosh', {inputs: {x}}) as T;
   }
 
   /**
@@ -290,8 +290,8 @@ export class Ops {
    * @param x The input NDArray.
    */
   @operation
-  static tanh<R extends Rank>(x: NDArray<R>): NDArray<R> {
-    return ENV.engine.executeKernel('Tanh', {inputs: {x}}) as NDArray<R>;
+  static tanh<R extends Rank, T extends NDArray<R>>(x: T): T {
+    return ENV.engine.executeKernel('Tanh', {inputs: {x}}) as T;
   }
 
   /**
@@ -302,9 +302,8 @@ export class Ops {
    * @param alpha The gradient when input is negative.
    */
   @operation
-  static step<R extends Rank>(x: NDArray<R>, alpha = 0.0): NDArray<R> {
-    return ENV.engine.executeKernel('Step', {inputs: {x}, args: {alpha}}) as
-        NDArray<R>;
+  static step<R extends Rank, T extends NDArray<R>>(x: T, alpha = 0.0): T {
+    return ENV.engine.executeKernel('Step', {inputs: {x}, args: {alpha}}) as T;
   }
 }
 

--- a/src/math/variable_test.ts
+++ b/src/math/variable_test.ts
@@ -19,6 +19,7 @@ import * as test_util from '../test_util';
 import {MathTests} from '../test_util';
 // tslint:disable-next-line:max-line-length
 import {Array1D, Array2D, Array3D, Array4D, NDArray, Scalar, variable, Variable} from './ndarray';
+import {Rank} from './types';
 
 const tests: MathTests = it => {
   it('simple assign', math => {
@@ -57,7 +58,7 @@ const tests: MathTests = it => {
   });
 
   it('variables are not affected by scopes', math => {
-    let v: Variable<'1'>;
+    let v: Variable<Rank.R1>;
     expect(math.getNumArrays()).toBe(0);
 
     math.scope(() => {
@@ -77,33 +78,33 @@ const tests: MathTests = it => {
 
   it('variables are assignable to ndarrays', () => {
     // This test asserts compilation, not doing any run-time assertion.
-    const x0: Variable<'0'> = null;
+    const x0: Variable<Rank.R0> = null;
     const y0: Scalar = x0;
     expect(y0).toBeNull();
 
-    const x1: Variable<'1'> = null;
+    const x1: Variable<Rank.R1> = null;
     const y1: Array1D = x1;
     expect(y1).toBeNull();
 
-    const x2: Variable<'2'> = null;
+    const x2: Variable<Rank.R2> = null;
     const y2: Array2D = x2;
     expect(y2).toBeNull();
 
-    const x3: Variable<'3'> = null;
+    const x3: Variable<Rank.R3> = null;
     const y3: Array3D = x3;
     expect(y3).toBeNull();
 
-    const x4: Variable<'4'> = null;
+    const x4: Variable<Rank.R4> = null;
     const y4: Array4D = x4;
     expect(y4).toBeNull();
 
-    const xh: Variable<'higher'> = null;
+    const xh: Variable = null;
     const yh: NDArray = xh;
     expect(yh).toBeNull();
   });
 
   it('assign will dispose old data', math => {
-    let v: Variable<'1'>;
+    let v: Variable<Rank.R1>;
     v = variable(Array1D.new([1, 2, 3]));
     expect(math.getNumArrays()).toBe(1);
     test_util.expectArraysClose(v, [1, 2, 3]);

--- a/src/math/variable_test.ts
+++ b/src/math/variable_test.ts
@@ -57,7 +57,7 @@ const tests: MathTests = it => {
   });
 
   it('variables are not affected by scopes', math => {
-    let v: Variable<'float32', '1'>;
+    let v: Variable<'1'>;
     expect(math.getNumArrays()).toBe(0);
 
     math.scope(() => {
@@ -77,33 +77,33 @@ const tests: MathTests = it => {
 
   it('variables are assignable to ndarrays', () => {
     // This test asserts compilation, not doing any run-time assertion.
-    const x0: Variable<'float32', '0'> = null;
-    const y0: Scalar<'float32'> = x0;
+    const x0: Variable<'0'> = null;
+    const y0: Scalar = x0;
     expect(y0).toBeNull();
 
-    const x1: Variable<'float32', '1'> = null;
-    const y1: Array1D<'float32'> = x1;
+    const x1: Variable<'1'> = null;
+    const y1: Array1D = x1;
     expect(y1).toBeNull();
 
-    const x2: Variable<'float32', '2'> = null;
-    const y2: Array2D<'float32'> = x2;
+    const x2: Variable<'2'> = null;
+    const y2: Array2D = x2;
     expect(y2).toBeNull();
 
-    const x3: Variable<'float32', '3'> = null;
-    const y3: Array3D<'float32'> = x3;
+    const x3: Variable<'3'> = null;
+    const y3: Array3D = x3;
     expect(y3).toBeNull();
 
-    const x4: Variable<'float32', '4'> = null;
-    const y4: Array4D<'float32'> = x4;
+    const x4: Variable<'4'> = null;
+    const y4: Array4D = x4;
     expect(y4).toBeNull();
 
-    const xh: Variable<'float32', 'higher'> = null;
-    const yh: NDArray<'float32'> = xh;
+    const xh: Variable<'higher'> = null;
+    const yh: NDArray = xh;
     expect(yh).toBeNull();
   });
 
   it('assign will dispose old data', math => {
-    let v: Variable<'float32', '1'>;
+    let v: Variable<'1'>;
     v = variable(Array1D.new([1, 2, 3]));
     expect(math.getNumArrays()).toBe(1);
     test_util.expectArraysClose(v, [1, 2, 3]);

--- a/src/test_util.ts
+++ b/src/test_util.ts
@@ -20,9 +20,8 @@ import {MathBackendCPU} from './math/backends/backend_cpu';
 import {MathBackendWebGL} from './math/backends/backend_webgl';
 import {NDArrayMath} from './math/math';
 import {NDArray} from './math/ndarray';
-import {DataType} from './math/types';
+import {DataType, TypedArray} from './math/types';
 import * as util from './util';
-import {TypedArray} from './util';
 
 // This is how the it(), fit() and xit() function look in your tests
 export type MathIt = (name: string, testFn: (math: NDArrayMath) => void) =>

--- a/src/util.ts
+++ b/src/util.ts
@@ -16,12 +16,12 @@
  */
 
 import {NDArray, Variable} from './math/ndarray';
-import {DataType, DataTypeMap} from './math/types';
+import {DataType, DataTypeMap, TypedArray} from './math/types';
 
-export type TypedArray = Float32Array|Int32Array|Uint8Array;
 export type FlatVector = boolean[]|number[]|TypedArray;
 export type RegularArray<T> = T[]|T[][]|T[][][]|T[][][][];
-export type ArrayData = TypedArray|RegularArray<number>|RegularArray<boolean>;
+export type ArrayData<D extends DataType> =
+    DataTypeMap[D]|RegularArray<number>|RegularArray<boolean>;
 
 export type NamedArrayMap = {
   [name: string]: NDArray
@@ -333,7 +333,7 @@ export function squeezeShape(shape: number[], axis?: number[]):
 }
 
 export function getTypedArrayFromDType<D extends DataType>(
-    dtype: DataType, size: number): DataTypeMap[D] {
+    dtype: D, size: number): DataTypeMap[D] {
   let values = null;
   if (dtype == null || dtype === 'float32') {
     values = new Float32Array(size);
@@ -357,8 +357,8 @@ export function isNDArrayInList(
   return false;
 }
 
-export function checkForNaN(
-    vals: TypedArray, dtype: DataType, name: string): void {
+export function checkForNaN<D extends DataType>(
+    vals: DataTypeMap[D], dtype: D, name: string): void {
   for (let i = 0; i < vals.length; i++) {
     if (isValNaN(vals[i], dtype)) {
       throw Error(`The result of the last math.${name} has NaNs.`);

--- a/src/util.ts
+++ b/src/util.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {NDArray, Variable} from './math/ndarray';
+import {NDArray} from './math/ndarray';
 // tslint:disable-next-line:max-line-length
 import {DataType, DataTypeMap, FlatVector, NamedArrayMap, RegularArray} from './math/types';
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -23,8 +23,8 @@ export type FlatVector = boolean[]|number[]|TypedArray;
 export type RegularArray<T> = T[]|T[][]|T[][][]|T[][][][];
 export type ArrayData = TypedArray|RegularArray<number>|RegularArray<boolean>;
 
-export type NamedArrayMap<D extends DataType = DataType> = {
-  [name: string]: NDArray<D>
+export type NamedArrayMap = {
+  [name: string]: NDArray
 };
 
 export type NamedVariableMap = {
@@ -332,8 +332,7 @@ export function squeezeShape(shape: number[], axis?: number[]):
   return {newShape, keptDims};
 }
 
-export function getTypedArrayFromDType<D extends DataType>(
-    dtype: D, size: number): DataTypeMap[D] {
+export function getTypedArrayFromDType(dtype: D, size: number): DataTypeMap[D] {
   let values = null;
   if (dtype == null || dtype === 'float32') {
     values = new Float32Array(size);
@@ -419,7 +418,7 @@ export function nextFrame(): Promise<void> {
   return new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
 }
 
-export function copyTypedArray<D extends DataType>(
+export function copyTypedArray(
     array: DataTypeMap[D]|number[]|boolean[], dtype: D): DataTypeMap[D] {
   if (dtype == null || dtype === 'float32') {
     return new Float32Array(array as number[]);

--- a/src/util.ts
+++ b/src/util.ts
@@ -16,20 +16,8 @@
  */
 
 import {NDArray, Variable} from './math/ndarray';
-import {DataType, DataTypeMap, TypedArray} from './math/types';
-
-export type FlatVector = boolean[]|number[]|TypedArray;
-export type RegularArray<T> = T[]|T[][]|T[][][]|T[][][][];
-export type ArrayData<D extends DataType> =
-    DataTypeMap[D]|RegularArray<number>|RegularArray<boolean>;
-
-export type NamedArrayMap = {
-  [name: string]: NDArray
-};
-
-export type NamedVariableMap = {
-  [name: string]: Variable;
-};
+// tslint:disable-next-line:max-line-length
+import {DataType, DataTypeMap, FlatVector, NamedArrayMap, RegularArray} from './math/types';
 
 /** Shuffles the array using Fisher-Yates algorithm. */
 // tslint:disable-next-line:no-any

--- a/src/util.ts
+++ b/src/util.ts
@@ -332,7 +332,8 @@ export function squeezeShape(shape: number[], axis?: number[]):
   return {newShape, keptDims};
 }
 
-export function getTypedArrayFromDType(dtype: D, size: number): DataTypeMap[D] {
+export function getTypedArrayFromDType<D extends DataType>(
+    dtype: DataType, size: number): DataTypeMap[D] {
   let values = null;
   if (dtype == null || dtype === 'float32') {
     values = new Float32Array(size);
@@ -418,7 +419,7 @@ export function nextFrame(): Promise<void> {
   return new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
 }
 
-export function copyTypedArray(
+export function copyTypedArray<D extends DataType>(
     array: DataTypeMap[D]|number[]|boolean[], dtype: D): DataTypeMap[D] {
   if (dtype == null || dtype === 'float32') {
     return new Float32Array(array as number[]);

--- a/src/util_test.ts
+++ b/src/util_test.ts
@@ -16,10 +16,10 @@
  */
 
 import {Array1D, NDArray, Scalar} from './math/ndarray';
+import {NamedArrayMap} from './math/types';
 import * as test_util from './test_util';
 import {MathTests} from './test_util';
 import * as util from './util';
-import {NamedArrayMap} from './util';
 
 describe('Util', () => {
   it('Flatten arrays', () => {


### PR DESCRIPTION
The introduction of `DataType` as generic in `NDArray` caused a lot of confusion and unreadable code. To vastly simplify the codebase and the compiler errors, we are removing `dtype` as generic. We expect this to have negligible impact on usability since most arrays are of type `float32`.

`NDArray<DataType, Rank>` becomes  `NDArray<Rank>`.

This change is breaking typescript users that use generics. JavaScript users should not be affected.

To further improve compiler error messages, we are replacing `Rank` from a union string to an enum. Before, in a compiler error message, or in a code editor, an array of unknown rank showed up as `NDArray<'0'|'1'|'2'|'3'|'4'|'higher'>`. Now it is `NDArray<Rank>`. `NDArray<'3'>` now shows up as `NDArray<Rank.R3>`.

Internal changes
 - Removed all instance and static methods of subclasses of NDArray (e.g. Scalar, Array1D etc). This improves the compiler inference and error messages.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/590)
<!-- Reviewable:end -->
