### PR TITLE
Make debug mode an environment flag and properly time kernels.

### DIFF
--- a/demos/adder/adder.ts
+++ b/demos/adder/adder.ts
@@ -17,18 +17,31 @@
 
 import * as dl from 'deeplearn';
 
-const outputElement = document.getElementById('output');
-const inA: HTMLInputElement = document.getElementById('A') as HTMLInputElement;
-const inB: HTMLInputElement = document.getElementById('B') as HTMLInputElement;
+// const outputElement = document.getElementById('output');
+// const inA: HTMLInputElement = document.getElementById('A') as
+// HTMLInputElement; const inB: HTMLInputElement = document.getElementById('B')
+// as HTMLInputElement;
 
-export async function execute(event?: Event) {
-  const a = dl.Scalar.new(+inA.value);
-  const b = dl.Scalar.new(+inB.value);
-  const result = await a.add(b).data();
-  outputElement.innerText = result.toString();
+// export async function execute(event?: Event) {
+//   const a = dl.Scalar.new(+inA.value);
+//   const b = dl.Scalar.new(+inB.value);
+//   const result = await a.add(b).data();
+//   outputElement.innerText = result.toString();
+// }
+
+// inA.addEventListener('keyup', execute);
+// inB.addEventListener('keyup', execute);
+
+// execute();
+
+async function go() {
+  const time = await dl.ENV.math.time(() => {
+    dl.square(dl.square(dl.Scalar.new(1)));
+    dl.ENV.math.time(() => {
+      dl.square(dl.square(dl.Scalar.new(1)));
+    });
+  });
+  console.log(time);
 }
 
-inA.addEventListener('keyup', execute);
-inB.addEventListener('keyup', execute);
-
-execute();
+go();

--- a/demos/adder/adder.ts
+++ b/demos/adder/adder.ts
@@ -17,26 +17,18 @@
 
 import * as dl from 'deeplearn';
 
-// const outputElement = document.getElementById('output');
-// const inA: HTMLInputElement = document.getElementById('A') as
-// HTMLInputElement; const inB: HTMLInputElement = document.getElementById('B')
-// as HTMLInputElement;
+const outputElement = document.getElementById('output');
+const inA: HTMLInputElement = document.getElementById('A') as HTMLInputElement;
+const inB: HTMLInputElement = document.getElementById('B') as HTMLInputElement;
 
-// export async function execute(event?: Event) {
-//   const a = dl.Scalar.new(+inA.value);
-//   const b = dl.Scalar.new(+inB.value);
-//   const result = await a.add(b).data();
-//   outputElement.innerText = result.toString();
-// }
-
-// inA.addEventListener('keyup', execute);
-// inB.addEventListener('keyup', execute);
-
-// execute();
-
-async function go() {
-  const a = dl.randNormal([100, 100]);
-  a.logSumExp([0]);
+export async function execute(event?: Event) {
+  const a = dl.Scalar.new(+inA.value);
+  const b = dl.Scalar.new(+inB.value);
+  const result = await a.add(b).data();
+  outputElement.innerText = result.toString();
 }
 
-go();
+inA.addEventListener('keyup', execute);
+inB.addEventListener('keyup', execute);
+
+execute();

--- a/demos/adder/adder.ts
+++ b/demos/adder/adder.ts
@@ -37,9 +37,20 @@ import * as dl from 'deeplearn';
 async function go() {
   const time = await dl.ENV.math.time(() => {
     dl.square(dl.square(dl.Scalar.new(1)));
-    dl.ENV.math.time(() => {
-      dl.square(dl.square(dl.Scalar.new(1)));
-    });
+    dl.ENV.math
+        .time(() => {
+          dl.square(dl.square(dl.Scalar.new(1)));
+          dl.ENV.math
+              .time(() => {
+                dl.sqrt(dl.Scalar.new(1));
+              })
+              .then((mostinner: number) => {
+                console.log('mostinner time', mostinner);
+              });
+        })
+        .then((inner: number) => {
+          console.log('inner time', inner);
+        });
   });
   console.log(time);
 }

--- a/demos/adder/adder.ts
+++ b/demos/adder/adder.ts
@@ -35,24 +35,8 @@ import * as dl from 'deeplearn';
 // execute();
 
 async function go() {
-  const time = await dl.ENV.math.time(() => {
-    dl.square(dl.square(dl.Scalar.new(1)));
-    dl.ENV.math
-        .time(() => {
-          dl.square(dl.square(dl.Scalar.new(1)));
-          dl.ENV.math
-              .time(() => {
-                dl.sqrt(dl.Scalar.new(1));
-              })
-              .then((mostinner: number) => {
-                console.log('mostinner time', mostinner);
-              });
-        })
-        .then((inner: number) => {
-          console.log('inner time', inner);
-        });
-  });
-  console.log(time);
+  const a = dl.randNormal([100, 100]);
+  a.logSumExp([0]);
 }
 
 go();

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -290,8 +290,8 @@ export class Environment {
    * Adds a custom backend. Usually used in tests to simulate different
    * environments.
    *
-   * @param factory: The backend factory function. When called, it should
-   * return an instance of the backend.
+   * @param factory: The backend factory function. When called, it should return
+   *     an instance of the backend.
    * @return False if the creation/registration failed. True otherwise.
    */
   addCustomBackend(name: BackendType, factory: () => MathBackend): boolean {

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -27,8 +27,15 @@ export enum Type {
 }
 
 export interface Features {
-  // Whether the disjoint_query_timer extension is an available extension.
-  'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_ENABLED'?: boolean;
+  // Whether to enable debug mode.
+  'DEBUG'?: boolean;
+  // The disjoint_query_timer extension version.
+  // 0: disabled, 1: EXT_disjoint_timer_query, 2:
+  // EXT_disjoint_timer_query_webgl2.
+  // In Firefox with WebGL 2.0,
+  // EXT_disjoint_timer_query_webgl2 is not available, so we must use the
+  // WebGL 1.0 extension.
+  'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION'?: number;
   // Whether the timer object from the disjoint_query_timer extension gives
   // timing information that is reliable.
   'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_RELIABLE'?: boolean;
@@ -42,7 +49,8 @@ export interface Features {
 }
 
 export const URL_PROPERTIES: URLProperty[] = [
-  {name: 'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_ENABLED', type: Type.BOOLEAN},
+  {name: 'DEBUG', type: Type.BOOLEAN},
+  {name: 'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION', type: Type.NUMBER},
   {name: 'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_RELIABLE', type: Type.BOOLEAN},
   {name: 'WEBGL_VERSION', type: Type.NUMBER},
   {name: 'WEBGL_FLOAT_TEXTURE_ENABLED', type: Type.BOOLEAN}, {
@@ -54,6 +62,11 @@ export const URL_PROPERTIES: URLProperty[] = [
 export interface URLProperty {
   name: keyof Features;
   type: Type;
+}
+
+function hasExtension(gl: WebGLRenderingContext, extensionName: string) {
+  const ext = gl.getExtension(extensionName);
+  return ext != null;
 }
 
 function getWebGLRenderingContext(webGLVersion: number): WebGLRenderingContext {
@@ -91,17 +104,26 @@ function isWebGLVersionEnabled(webGLVersion: 1|2) {
   return false;
 }
 
-function isWebGLDisjointQueryTimerEnabled(webGLVersion: number) {
+function getWebGLDisjointQueryTimerVersion(webGLVersion: number): number {
+  if (webGLVersion === 0) {
+    return 0;
+  }
+
+  let queryTimerVersion: number;
   const gl = getWebGLRenderingContext(webGLVersion);
 
-  const extensionName = webGLVersion === 1 ? 'EXT_disjoint_timer_query' :
-                                             'EXT_disjoint_timer_query_webgl2';
-  const ext = gl.getExtension(extensionName);
-  const isExtEnabled = ext != null;
+  if (hasExtension(gl, 'EXT_disjoint_timer_query_webgl2')) {
+    queryTimerVersion = 2;
+  } else if (hasExtension(gl, 'EXT_disjoint_timer_query')) {
+    queryTimerVersion = 1;
+  } else {
+    queryTimerVersion = 0;
+  }
+
   if (gl != null) {
     loseContext(gl);
   }
-  return isExtEnabled;
+  return queryTimerVersion;
 }
 
 function isFloatTextureReadPixelsEnabled(webGLVersion: number): boolean {
@@ -112,11 +134,11 @@ function isFloatTextureReadPixelsEnabled(webGLVersion: number): boolean {
   const gl = getWebGLRenderingContext(webGLVersion);
 
   if (webGLVersion === 1) {
-    if (gl.getExtension('OES_texture_float') == null) {
+    if (!hasExtension(gl, 'OES_texture_float')) {
       return false;
     }
   } else {
-    if (gl.getExtension('EXT_color_buffer_float') == null) {
+    if (!hasExtension(gl, 'EXT_color_buffer_float')) {
       return false;
     }
   }
@@ -152,8 +174,8 @@ function isWebGLGetBufferSubDataAsyncExtensionEnabled(webGLVersion: number) {
     return false;
   }
   const gl = getWebGLRenderingContext(webGLVersion);
-  const ext = gl.getExtension('WEBGL_get_buffer_sub_data_async');
-  const isEnabled = ext != null;
+
+  const isEnabled = hasExtension(gl, 'WEBGL_get_buffer_sub_data_async');
   loseContext(gl);
   return isEnabled;
 }
@@ -170,6 +192,13 @@ export class Environment {
     if (features != null) {
       this.features = features;
     }
+
+    if (this.get('DEBUG')) {
+      console.warn(
+          'Debugging mode is ON. The output of every math call will ' +
+          'be downloaded to CPU and checked for NaNs. ' +
+          'This significantly impacts performance.');
+    }
   }
 
   get<K extends keyof Features>(feature: K): Features[K] {
@@ -180,6 +209,10 @@ export class Environment {
     this.features[feature] = this.evaluateFeature(feature);
 
     return this.features[feature];
+  }
+
+  set<K extends keyof Features>(feature: K, value: Features[K]): void {
+    this.features[feature] = value;
   }
 
   getBestBackendType(): BackendType {
@@ -194,16 +227,18 @@ export class Environment {
   }
 
   private evaluateFeature<K extends keyof Features>(feature: K): Features[K] {
-    if (feature === 'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_ENABLED') {
+    if (feature === 'DEBUG') {
+      return false;
+    } else if (feature === 'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') {
       const webGLVersion = this.get('WEBGL_VERSION');
 
       if (webGLVersion === 0) {
-        return false;
+        return 0;
       }
 
-      return isWebGLDisjointQueryTimerEnabled(webGLVersion);
+      return getWebGLDisjointQueryTimerVersion(webGLVersion);
     } else if (feature === 'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_RELIABLE') {
-      return this.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_ENABLED') &&
+      return this.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') > 0 &&
           !device_util.isMobile();
     } else if (feature === 'WEBGL_VERSION') {
       if (isWebGLVersionEnabled(2)) {
@@ -254,8 +289,8 @@ export class Environment {
    * Adds a custom backend. Usually used in tests to simulate different
    * environments.
    *
-   * @param factory: The backend factory function. When called, it should return
-   *     an instance of the backend.
+   * @param factory: The backend factory function. When called, it should
+   * return an instance of the backend.
    * @return False if the creation/registration failed. True otherwise.
    */
   addCustomBackend(name: BackendType, factory: () => MathBackend): boolean {
@@ -276,8 +311,8 @@ export class Environment {
    * a module file (e.g. when importing `backend_webgl.ts`), and is used for
    * modular builds (e.g. custom deeplearn.js bundle with only webgl support).
    *
-   * @param factory: The backend factory function. When called, it should return
-   *     an instance of the backend.
+   * @param factory: The backend factory function. When called, it should
+   * return an instance of the backend.
    * @return False if the creation/registration failed. True otherwise.
    */
   registerBackend(name: BackendType, factory: () => MathBackend): boolean {

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -112,7 +112,8 @@ function getWebGLDisjointQueryTimerVersion(webGLVersion: number): number {
   let queryTimerVersion: number;
   const gl = getWebGLRenderingContext(webGLVersion);
 
-  if (hasExtension(gl, 'EXT_disjoint_timer_query_webgl2')) {
+  if (hasExtension(gl, 'EXT_disjoint_timer_query_webgl2') &&
+      webGLVersion === 2) {
     queryTimerVersion = 2;
   } else if (hasExtension(gl, 'EXT_disjoint_timer_query')) {
     queryTimerVersion = 1;

--- a/src/environment_test.ts
+++ b/src/environment_test.ts
@@ -28,7 +28,7 @@ describe('disjoint query timer enabled', () => {
 
   it('no webgl', () => {
     ENV.setFeatures({'WEBGL_VERSION': 0});
-    expect(ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_ENABLED')).toBe(false);
+    expect(ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION')).toBe(0);
   });
 
   it('webgl 1', () => {
@@ -54,7 +54,7 @@ describe('disjoint query timer enabled', () => {
 
     ENV.setFeatures(features);
 
-    expect(ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_ENABLED')).toBe(true);
+    expect(ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION')).toBe(1);
   });
 
   it('webgl 2', () => {
@@ -79,7 +79,7 @@ describe('disjoint query timer enabled', () => {
     });
 
     ENV.setFeatures(features);
-    expect(ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_ENABLED')).toBe(true);
+    expect(ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION')).toBe(2);
   });
 });
 
@@ -90,7 +90,7 @@ describe('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_RELIABLE', () => {
 
   it('disjoint query timer disabled', () => {
     const features:
-        Features = {'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_ENABLED': false};
+        Features = {'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION': 0};
 
     const env = new Environment(features);
 
@@ -100,7 +100,7 @@ describe('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_RELIABLE', () => {
 
   it('disjoint query timer enabled, mobile', () => {
     const features:
-        Features = {'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_ENABLED': true};
+        Features = {'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION': 1};
     spyOn(device_util, 'isMobile').and.returnValue(true);
 
     const env = new Environment(features);
@@ -111,7 +111,7 @@ describe('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_RELIABLE', () => {
 
   it('disjoint query timer enabled, not mobile', () => {
     const features:
-        Features = {'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_ENABLED': true};
+        Features = {'WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION': 1};
     spyOn(device_util, 'isMobile').and.returnValue(false);
 
     const env = new Environment(features);

--- a/src/math/backends/backend.ts
+++ b/src/math/backends/backend.ts
@@ -37,11 +37,6 @@ export interface NDArrayStorage {
 
 export interface BackendTimer { time(f: () => void): Promise<number>; }
 
-export interface TimerQuery {
-  startMs: number;
-  endMs?: number;
-}
-
 /**
  * The interface that defines the kernels that should be implemented when
  * adding a new backend. New backends don't need to implement every one of the

--- a/src/math/backends/backend.ts
+++ b/src/math/backends/backend.ts
@@ -35,18 +35,11 @@ export interface NDArrayStorage {
   register(dataId: number, shape: number[], dtype: DataType): void;
 }
 
+export interface BackendTimer { time(f: () => void): Promise<number>; }
+
 export interface TimerQuery {
   startMs: number;
   endMs?: number;
-}
-  export interface BackendTimer {
-  time(f: () => NDArray): Promise<number>;
-  // Calling these three functions independently should be equivalent to calling
-  // time. We split them up so we can queue getQueryTimer promises so they don't
-  // run in parallel.
-  startTimer(): {};
-  endTimer(query: {}): {};
-  getQueryTime(query: {}): Promise<number>;
 }
 
 /**

--- a/src/math/backends/backend.ts
+++ b/src/math/backends/backend.ts
@@ -31,7 +31,7 @@ export interface NDArrayStorage {
   fromPixels(
       pixels: ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement,
       numChannels: number): Array3D;
-  time(query: () => NDArray): Promise<number>;
+  time(query: () => void): Promise<number>;
   register(dataId: number, shape: number[], dtype: DataType): void;
 }
 

--- a/src/math/backends/backend.ts
+++ b/src/math/backends/backend.ts
@@ -32,8 +32,21 @@ export interface NDArrayStorage {
       dataId: number,
       pixels: ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement,
       numChannels: number): void;
-  time(query: () => NDArray): Promise<number>;
   register(dataId: number, shape: number[], dtype: DataType): void;
+}
+
+export interface TimerQuery {
+  startMs: number;
+  endMs?: number;
+}
+  export interface BackendTimer {
+  time(f: () => NDArray): Promise<number>;
+  // Calling these three functions independently should be equivalent to calling
+  // time. We split them up so we can queue getQueryTimer promises so they don't
+  // run in parallel.
+  startTimer(): {};
+  endTimer(query: {}): {};
+  getQueryTime(query: {}): Promise<number>;
 }
 
 /**
@@ -42,7 +55,7 @@ export interface NDArrayStorage {
  * methods, this can be done gradually (throw an error for unimplemented
  * methods).
  */
-export interface MathBackend extends NDArrayStorage {
+export interface MathBackend extends NDArrayStorage, BackendTimer {
   matMul(
       a: Array2D, b: Array2D, aOrientation: MatrixOrientation,
       bOrientation: MatrixOrientation): Array2D;

--- a/src/math/backends/backend_cpu.ts
+++ b/src/math/backends/backend_cpu.ts
@@ -29,7 +29,7 @@ import * as ops from '../ops';
 import * as types from '../types';
 import {DataType, DataTypeMap, Rank, TypedArray} from '../types';
 import * as axis_util from './../axis_util';
-import {MathBackend, TimerQuery} from './backend';
+import {MathBackend} from './backend';
 import {MatrixOrientation} from './types/matmul';
 
 export class MathBackendCPU implements MathBackend {

--- a/src/math/backends/backend_cpu.ts
+++ b/src/math/backends/backend_cpu.ts
@@ -113,23 +113,10 @@ export class MathBackendCPU implements MathBackend {
     delete this.data[dataId];
   }
 
-  time(f: () => void): Promise<number> {
-    const query = this.startTimer();
+  async time(f: () => void): Promise<number> {
+    const start = performance.now();
     f();
-    this.endTimer(query);
-    return this.getQueryTime(query);
-  }
-
-  startTimer(): TimerQuery {
-    return {startMs: performance.now(), endMs: null};
-  }
-
-  endTimer(query: TimerQuery): TimerQuery {
-    query.endMs = performance.now();
-    return query;
-  }
-  async getQueryTime(query: TimerQuery): Promise<number> {
-    return query.endMs - query.startMs;
+    return performance.now() - start;
   }
 
   private throwIfNoData(dataId: number) {

--- a/src/math/backends/backend_cpu.ts
+++ b/src/math/backends/backend_cpu.ts
@@ -113,24 +113,26 @@ export class MathBackendCPU implements MathBackend {
     delete this.data[dataId];
   }
 
-  time(f: () => NDArray): Promise<number> {
+  time(f: () => void): Promise<number> {
     const query = this.startTimer();
     f();
     this.endTimer(query);
     return this.getQueryTime(query);
   }
-   startTimer(): TimerQuery {
+
+  startTimer(): TimerQuery {
     return {startMs: performance.now(), endMs: null};
   }
-   endTimer(query: TimerQuery): TimerQuery {
+
+  endTimer(query: TimerQuery): TimerQuery {
     query.endMs = performance.now();
     return query;
   }
-   async getQueryTime(query: TimerQuery): Promise<number> {
+  async getQueryTime(query: TimerQuery): Promise<number> {
     return query.endMs - query.startMs;
   }
 
-   private throwIfNoData(dataId: number) {
+  private throwIfNoData(dataId: number) {
     if (!(dataId in this.data)) {
       throw new Error(
           `No data found for NDArray with data id ${dataId}. ` +

--- a/src/math/backends/backend_webgl.ts
+++ b/src/math/backends/backend_webgl.ts
@@ -182,6 +182,7 @@ export class MathBackendWebGL implements MathBackend {
     await this.gpgpu.runQuery(() => {});
     return this.readSync(dataId);
   }
+
   async time(f: () => NDArray): Promise<number> {
     if (ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') === 0) {
       const start = performance.now();

--- a/src/math/backends/kernel_registry.ts
+++ b/src/math/backends/kernel_registry.ts
@@ -460,3 +460,4 @@ export interface KernelConfigRegistry<R extends Rank> {
   Multinomial: MultinomialNode;
   OneHot: OneHotNode;
 }
+export type Kernel = keyof KernelConfigRegistry<Rank>;

--- a/src/math/backends/profiler.ts
+++ b/src/math/backends/profiler.ts
@@ -23,9 +23,6 @@ import {BackendTimer} from './backend';
 import {Kernel} from './kernel_registry';
 
 export class Profiler {
-  // private pendingTimer: Promise<number>;
-  // private pendingKernel = false;
-
   constructor(private backendTimer: BackendTimer, private logger?: Logger) {
     if (logger == null) {
       this.logger = new Logger();
@@ -47,45 +44,6 @@ export class Profiler {
     });
 
     return result as T;
-
-    // let result: NDArray;
-
-    // const shouldTimeKernel = this.pendingKernel === false;
-
-    // let query: {};
-    // if (shouldTimeKernel) {
-    //   query = this.backendTimer.startTimer();
-    //   this.pendingKernel = true;
-    // }
-
-    // result = f();
-
-    // if (shouldTimeKernel) {
-    //   query = this.backendTimer.endTimer(query);
-    //   this.pendingKernel = false;
-    // }
-
-    // if (shouldTimeKernel) {
-    //   const vals = result.dataSync();
-    //   util.checkForNaN(vals, result.dtype, name);
-
-    //   const profile = (timeMs: number) => {
-    //     this.logger.logKernelProfile(kernelName, result, vals, timeMs);
-    //   };
-
-    //   if (this.pendingTimer == null) {
-    //     this.pendingTimer = this.backendTimer.getQueryTime(query);
-    //     this.pendingTimer.then(timeMs => {
-    //       profile(timeMs);
-    //       this.pendingTimer = null;
-    //     });
-    //   } else {
-    //     this.pendingTimer.then(
-    //         () => this.backendTimer.getQueryTime(query).then(profile));
-    //   }
-    // }
-
-    // return result as T;
   }
 }
 

--- a/src/math/backends/profiler.ts
+++ b/src/math/backends/profiler.ts
@@ -1,3 +1,20 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
 import * as util from '../../util';
 import {NDArray} from '../ndarray';
 import {TypedArray} from '../types';
@@ -25,9 +42,9 @@ export class Profiler {
     const vals = result.dataSync();
     util.checkForNaN(vals, result.dtype, name);
 
-    timer.then(
-        (timeMs: number) =>
-            this.logger.logKernelProfile(kernelName, result, vals, timeMs));
+    timer.then((timeMs: number) => {
+      this.logger.logKernelProfile(kernelName, result, vals, timeMs);
+    });
 
     return result as T;
 

--- a/src/math/backends/profiler.ts
+++ b/src/math/backends/profiler.ts
@@ -31,10 +31,10 @@ export class Profiler {
 
   profileKernel<T extends NDArray>(kernelName: Kernel, f: () => T): T {
     let result: T;
-    const wrapperFn = () => {
+    const holdResultWrapperFn = () => {
       result = f();
     };
-    const timer = this.backendTimer.time(wrapperFn);
+    const timer = this.backendTimer.time(holdResultWrapperFn);
 
     const vals = result.dataSync();
     util.checkForNaN(vals, result.dtype, name);

--- a/src/math/backends/profiler.ts
+++ b/src/math/backends/profiler.ts
@@ -1,0 +1,64 @@
+import * as util from '../../util';
+import {NDArray} from '../ndarray';
+import {TypedArray} from '../types';
+
+import {BackendTimer} from './backend';
+import {Kernel} from './kernel_registry';
+
+export class Profiler {
+  private pendingTimer: Promise<number>;
+  private pendingKernel = false;
+
+  constructor(private backendTimer: BackendTimer) {}
+
+  profileKernel<T extends NDArray>(kernelName: Kernel, f: () => T): T {
+    let result: NDArray;
+
+    const shouldTimeKernel = this.pendingKernel === false;
+
+    let query: {};
+    if (shouldTimeKernel) {
+      query = this.backendTimer.startTimer();
+      this.pendingKernel = true;
+    }
+
+    result = f();
+
+    if (shouldTimeKernel) {
+      query = this.backendTimer.endTimer(query);
+      this.pendingKernel = false;
+
+      const vals = result.dataSync();
+      util.checkForNaN(vals, result.dtype, name);
+
+      const profile = (timeMs: number) => {
+        this.logKernelProfile(kernelName, result, vals, timeMs);
+      };
+
+      if (this.pendingTimer == null) {
+        this.pendingTimer = this.backendTimer.getQueryTime(query);
+        this.pendingTimer.then(timeMs => {
+          profile(timeMs);
+          this.pendingTimer = null;
+        });
+      } else {
+        this.pendingTimer.then(
+            () => this.backendTimer.getQueryTime(query).then(profile));
+      }
+    }
+
+    return result as T;
+  }
+
+  logKernelProfile(
+      kernelName: Kernel, result: NDArray, vals: TypedArray, timeMs: number) {
+    const time = util.rightPad(`${timeMs}ms`, 9);
+    const paddedName = util.rightPad(kernelName, 25);
+    const rank = result.rank;
+    const size = result.size;
+    const shape = util.rightPad(result.shape.toString(), 14);
+    console.log(
+        `%c${paddedName}\t%c${time}\t%c${rank}D ${shape}\t%c${size}`,
+        'font-weight:bold', 'color:red', 'color:blue', 'color: orange');
+  }
+}

--- a/src/math/backends/profiler_test.ts
+++ b/src/math/backends/profiler_test.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import * as test_util from '../../test_util';
+import {MathTests} from '../../test_util';
+import {NDArray} from '../ndarray';
+
+import {BackendTimer} from './backend';
+import {Profiler} from './profiler';
+
+class TestBackendTimer implements BackendTimer {
+  async time(query: () => NDArray): Promise<number> {
+    query();
+    return 10;
+  }
+
+  startTimer(): {} {
+    return {};
+  }
+  endTimer(query: {}): {} {
+    return {};
+  }
+  async getQueryTime(query: {}): Promise<number> {
+    return 10;
+  }
+}
+
+const tests: MathTests = it => {
+  it('profiles simple function ', () => {
+    const profiler = new Profiler(new TestBackendTimer());
+    console.log(profiler);
+  });
+};
+test_util.describeMathCPU('profiler.Profiler', [tests]);

--- a/src/math/backends/profiler_test.ts
+++ b/src/math/backends/profiler_test.ts
@@ -17,7 +17,7 @@
 
 import * as test_util from '../../test_util';
 import {MathTests} from '../../test_util';
-import {NDArray} from '../ndarray';
+import {NDArray, Scalar} from '../ndarray';
 
 import {BackendTimer} from './backend';
 import {Profiler} from './profiler';
@@ -42,7 +42,13 @@ class TestBackendTimer implements BackendTimer {
 const tests: MathTests = it => {
   it('profiles simple function ', () => {
     const profiler = new Profiler(new TestBackendTimer());
-    console.log(profiler);
+    spyOn(profiler, 'logKernelProfile');
+
+    profiler.profileKernel('MatMul', () => {
+      return Scalar.new(1);
+    });
+
+    console.log(profiler.logKernelProfile.calls.count);
   });
 };
 test_util.describeMathCPU('profiler.Profiler', [tests]);

--- a/src/math/backends/profiler_test.ts
+++ b/src/math/backends/profiler_test.ts
@@ -15,131 +15,150 @@
  * =============================================================================
  */
 
-import {NDArray, Scalar} from '../ndarray';
+// import {NDArray, Scalar} from '../ndarray';
 
-import {BackendTimer} from './backend';
-import {Kernel} from './kernel_registry';
-import {Logger, Profiler} from './profiler';
-import {TypedArray} from './webgl/tex_util';
+// import {BackendTimer} from './backend';
+// import {Kernel} from './kernel_registry';
+// import {Logger, Profiler} from './profiler';
+// import {TypedArray} from './webgl/tex_util';
 
-class TestBackendTimer implements BackendTimer {
-  constructor(private delayMs: number, private queryTimeMs: number) {}
+// class TestBackendTimer implements BackendTimer {
+//   constructor(private delayMs: number, private queryTimeMs: number) {}
 
-  async time(query: () => NDArray): Promise<number> {
-    query();
-    return this.queryTimeMs;
-  }
+//   time<T extends NDArray>(query: () => T): {result: T, timer:
+//   Promise<number>} {
+//     const result = query();
+//     return {
+//       result,
+//       timer: new Promise<number>(
+//           resolve => setTimeout(resolve(this.queryTimeMs), delayMs))
+//     };
+//   }
+// }
 
-  startTimer(): {} {
-    return {};
-  }
-  endTimer(query: {}): {} {
-    return {};
-  }
-  async getQueryTime(query: {}): Promise<number> {
-    return new Promise<number>(resolve => {
-      setTimeout(() => resolve(this.queryTimeMs), this.delayMs);
+import * as test_util from '../../test_util';
+import {MathTests} from '../../test_util';
+import {Array1D} from '../ndarray';
+
+// math.prelu
+{
+  const tests: MathTests = it => {
+    it('nikhil', math => {
+      const x = Array1D.new([0, 1, -2, -4]);
+      const a = Array1D.new([0.15, 0.2, 0.25, 0.15]);
+      math.time(() => {
+            math.prelu(x, a);
+          })
+          .then(timeMs => {
+            console.log('-----time', timeMs);
+          });
+
+      // expect(result.shape).toEqual(x.shape);
+      // test_util.expectArraysClose(result, [0, 1, -0.5, -0.6]);
     });
-  }
+  };
+
+  test_util.describeMathGPU('prelu', [tests], [
+    {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2},
+  ]);
 }
 
-class TestLogger extends Logger {
-  logKernelProfile(
-      kernelName: Kernel, result: NDArray, vals: TypedArray, timeMs: number) {}
-}
+// class TestLogger extends Logger {
+//   logKernelProfile(
+//       kernelName: Kernel, result: NDArray, vals: TypedArray, timeMs: number)
+//       {}
+// }
 
-describe('profiler.Profiler', () => {
-  it('profiles simple function', doneFn => {
-    const delayMs = 5;
-    const queryTimeMs = 10;
-    const timer = new TestBackendTimer(delayMs, queryTimeMs);
-    const logger = new TestLogger();
-    const profiler = new Profiler(timer, logger);
+// describe('profiler.Profiler', () => {
+//   it('profiles simple function', doneFn => {
+//     const delayMs = 5;
+//     const queryTimeMs = 10;
+//     const timer = new TestBackendTimer(delayMs, queryTimeMs);
+//     const logger = new TestLogger();
+//     const profiler = new Profiler(timer, logger);
 
-    spyOn(timer, 'startTimer').and.callThrough();
-    spyOn(timer, 'endTimer').and.callThrough();
-    spyOn(timer, 'getQueryTime').and.callThrough();
+//     spyOn(timer, 'time').and.callThrough();
 
-    spyOn(logger, 'logKernelProfile').and.callThrough();
+//     spyOn(logger, 'logKernelProfile').and.callThrough();
 
-    const startTimerSpy = timer.startTimer as jasmine.Spy;
-    const endTimerSpy = timer.endTimer as jasmine.Spy;
-    const getQueryTimeSpy = timer.getQueryTime as jasmine.Spy;
+//     const startTimerSpy = timer.startTimer as jasmine.Spy;
+//     const endTimerSpy = timer.endTimer as jasmine.Spy;
+//     const getQueryTimeSpy = timer.getQueryTime as jasmine.Spy;
 
-    const logKernelProfileSpy = logger.logKernelProfile as jasmine.Spy;
+//     const logKernelProfileSpy = logger.logKernelProfile as jasmine.Spy;
 
-    let kernelCalled = false;
-    const result = 1;
-    const resultScalar = Scalar.new(result);
+//     let kernelCalled = false;
+//     const result = 1;
+//     const resultScalar = Scalar.new(result);
 
-    profiler.profileKernel('MatMul', () => {
-      kernelCalled = true;
-      return resultScalar;
-    });
+//     profiler.profileKernel('MatMul', () => {
+//       kernelCalled = true;
+//       return resultScalar;
+//     });
 
-    setTimeout(() => {
-      expect(startTimerSpy.calls.count()).toBe(1);
-      expect(endTimerSpy.calls.count()).toBe(1);
-      expect(getQueryTimeSpy.calls.count()).toBe(1);
+//     setTimeout(() => {
+//       expect(startTimerSpy.calls.count()).toBe(1);
+//       expect(endTimerSpy.calls.count()).toBe(1);
+//       expect(getQueryTimeSpy.calls.count()).toBe(1);
 
-      expect(logKernelProfileSpy.calls.count()).toBe(1);
-      expect(logKernelProfileSpy.calls.first().args).toEqual([
-        'MatMul', resultScalar, new Float32Array([result]), queryTimeMs
-      ]);
+//       expect(logKernelProfileSpy.calls.count()).toBe(1);
+//       expect(logKernelProfileSpy.calls.first().args).toEqual([
+//         'MatMul', resultScalar, new Float32Array([result]), queryTimeMs
+//       ]);
 
-      expect(kernelCalled).toBe(true);
-      doneFn();
-    }, delayMs * 2);
-  });
+//       expect(kernelCalled).toBe(true);
+//       doneFn();
+//     }, delayMs * 2);
+//   });
 
-  it('profiles nested kernel', doneFn => {
-    const delayMs = 5;
-    const queryTimeMs = 10;
-    const timer = new TestBackendTimer(delayMs, queryTimeMs);
-    const logger = new TestLogger();
-    const profiler = new Profiler(timer, logger);
+//   it('profiles nested kernel', doneFn => {
+//     const delayMs = 5;
+//     const queryTimeMs = 10;
+//     const timer = new TestBackendTimer(delayMs, queryTimeMs);
+//     const logger = new TestLogger();
+//     const profiler = new Profiler(timer, logger);
 
-    spyOn(timer, 'startTimer').and.callThrough();
-    spyOn(timer, 'endTimer').and.callThrough();
-    spyOn(timer, 'getQueryTime').and.callThrough();
+//     spyOn(timer, 'startTimer').and.callThrough();
+//     spyOn(timer, 'endTimer').and.callThrough();
+//     spyOn(timer, 'getQueryTime').and.callThrough();
 
-    spyOn(logger, 'logKernelProfile').and.callThrough();
+//     spyOn(logger, 'logKernelProfile').and.callThrough();
 
-    const startTimerSpy = timer.startTimer as jasmine.Spy;
-    const endTimerSpy = timer.endTimer as jasmine.Spy;
-    const getQueryTimeSpy = timer.getQueryTime as jasmine.Spy;
+//     const startTimerSpy = timer.startTimer as jasmine.Spy;
+//     const endTimerSpy = timer.endTimer as jasmine.Spy;
+//     const getQueryTimeSpy = timer.getQueryTime as jasmine.Spy;
 
-    const logKernelProfileSpy = logger.logKernelProfile as jasmine.Spy;
+//     const logKernelProfileSpy = logger.logKernelProfile as jasmine.Spy;
 
-    let matmulKernelCalled = false;
-    let maxKernelCalled = false;
-    const result = 1;
-    const resultScalar = Scalar.new(result);
+//     let matmulKernelCalled = false;
+//     let maxKernelCalled = false;
+//     const result = 1;
+//     const resultScalar = Scalar.new(result);
 
-    profiler.profileKernel('MatMul', () => {
-      const result = profiler.profileKernel('Max', () => {
-        maxKernelCalled = true;
-        return resultScalar;
-      });
-      matmulKernelCalled = true;
-      return result;
-    });
+//     profiler.profileKernel('MatMul', () => {
+//       const result = profiler.profileKernel('Max', () => {
+//         maxKernelCalled = true;
+//         return resultScalar;
+//       });
+//       matmulKernelCalled = true;
+//       return result;
+//     });
 
-    setTimeout(() => {
-      expect(startTimerSpy.calls.count()).toBe(1);
-      expect(endTimerSpy.calls.count()).toBe(1);
-      expect(getQueryTimeSpy.calls.count()).toBe(1);
+//     setTimeout(() => {
+//       expect(startTimerSpy.calls.count()).toBe(1);
+//       expect(endTimerSpy.calls.count()).toBe(1);
+//       expect(getQueryTimeSpy.calls.count()).toBe(1);
 
-      // Only MatMul should have been logged, nested kernels will be ignored,
-      // however the function should be evaluated.
-      expect(logKernelProfileSpy.calls.count()).toBe(1);
-      expect(logKernelProfileSpy.calls.first().args).toEqual([
-        'MatMul', resultScalar, new Float32Array([result]), queryTimeMs
-      ]);
+//       // Only MatMul should have been logged, nested kernels will be ignored,
+//       // however the function should be evaluated.
+//       expect(logKernelProfileSpy.calls.count()).toBe(1);
+//       expect(logKernelProfileSpy.calls.first().args).toEqual([
+//         'MatMul', resultScalar, new Float32Array([result]), queryTimeMs
+//       ]);
 
-      expect(matmulKernelCalled).toBe(true);
-      expect(maxKernelCalled).toBe(true);
-      doneFn();
-    }, delayMs * 2);
-  });
-});
+//       expect(matmulKernelCalled).toBe(true);
+//       expect(maxKernelCalled).toBe(true);
+//       doneFn();
+//     }, delayMs * 2);
+//   });
+// });

--- a/src/math/backends/profiler_test.ts
+++ b/src/math/backends/profiler_test.ts
@@ -15,150 +15,106 @@
  * =============================================================================
  */
 
-// import {NDArray, Scalar} from '../ndarray';
+import {NDArray, Scalar} from '../ndarray';
 
-// import {BackendTimer} from './backend';
-// import {Kernel} from './kernel_registry';
-// import {Logger, Profiler} from './profiler';
-// import {TypedArray} from './webgl/tex_util';
+import {BackendTimer} from './backend';
+import {Kernel} from './kernel_registry';
+import {Logger, Profiler} from './profiler';
+import {TypedArray} from './webgl/tex_util';
 
-// class TestBackendTimer implements BackendTimer {
-//   constructor(private delayMs: number, private queryTimeMs: number) {}
+class TestBackendTimer implements BackendTimer {
+  private counter = 1;
+  constructor(private delayMs: number, private queryTimeMs: number) {}
 
-//   time<T extends NDArray>(query: () => T): {result: T, timer:
-//   Promise<number>} {
-//     const result = query();
-//     return {
-//       result,
-//       timer: new Promise<number>(
-//           resolve => setTimeout(resolve(this.queryTimeMs), delayMs))
-//     };
-//   }
-// }
-
-import * as test_util from '../../test_util';
-import {MathTests} from '../../test_util';
-import {Array1D} from '../ndarray';
-
-// math.prelu
-{
-  const tests: MathTests = it => {
-    it('nikhil', math => {
-      const x = Array1D.new([0, 1, -2, -4]);
-      const a = Array1D.new([0.15, 0.2, 0.25, 0.15]);
-      math.time(() => {
-            math.prelu(x, a);
-          })
-          .then(timeMs => {
-            console.log('-----time', timeMs);
-          });
-
-      // expect(result.shape).toEqual(x.shape);
-      // test_util.expectArraysClose(result, [0, 1, -0.5, -0.6]);
-    });
-  };
-
-  test_util.describeMathGPU('prelu', [tests], [
-    {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2},
-  ]);
+  time(query: () => void): Promise<number> {
+    query();
+    return new Promise<number>(
+        resolve => setTimeout(
+            resolve(this.queryTimeMs * this.counter++), this.delayMs));
+  }
 }
 
-// class TestLogger extends Logger {
-//   logKernelProfile(
-//       kernelName: Kernel, result: NDArray, vals: TypedArray, timeMs: number)
-//       {}
-// }
+class TestLogger extends Logger {
+  logKernelProfile(
+      kernelName: Kernel, result: NDArray, vals: TypedArray, timeMs: number) {}
+}
 
-// describe('profiler.Profiler', () => {
-//   it('profiles simple function', doneFn => {
-//     const delayMs = 5;
-//     const queryTimeMs = 10;
-//     const timer = new TestBackendTimer(delayMs, queryTimeMs);
-//     const logger = new TestLogger();
-//     const profiler = new Profiler(timer, logger);
+describe('profiler.Profiler', () => {
+  it('profiles simple function', doneFn => {
+    const delayMs = 5;
+    const queryTimeMs = 10;
+    const timer = new TestBackendTimer(delayMs, queryTimeMs);
+    const logger = new TestLogger();
+    const profiler = new Profiler(timer, logger);
 
-//     spyOn(timer, 'time').and.callThrough();
+    spyOn(timer, 'time').and.callThrough();
+    spyOn(logger, 'logKernelProfile').and.callThrough();
 
-//     spyOn(logger, 'logKernelProfile').and.callThrough();
+    const timeSpy = timer.time as jasmine.Spy;
+    const logKernelProfileSpy = logger.logKernelProfile as jasmine.Spy;
 
-//     const startTimerSpy = timer.startTimer as jasmine.Spy;
-//     const endTimerSpy = timer.endTimer as jasmine.Spy;
-//     const getQueryTimeSpy = timer.getQueryTime as jasmine.Spy;
+    let kernelCalled = false;
+    const result = 1;
+    const resultScalar = Scalar.new(result);
 
-//     const logKernelProfileSpy = logger.logKernelProfile as jasmine.Spy;
+    profiler.profileKernel('MatMul', () => {
+      kernelCalled = true;
+      return resultScalar;
+    });
 
-//     let kernelCalled = false;
-//     const result = 1;
-//     const resultScalar = Scalar.new(result);
+    setTimeout(() => {
+      expect(timeSpy.calls.count()).toBe(1);
 
-//     profiler.profileKernel('MatMul', () => {
-//       kernelCalled = true;
-//       return resultScalar;
-//     });
+      expect(logKernelProfileSpy.calls.count()).toBe(1);
+      expect(logKernelProfileSpy.calls.first().args).toEqual([
+        'MatMul', resultScalar, new Float32Array([result]), queryTimeMs
+      ]);
 
-//     setTimeout(() => {
-//       expect(startTimerSpy.calls.count()).toBe(1);
-//       expect(endTimerSpy.calls.count()).toBe(1);
-//       expect(getQueryTimeSpy.calls.count()).toBe(1);
+      expect(kernelCalled).toBe(true);
+      doneFn();
+    }, delayMs * 2);
+  });
 
-//       expect(logKernelProfileSpy.calls.count()).toBe(1);
-//       expect(logKernelProfileSpy.calls.first().args).toEqual([
-//         'MatMul', resultScalar, new Float32Array([result]), queryTimeMs
-//       ]);
+  it('profiles nested kernel', doneFn => {
+    const delayMs = 5;
+    const queryTimeMs = 10;
+    const timer = new TestBackendTimer(delayMs, queryTimeMs);
+    const logger = new TestLogger();
+    const profiler = new Profiler(timer, logger);
 
-//       expect(kernelCalled).toBe(true);
-//       doneFn();
-//     }, delayMs * 2);
-//   });
+    spyOn(timer, 'time').and.callThrough();
+    spyOn(logger, 'logKernelProfile').and.callThrough();
+    const timeSpy = timer.time as jasmine.Spy;
+    const logKernelProfileSpy = logger.logKernelProfile as jasmine.Spy;
 
-//   it('profiles nested kernel', doneFn => {
-//     const delayMs = 5;
-//     const queryTimeMs = 10;
-//     const timer = new TestBackendTimer(delayMs, queryTimeMs);
-//     const logger = new TestLogger();
-//     const profiler = new Profiler(timer, logger);
+    let matmulKernelCalled = false;
+    let maxKernelCalled = false;
+    const result = 1;
+    const resultScalar = Scalar.new(result);
 
-//     spyOn(timer, 'startTimer').and.callThrough();
-//     spyOn(timer, 'endTimer').and.callThrough();
-//     spyOn(timer, 'getQueryTime').and.callThrough();
+    profiler.profileKernel('MatMul', () => {
+      const result = profiler.profileKernel('Max', () => {
+        maxKernelCalled = true;
+        return resultScalar;
+      });
+      matmulKernelCalled = true;
+      return result;
+    });
 
-//     spyOn(logger, 'logKernelProfile').and.callThrough();
+    setTimeout(() => {
+      expect(timeSpy.calls.count()).toBe(2);
 
-//     const startTimerSpy = timer.startTimer as jasmine.Spy;
-//     const endTimerSpy = timer.endTimer as jasmine.Spy;
-//     const getQueryTimeSpy = timer.getQueryTime as jasmine.Spy;
+      expect(logKernelProfileSpy.calls.count()).toBe(2);
+      expect(logKernelProfileSpy.calls.first().args).toEqual([
+        'Max', resultScalar, new Float32Array([result]), queryTimeMs
+      ]);
+      expect(logKernelProfileSpy.calls.argsFor(1)).toEqual([
+        'MatMul', resultScalar, new Float32Array([result]), queryTimeMs * 2
+      ]);
 
-//     const logKernelProfileSpy = logger.logKernelProfile as jasmine.Spy;
-
-//     let matmulKernelCalled = false;
-//     let maxKernelCalled = false;
-//     const result = 1;
-//     const resultScalar = Scalar.new(result);
-
-//     profiler.profileKernel('MatMul', () => {
-//       const result = profiler.profileKernel('Max', () => {
-//         maxKernelCalled = true;
-//         return resultScalar;
-//       });
-//       matmulKernelCalled = true;
-//       return result;
-//     });
-
-//     setTimeout(() => {
-//       expect(startTimerSpy.calls.count()).toBe(1);
-//       expect(endTimerSpy.calls.count()).toBe(1);
-//       expect(getQueryTimeSpy.calls.count()).toBe(1);
-
-//       // Only MatMul should have been logged, nested kernels will be ignored,
-//       // however the function should be evaluated.
-//       expect(logKernelProfileSpy.calls.count()).toBe(1);
-//       expect(logKernelProfileSpy.calls.first().args).toEqual([
-//         'MatMul', resultScalar, new Float32Array([result]), queryTimeMs
-//       ]);
-
-//       expect(matmulKernelCalled).toBe(true);
-//       expect(maxKernelCalled).toBe(true);
-//       doneFn();
-//     }, delayMs * 2);
-//   });
-// });
+      expect(matmulKernelCalled).toBe(true);
+      expect(maxKernelCalled).toBe(true);
+      doneFn();
+    }, delayMs * 2);
+  });
+});

--- a/src/math/backends/webgl/gpgpu_context.ts
+++ b/src/math/backends/webgl/gpgpu_context.ts
@@ -20,9 +20,9 @@ import * as util from '../../../util';
 
 import * as gpgpu_util from './gpgpu_util';
 import * as tex_util from './tex_util';
-import * as webgl_util from './webgl_util';
 // tslint:disable-next-line:max-line-length
-import {WebGL1DisjointQueryTimerExtension, WebGL2DisjointQueryTimerExtension, WebGL2RenderingContext, WebGLLoseContextExtension, WebGLQuery} from './webgl_util';
+import {WebGL1DisjointQueryTimerExtension, WebGL2DisjointQueryTimerExtension, WebGL2RenderingContext, WebGLLoseContextExtension, WebGLQuery} from './webgl_types';
+import * as webgl_util from './webgl_util';
 
 export class GPGPUContext {
   gl: WebGLRenderingContext;
@@ -391,8 +391,6 @@ export class GPGPUContext {
           gl2.getQueryParameter(query, gl2.QUERY_RESULT_AVAILABLE);
 
       const disjoint = this.gl.getParameter(ext.GPU_DISJOINT_EXT);
-      console.log('quer', available, !disjoint);
-
       return available && !disjoint;
     } else {
       const ext = this.getQueryTimerExtensionWebGL1();

--- a/src/math/backends/webgl/gpgpu_context.ts
+++ b/src/math/backends/webgl/gpgpu_context.ts
@@ -391,6 +391,8 @@ export class GPGPUContext {
           gl2.getQueryParameter(query, gl2.QUERY_RESULT_AVAILABLE);
 
       const disjoint = this.gl.getParameter(ext.GPU_DISJOINT_EXT);
+      console.log('quer', available, !disjoint);
+
       return available && !disjoint;
     } else {
       const ext = this.getQueryTimerExtensionWebGL1();

--- a/src/math/backends/webgl/gpgpu_context.ts
+++ b/src/math/backends/webgl/gpgpu_context.ts
@@ -17,10 +17,12 @@
 
 import {ENV} from '../../../environment';
 import * as util from '../../../util';
+
 import * as gpgpu_util from './gpgpu_util';
 import * as tex_util from './tex_util';
 import * as webgl_util from './webgl_util';
-import {WebGLLoseContextExtension} from './webgl_util';
+// tslint:disable-next-line:max-line-length
+import {WebGL1DisjointQueryTimerExtension, WebGL2DisjointQueryTimerExtension, WebGL2RenderingContext, WebGLLoseContextExtension, WebGLQuery} from './webgl_util';
 
 export class GPGPUContext {
   gl: WebGLRenderingContext;
@@ -28,6 +30,8 @@ export class GPGPUContext {
   colorBufferFloatExtension: {};
   getBufferSubDataAsyncExtension: {};
   loseContextExtension: WebGLLoseContextExtension;
+  disjointQueryTimerExtension: WebGL2DisjointQueryTimerExtension|
+      WebGL1DisjointQueryTimerExtension;
   vertexBuffer: WebGLBuffer;
   indexBuffer: WebGLBuffer;
   framebuffer: WebGLFramebuffer;
@@ -303,103 +307,126 @@ export class GPGPUContext {
     webgl_util.callAndCheck(this.gl, () => this.gl.finish());
   }
 
+  private getQueryTimerExtension(): WebGL1DisjointQueryTimerExtension
+      |WebGL2DisjointQueryTimerExtension {
+    if (this.disjointQueryTimerExtension == null) {
+      this.disjointQueryTimerExtension =
+          webgl_util.getExtensionOrThrow(
+              this.gl,
+              ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') === 2 ?
+                  'EXT_disjoint_timer_query_webgl2' :
+                  'EXT_disjoint_timer_query') as
+              WebGL1DisjointQueryTimerExtension |
+          WebGL2DisjointQueryTimerExtension;
+    }
+    return this.disjointQueryTimerExtension;
+  }
+
+  private getQueryTimerExtensionWebGL2(): WebGL2DisjointQueryTimerExtension {
+    return this.getQueryTimerExtension();
+  }
+
+  private getQueryTimerExtensionWebGL1(): WebGL1DisjointQueryTimerExtension {
+    return this.getQueryTimerExtension() as WebGL1DisjointQueryTimerExtension;
+  }
+
   /**
    * Executes a query function which contains GL commands and resolves when
    * the command buffer has finished executing the query.
    * @param queryFn The query function containing GL commands to execute.
-   * @return a promise that resolves with the ellapsed time in milliseconds.
+   * @return a promise that resolves with the ellapsed GPU time in milliseconds.
    */
   public runQuery(queryFn: () => void): Promise<number> {
-    if (ENV.get('WEBGL_VERSION') === 2) {
-      return this.runQueryWebGL2(queryFn);
+    const query = this.beginQuery();
+
+    queryFn();
+
+    this.endQuery();
+
+    return this.pollQueryTime(query);
+  }
+
+  beginQuery(): WebGLQuery {
+    if (ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') === 2) {
+      const gl2 = this.gl as WebGL2RenderingContext;
+      const ext = this.getQueryTimerExtensionWebGL2();
+
+      const query = gl2.createQuery();
+      gl2.beginQuery(ext.TIME_ELAPSED_EXT, query);
+
+      return query;
+    } else {
+      const ext = this.getQueryTimerExtensionWebGL1();
+      const query = ext.createQueryEXT();
+
+      ext.beginQueryEXT(ext.TIME_ELAPSED_EXT, query);
+
+      return query;
     }
-    return this.runQueryWebGL1(queryFn);
   }
 
-  private runQueryWebGL2(benchmark: () => void): Promise<number> {
-    const ext = webgl_util.getExtensionOrThrow(
-        this.gl, 'EXT_disjoint_timer_query_webgl2');
-    // tslint:disable-next-line:no-any
-    const query = (this.gl as any).createQuery();
+  endQuery() {
+    if (ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') === 2) {
+      const gl2 = this.gl as WebGL2RenderingContext;
+      const ext = this.getQueryTimerExtensionWebGL2();
 
-    // tslint:disable-next-line:no-any
-    (this.gl as any).beginQuery((ext as any).TIME_ELAPSED_EXT, query);
+      gl2.endQuery(ext.TIME_ELAPSED_EXT);
+    } else {
+      const ext = this.getQueryTimerExtensionWebGL1();
+      ext.endQueryEXT(ext.TIME_ELAPSED_EXT);
+    }
+  }
 
-    benchmark();
+  isQueryAvailable(query: WebGLQuery): boolean {
+    if (ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') === 2) {
+      const gl2 = this.gl as WebGL2RenderingContext;
+      const ext = this.getQueryTimerExtensionWebGL2();
 
-    // tslint:disable-next-line:no-any
-    (this.gl as any).endQuery((ext as any).TIME_ELAPSED_EXT);
+      const available =
+          gl2.getQueryParameter(query, gl2.QUERY_RESULT_AVAILABLE);
 
+      const disjoint = this.gl.getParameter(ext.GPU_DISJOINT_EXT);
+      return available && !disjoint;
+    } else {
+      const ext = this.getQueryTimerExtensionWebGL1();
+
+      const available =
+          ext.getQueryObjectEXT(query, ext.QUERY_RESULT_AVAILABLE_EXT);
+
+      const disjoint = this.gl.getParameter(ext.GPU_DISJOINT_EXT);
+
+      return available && !disjoint;
+    }
+  }
+
+  pollQueryTime(query: WebGLQuery): Promise<number> {
     return new Promise<number>((resolve, reject) => {
-      const queryGPU = () => {
-        const available =
-            // tslint:disable-next-line:no-any
-            (this.gl as any)
-                .getQueryParameter(
-                    // tslint:disable-next-line:no-any
-                    query, (this.gl as any).QUERY_RESULT_AVAILABLE);
-
-        const disjoint =
-            // tslint:disable-next-line:no-any
-            this.gl.getParameter((ext as any).GPU_DISJOINT_EXT);
-        return available && !disjoint;
-      };
-
-      const getTimeElapsed = () => {
-        const timeElapsedNanos =
-            // tslint:disable-next-line:no-any
-            (this.gl as any)
-                // tslint:disable-next-line:no-any
-                .getQueryParameter(query, (this.gl as any).QUERY_RESULT);
-        // Return milliseconds.
-        resolve(timeElapsedNanos / 1000000);
-      };
-
       const resolveWithWarning = () => {
         console.warn('Disjoint query timer never available.');
         resolve(-1);
       };
 
-      util.repeatedTry(queryGPU).then(getTimeElapsed).catch(resolveWithWarning);
+      util.repeatedTry(() => this.isQueryAvailable(query))
+          .then(() => resolve(this.getQueryTime(query)))
+          .catch(resolveWithWarning);
     });
   }
 
-  private runQueryWebGL1(benchmark: () => void): Promise<number> {
-    const ext = webgl_util.getExtensionOrThrow(
-                    // tslint:disable-next-line:no-any
-                    this.gl, 'EXT_disjoint_timer_query') as any;
-    const query = ext.createQueryEXT();
+  private getQueryTime(query: WebGLQuery): number {
+    if (ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') === 2) {
+      const gl2 = this.gl as WebGL2RenderingContext;
 
-    ext.beginQueryEXT(ext.TIME_ELAPSED_EXT, query);
+      const timeElapsedNanos = gl2.getQueryParameter(query, gl2.QUERY_RESULT);
+      // Return milliseconds.
+      return timeElapsedNanos / 1000000;
+    } else {
+      const ext = this.getQueryTimerExtensionWebGL1();
 
-    benchmark();
-
-    ext.endQueryEXT(ext.TIME_ELAPSED_EXT);
-
-    return new Promise<number>((resolve, reject) => {
-      const queryGPU = () => {
-        const available =
-            ext.getQueryObjectEXT(query, ext.QUERY_RESULT_AVAILABLE_EXT);
-
-        const disjoint = this.gl.getParameter(ext.GPU_DISJOINT_EXT);
-
-        return available && !disjoint;
-      };
-
-      const getTimeElapsed = () => {
-        const timeElapsedNanos =
-            ext.getQueryObjectEXT(query, ext.QUERY_RESULT_EXT);
-        // Return milliseconds.
-        resolve(timeElapsedNanos / 1000000);
-      };
-
-      const resolveWithWarning = () => {
-        console.warn('Disjoint query timer never available.');
-        resolve(-1);
-      };
-
-      util.repeatedTry(queryGPU).then(getTimeElapsed).catch(resolveWithWarning);
-    });
+      const timeElapsedNanos =
+          ext.getQueryObjectEXT(query, ext.QUERY_RESULT_EXT);
+      // Return milliseconds.
+      return timeElapsedNanos / 1000000;
+    }
   }
 
   private downloadMatrixDriverSetup(texture: WebGLTexture) {

--- a/src/math/backends/webgl/gpgpu_context.ts
+++ b/src/math/backends/webgl/gpgpu_context.ts
@@ -377,8 +377,13 @@ export class GPGPUContext {
     }
   }
 
-  isQueryAvailable(query: WebGLQuery): boolean {
-    if (ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') === 2) {
+  private isQueryAvailable(query: WebGLQuery, queryTimerVersion: number):
+      boolean {
+    if (queryTimerVersion === 0) {
+      return true;
+    }
+
+    if (queryTimerVersion === 2) {
       const gl2 = this.gl as WebGL2RenderingContext;
       const ext = this.getQueryTimerExtensionWebGL2();
 
@@ -406,14 +411,20 @@ export class GPGPUContext {
         resolve(-1);
       };
 
-      util.repeatedTry(() => this.isQueryAvailable(query))
-          .then(() => resolve(this.getQueryTime(query)))
+      const queryTimerVersion =
+          ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION');
+      util.repeatedTry(() => this.isQueryAvailable(query, queryTimerVersion))
+          .then(() => resolve(this.getQueryTime(query, queryTimerVersion)))
           .catch(resolveWithWarning);
     });
   }
 
-  private getQueryTime(query: WebGLQuery): number {
-    if (ENV.get('WEBGL_DISJOINT_QUERY_TIMER_EXTENSION_VERSION') === 2) {
+  private getQueryTime(query: WebGLQuery, queryTimerVersion: number): number {
+    if (queryTimerVersion === 0) {
+      return null;
+    }
+
+    if (queryTimerVersion === 2) {
       const gl2 = this.gl as WebGL2RenderingContext;
 
       const timeElapsedNanos = gl2.getQueryParameter(query, gl2.QUERY_RESULT);

--- a/src/math/backends/webgl/webgl_types.ts
+++ b/src/math/backends/webgl/webgl_types.ts
@@ -1,0 +1,42 @@
+export interface WebGLQuery {}
+
+export interface WebGL2RenderingContext extends WebGLRenderingContext {
+  QUERY_RESULT: number;
+  QUERY_RESULT_AVAILABLE: number;
+  createQuery: () => WebGLQuery;
+  beginQuery: (ext: number, query: WebGLQuery) => void;
+  endQuery: (ext: number) => void;
+  getQueryParameter: (query: WebGLQuery, queryResult: number) => number;
+}
+
+// TODO(nsthorat): Move these to the webgl official typings.
+export interface WebGL2DisjointQueryTimerExtension {
+  TIME_ELAPSED_EXT: number;
+  GPU_DISJOINT_EXT: number;
+}
+
+export interface WebGL1DisjointQueryTimerExtension {
+  TIME_ELAPSED_EXT: number;
+  QUERY_RESULT_AVAILABLE_EXT: number;
+  GPU_DISJOINT_EXT: number;
+  QUERY_RESULT_EXT: number;
+  createQueryEXT: () => {};
+  beginQueryEXT: (ext: number, query: WebGLQuery) => void;
+  endQueryEXT: (ext: number) => void;
+  deleteQueryEXT: (query: WebGLQuery) => void;
+  isQueryEXT: (query: WebGLQuery) => boolean;
+  getQueryObjectEXT:
+      (query: WebGLQuery, queryResultAvailableExt: number) => number;
+}
+
+export interface WebGLContextAttributes {
+  alpha?: boolean;
+  antialias?: boolean;
+  premultipliedAlpha?: boolean;
+  preserveDrawingBuffer?: boolean;
+  depth?: boolean;
+  stencil?: boolean;
+  failIfMajorPerformanceCaveat?: boolean;
+}
+
+export interface WebGLLoseContextExtension { loseContext(): void; }

--- a/src/math/backends/webgl/webgl_util.ts
+++ b/src/math/backends/webgl/webgl_util.ts
@@ -20,6 +20,37 @@ let MAX_TEXTURE_SIZE: number = null;
 import * as util from '../../../util';
 import {ENV} from '../../../environment';
 
+export interface WebGLQuery {}
+
+export interface WebGL2RenderingContext extends WebGLRenderingContext {
+  QUERY_RESULT: number;
+  QUERY_RESULT_AVAILABLE: number;
+  createQuery: () => WebGLQuery;
+  beginQuery: (ext: number, query: WebGLQuery) => void;
+  endQuery: (ext: number) => void;
+  getQueryParameter: (query: WebGLQuery, queryResult: number) => number;
+}
+
+// TODO(nsthorat): Move these to the webgl official typings.
+export interface WebGL2DisjointQueryTimerExtension {
+  TIME_ELAPSED_EXT: number;
+  GPU_DISJOINT_EXT: number;
+}
+
+export interface WebGL1DisjointQueryTimerExtension {
+  TIME_ELAPSED_EXT: number;
+  QUERY_RESULT_AVAILABLE_EXT: number;
+  GPU_DISJOINT_EXT: number;
+  QUERY_RESULT_EXT: number;
+  createQueryEXT: () => {};
+  beginQueryEXT: (ext: number, query: WebGLQuery) => void;
+  endQueryEXT: (ext: number) => void;
+  deleteQueryEXT: (query: WebGLQuery) => void;
+  isQueryEXT: (query: WebGLQuery) => boolean;
+  getQueryObjectEXT:
+      (query: WebGLQuery, queryResultAvailableExt: number) => number;
+}
+
 export interface WebGLContextAttributes {
   alpha?: boolean;
   antialias?: boolean;

--- a/src/math/backends/webgl/webgl_util.ts
+++ b/src/math/backends/webgl/webgl_util.ts
@@ -20,49 +20,6 @@ let MAX_TEXTURE_SIZE: number = null;
 import * as util from '../../../util';
 import {ENV} from '../../../environment';
 
-export interface WebGLQuery {}
-
-export interface WebGL2RenderingContext extends WebGLRenderingContext {
-  QUERY_RESULT: number;
-  QUERY_RESULT_AVAILABLE: number;
-  createQuery: () => WebGLQuery;
-  beginQuery: (ext: number, query: WebGLQuery) => void;
-  endQuery: (ext: number) => void;
-  getQueryParameter: (query: WebGLQuery, queryResult: number) => number;
-}
-
-// TODO(nsthorat): Move these to the webgl official typings.
-export interface WebGL2DisjointQueryTimerExtension {
-  TIME_ELAPSED_EXT: number;
-  GPU_DISJOINT_EXT: number;
-}
-
-export interface WebGL1DisjointQueryTimerExtension {
-  TIME_ELAPSED_EXT: number;
-  QUERY_RESULT_AVAILABLE_EXT: number;
-  GPU_DISJOINT_EXT: number;
-  QUERY_RESULT_EXT: number;
-  createQueryEXT: () => {};
-  beginQueryEXT: (ext: number, query: WebGLQuery) => void;
-  endQueryEXT: (ext: number) => void;
-  deleteQueryEXT: (query: WebGLQuery) => void;
-  isQueryEXT: (query: WebGLQuery) => boolean;
-  getQueryObjectEXT:
-      (query: WebGLQuery, queryResultAvailableExt: number) => number;
-}
-
-export interface WebGLContextAttributes {
-  alpha?: boolean;
-  antialias?: boolean;
-  premultipliedAlpha?: boolean;
-  preserveDrawingBuffer?: boolean;
-  depth?: boolean;
-  stencil?: boolean;
-  failIfMajorPerformanceCaveat?: boolean;
-}
-
-export interface WebGLLoseContextExtension { loseContext(): void; }
-
 export function createWebGLRenderingContext(attributes: WebGLContextAttributes):
     WebGLRenderingContext {
   const canvas = document.createElement('canvas');

--- a/src/math/debug_mode_test.ts
+++ b/src/math/debug_mode_test.ts
@@ -48,7 +48,7 @@ import {Array1D, Array2D} from './ndarray';
       expect(f).toThrowError();
     });
 
-    it('nikhil A x B', math => {
+    it('A x B', math => {
       const a = Array2D.new([2, 3], [1, 2, 3, 4, 5, 6]);
       const b = Array2D.new([3, 2], [0, 1, -3, 2, 2, 1]);
 

--- a/src/math/debug_mode_test.ts
+++ b/src/math/debug_mode_test.ts
@@ -1,0 +1,89 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import * as test_util from '../test_util';
+import {MathTests} from '../test_util';
+import * as util from '../util';
+
+import {Array1D, Array2D} from './ndarray';
+
+// // debug mode
+{
+  const tests: MathTests = it => {
+    it('debug mode does not error when no nans', math => {
+      const a = Array1D.new([2, -1, 0, 3]);
+      const res = math.relu(a);
+      test_util.expectArraysClose(res, [2, 0, 0, 3]);
+    });
+
+    it('debug mode errors when there are nans, float32', math => {
+      const a = Array1D.new([2, NaN]);
+      const f = () => math.relu(a);
+      expect(f).toThrowError();
+    });
+
+    it('debug mode errors when there are nans, int32', math => {
+      const a = Array1D.new([2, util.NAN_INT32], 'int32');
+      const f = () => math.relu(a);
+      expect(f).toThrowError();
+    });
+
+    it('debug mode errors when there are nans, bool', math => {
+      const a = Array1D.new([1, util.NAN_BOOL], 'bool');
+      const f = () => math.relu(a);
+      expect(f).toThrowError();
+    });
+
+    it('A x B', math => {
+      const a = Array2D.new([2, 3], [1, 2, 3, 4, 5, 6]);
+      const b = Array2D.new([3, 2], [0, 1, -3, 2, 2, 1]);
+
+      const c = math.matMul(a, b);
+
+      expect(c.shape).toEqual([2, 2]);
+      test_util.expectArraysClose(c, [0, 8, -3, 20]);
+    });
+  };
+
+  test_util.describeMathCPU('debug mode', [tests], [{'DEBUG': true}]);
+  test_util.describeMathGPU('debug mode', [tests], [
+    {'DEBUG': true, 'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 1},
+    {'DEBUG': true, 'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2},
+    {'DEBUG': true, 'WEBGL_FLOAT_TEXTURE_ENABLED': false, 'WEBGL_VERSION': 1}
+  ]);
+}
+
+// debug mode off
+{
+  const gpuTests: MathTests = it => {
+    it('no errors where there are nans, and debug mode is disabled', math => {
+      const a = Array1D.new([2, NaN]);
+      const res = math.relu(a);
+      test_util.expectArraysClose(res, [2, NaN]);
+    });
+  };
+
+  test_util.describeMathCPU('debug mode', [gpuTests], [{'DEBUG': false}]);
+  test_util.describeMathGPU('debug mode', [gpuTests], [
+    {'DEBUG': false, 'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 1},
+    {'DEBUG': false, 'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2}, {
+      'DEBUG': false,
+      'WEBGL_FLOAT_TEXTURE_ENABLED': false,
+      'WEBGL_VERSION': 1
+    }
+  ]);
+}

--- a/src/math/debug_mode_test.ts
+++ b/src/math/debug_mode_test.ts
@@ -48,7 +48,7 @@ import {Array1D, Array2D} from './ndarray';
       expect(f).toThrowError();
     });
 
-    it('A x B', math => {
+    it('nikhil A x B', math => {
       const a = Array2D.new([2, 3], [1, 2, 3, 4, 5, 6]);
       const b = Array2D.new([3, 2], [0, 1, -3, 2, 2, 1]);
 
@@ -59,8 +59,8 @@ import {Array1D, Array2D} from './ndarray';
     });
   };
 
-  test_util.describeMathCPU('debug mode', [tests], [{'DEBUG': true}]);
-  test_util.describeMathGPU('debug mode', [tests], [
+  test_util.describeMathCPU('debug mode on', [tests], [{'DEBUG': true}]);
+  test_util.describeMathGPU('debug mode on ', [tests], [
     {'DEBUG': true, 'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 1},
     {'DEBUG': true, 'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2},
     {'DEBUG': true, 'WEBGL_FLOAT_TEXTURE_ENABLED': false, 'WEBGL_VERSION': 1}
@@ -77,8 +77,8 @@ import {Array1D, Array2D} from './ndarray';
     });
   };
 
-  test_util.describeMathCPU('debug mode', [gpuTests], [{'DEBUG': false}]);
-  test_util.describeMathGPU('debug mode', [gpuTests], [
+  test_util.describeMathCPU('debug mode off', [gpuTests], [{'DEBUG': false}]);
+  test_util.describeMathGPU('debug mode off', [gpuTests], [
     {'DEBUG': false, 'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 1},
     {'DEBUG': false, 'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2}, {
       'DEBUG': false,

--- a/src/math/math.ts
+++ b/src/math/math.ts
@@ -210,7 +210,7 @@ export class NDArrayMath implements NDArrayManager {
   // Public since optimizers will use it.
   registeredVariables: NamedVariableMap = {};
 
-  time(f: () => NDArray): Promise<number> {
+  time(f: () => void): Promise<number> {
     return this.backend.time(f);
   }
 

--- a/src/math/math.ts
+++ b/src/math/math.ts
@@ -187,8 +187,8 @@ export class NDArrayMath implements NDArrayManager {
   // Public since optimizers will use it.
   registeredVariables: NamedVariableMap = {};
 
-  time(query: () => NDArray): Promise<number> {
-    return this.backend.time(query);
+  time(f: () => NDArray): Promise<number> {
+    return this.backend.time(f);
   }
 
   getNumArrays() {
@@ -251,7 +251,8 @@ export class NDArrayMath implements NDArrayManager {
    * and checked for NaNs. This significantly impacts performance.
    */
   enableDebugMode() {
-    this.engine.enableDebugMode();
+    ENV.set('DEBUG', true);
+
     console.warn(
         'Debugging mode is ON. The output of every math call will ' +
         'be downloaded to CPU and checked for NaNs. ' +

--- a/src/math/math_test.ts
+++ b/src/math/math_test.ts
@@ -17,7 +17,6 @@
 
 import * as test_util from '../test_util';
 import {MathTests} from '../test_util';
-import * as util from '../util';
 import {MatrixOrientation} from './backends/types/matmul';
 import {Array1D, Array2D, NDArray, Scalar} from './ndarray';
 
@@ -203,52 +202,6 @@ import {Array1D, Array2D, NDArray, Scalar} from './ndarray';
   };
 
   test_util.describeMathGPU('scope', [gpuTests], [
-    {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 1},
-    {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2},
-    {'WEBGL_FLOAT_TEXTURE_ENABLED': false, 'WEBGL_VERSION': 1}
-  ]);
-}
-
-// debug mode
-{
-  const gpuTests: MathTests = it => {
-    it('debug mode does not error when no nans', math => {
-      math.enableDebugMode();
-      const a = Array1D.new([2, -1, 0, 3]);
-      const res = math.relu(a);
-      test_util.expectArraysClose(res, [2, 0, 0, 3]);
-    });
-
-    it('debug mode errors when there are nans, float32', math => {
-      math.enableDebugMode();
-      const a = Array1D.new([2, NaN]);
-      const f = () => math.relu(a);
-      expect(f).toThrowError();
-    });
-
-    it('debug mode errors when there are nans, int32', math => {
-      math.enableDebugMode();
-      const a = Array1D.new([2, util.NAN_INT32], 'int32');
-      const f = () => math.relu(a);
-      expect(f).toThrowError();
-    });
-
-    it('debug mode errors when there are nans, bool', math => {
-      math.enableDebugMode();
-      const a = Array1D.new([1, util.NAN_BOOL], 'bool');
-      const f = () => math.relu(a);
-      expect(f).toThrowError();
-    });
-
-    it('no errors where there are nans, and debug mode is disabled', math => {
-      const a = Array1D.new([2, NaN]);
-      const res = math.relu(a);
-      test_util.expectArraysClose(res, [2, NaN]);
-    });
-  };
-
-  test_util.describeMathCPU('debug mode', [gpuTests]);
-  test_util.describeMathGPU('debug mode', [gpuTests], [
     {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 1},
     {'WEBGL_FLOAT_TEXTURE_ENABLED': true, 'WEBGL_VERSION': 2},
     {'WEBGL_FLOAT_TEXTURE_ENABLED': false, 'WEBGL_VERSION': 1}

--- a/src/math/types.ts
+++ b/src/math/types.ts
@@ -53,6 +53,11 @@ export type RegularArray<T> = T[]|T[][]|T[][][]|T[][][][];
 export type ArrayData<D extends DataType> =
     DataTypeMap[D]|RegularArray<number>|RegularArray<boolean>;
 
+// tslint:disable-next-line:no-any
+export interface RecursiveArray<T extends any> {
+  [index: number]: T|RecursiveArray<T>;
+}
+
 export type NamedArrayMap = {
   [name: string]: NDArray
 };

--- a/src/util.ts
+++ b/src/util.ts
@@ -17,7 +17,8 @@
 
 import {NDArray} from './math/ndarray';
 // tslint:disable-next-line:max-line-length
-import {DataType, DataTypeMap, FlatVector, NamedArrayMap, RegularArray} from './math/types';
+import {DataType, DataTypeMap, FlatVector, NamedArrayMap, RecursiveArray, RegularArray} from './math/types';
+
 
 /** Shuffles the array using Fisher-Yates algorithm. */
 // tslint:disable-next-line:no-any
@@ -79,15 +80,17 @@ export function assertTypesMatch(a: NDArray, b: NDArray): void {
           `second (${b.dtype}) input must match`);
 }
 
-// tslint:disable-next-line:no-any
-export function flatten<T extends number|boolean|NDArray>(
-    arr: T|RegularArray<T>, ret: T[] = []): T[] {
+// NOTE: We explicitly type out what T extends instead of any so that
+// util.flatten on a nested array of number doesn't try to infer T as a
+// number[][], causing us to explicitly type util.flatten<number>().
+export function flatten<T extends number|boolean|NDArray|Promise<number>>(
+    arr: T|RecursiveArray<T>, ret: T[] = []): T[] {
   if (Array.isArray(arr)) {
     for (let i = 0; i < arr.length; ++i) {
       flatten(arr[i], ret);
     }
   } else {
-    ret.push(arr);
+    ret.push(arr as T);
   }
   return ret;
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -19,7 +19,6 @@ import {NDArray} from './math/ndarray';
 // tslint:disable-next-line:max-line-length
 import {DataType, DataTypeMap, FlatVector, NamedArrayMap, RecursiveArray, RegularArray} from './math/types';
 
-
 /** Shuffles the array using Fisher-Yates algorithm. */
 // tslint:disable-next-line:no-any
 export function shuffle(array: any[]|Uint32Array|Int32Array|


### PR DESCRIPTION
This PR:

* Adds an environment flag for debug mode under 'DEBUG'. Users can flip debug mode on via the URL now, with &dljsflags=DEBUG:true
* Uses proper GPU timing for kernels in debug mode.
* Converts the WebGL disjoint query timer enabled flag to a version, decoupling it from WebGL version. In firefox, the WebGL version will be 2.0, but the query timer only works with the WebGL 1.0 API. This flag is separately feature tested.
* Adds a "Profiler" and "Logger" class. These are separated so that Profiler will simply build a datastructure of nodes and their execution profiles, and logger will render it. This will allow us to build visual loggers (HTML) that simply render the data structure provided by the profiler. This will come in another PR.
* Simplifies the gpgpu_context timing code, and tries to use typings wherever possible. I wrote simple typings for the interfaces we use. Using WebGL proper typings from @typings via npm adds 3 seconds to build time (currently 7s, would be 10s).
* Simplifies WebGL backend timing. When timers are used, all programs are independently timed and we keep a tree datastructure that we flatten and sum.

Note: sometimes, kernels may call other kernels (for example, the webgl backend calls other kernels in reduction ops), in this cases, we ignore inner kernels and simply time the outer kernel.

This PR does *not* yet log aggregations of kernel times into scopes, this will be a follow up.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/596)
<!-- Reviewable:end -->
