### PR TITLE
Fix small bug in mnist_eager demo

### DIFF
--- a/demos/mnist_eager/model.ts
+++ b/demos/mnist_eager/model.ts
@@ -25,9 +25,8 @@ const loss = (labels: dl.Tensor2D, ys: dl.Tensor2D) =>
 export async function train(data: MnistData, log: (message: string) => void) {
   const returnCost = true;
   for (let i = 0; i < TRAIN_STEPS; i++) {
+    const batch = data.nextTrainBatch(BATCH_SIZE);
     const cost = optimizer.minimize(() => {
-      const batch = data.nextTrainBatch(BATCH_SIZE);
-
       return loss(batch.labels, model(batch.xs));
     }, returnCost);
 


### PR DESCRIPTION
I think each iteration of the training loop should obtain one batch and then optimize over that, where currently the optimizer repeatedly sees new batches within its minimize() loop.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/699)
<!-- Reviewable:end -->
