### PR TITLE
Link symbols in the doc generator.

### DIFF
--- a/src/gradients.ts
+++ b/src/gradients.ts
@@ -88,8 +88,8 @@ export class Gradients {
    * Like `dl.grad`, but returns also the value of `f()`. Useful when `f()`
    * returns a metric you want to show. The result is a rich object with
    * the following properties:
-   * - `grad`: The gradient of `f(x)` w.r.t `x` (result of `grad`).
-   * - `value`: The value returned by `f(x)`.
+   * - grad: The gradient of `f(x)` w.r.t `x` (result of `grad`).
+   * - value: The value returned by `f(x)`.
    */
   @doc({heading: 'Training', subheading: 'Gradients'})
   static valueAndGrad<I extends Tensor, O extends Tensor>(f: (x: I) => O):
@@ -108,8 +108,8 @@ export class Gradients {
    * Like `grads`, but returns also the value of `f()`. Useful when `f()`
    * returns a metric you want to show. The result is a rich object with
    * the following properties:
-   * - `grads`: The gradients of `f()` w.r.t each input (result of `grads`).
-   * - `value`: The value returned by `f(x)`.
+   * - grads: The gradients of `f()` w.r.t each input (result of `grads`).
+   * - value: The value returned by `f(x)`.
    */
   @doc({heading: 'Training', subheading: 'Gradients'})
   static valueAndGrads<O extends Tensor>(f: (...args: Tensor[]) => O):

--- a/src/gradients.ts
+++ b/src/gradients.ts
@@ -47,7 +47,7 @@ export class Gradients {
    * which when called gives `df/dx`. If `dy` is provided, the gradient of
    * `f(x).mul(dy).sum()` w.r.t. `x` is computed instead.
    *
-   * If `f()` takes multiple inputs, use `dl.grads` instead.
+   * If `f()` takes multiple inputs, use `grads` instead.
    *
    * @param f The function f(x), to compute gradient for.
    */
@@ -69,7 +69,7 @@ export class Gradients {
    * If `dy` is provided, the gradient of `f(x).mul(dy).sum()` w.r.t. each input
    * is computed instead.
    *
-   * If `f()` takes a single input, use `dl.grad` instead.
+   * If `f()` takes a single input, use `grad` instead.
    *
    * @param f The function `f(x1, x2,...)` to compute gradients for.
    */
@@ -88,7 +88,7 @@ export class Gradients {
    * Like `dl.grad`, but returns also the value of `f()`. Useful when `f()`
    * returns a metric you want to show. The result is a rich object with
    * the following properties:
-   * - `grad`: The gradient of `f(x)` w.r.t `x` (result of `dl.grad`).
+   * - `grad`: The gradient of `f(x)` w.r.t `x` (result of `grad`).
    * - `value`: The value returned by `f(x)`.
    */
   @doc({heading: 'Training', subheading: 'Gradients'})
@@ -105,10 +105,10 @@ export class Gradients {
   }
 
   /**
-   * Like `dl.grads`, but returns also the value of `f()`. Useful when `f()`
+   * Like `grads`, but returns also the value of `f()`. Useful when `f()`
    * returns a metric you want to show. The result is a rich object with
    * the following properties:
-   * - `grads`: The gradients of `f()` w.r.t each input (result of `dl.grads`).
+   * - `grads`: The gradients of `f()` w.r.t each input (result of `grads`).
    * - `value`: The value returned by `f(x)`.
    */
   @doc({heading: 'Training', subheading: 'Gradients'})
@@ -130,7 +130,7 @@ export class Gradients {
    * defaults to all trainable variables.
    * @param f The function to execute. f() should return a scalar.
    * @param varList An optional list of variables to provide gradients with
-   * respect to. Defaults to all trainable variables.
+   *     respect to. Defaults to all trainable variables.
    */
   @doc({heading: 'Training', subheading: 'Gradients'})
   static variableGrads(f: () => Scalar, varList?: Variable[]):
@@ -169,8 +169,8 @@ export class Gradients {
    * using `f().gradFunc`.
    *
    * @param f The function to evaluate in forward mode, which should return
-   * `{value: Tensor, gradFunc: (dy) => Tensor[]}`, where gradFunc returns the
-   * custom gradients of `f` w.r.t. its inputs.
+   *     `{value: Tensor, gradFunc: (dy) => Tensor[]}`, where `gradFunc` returns
+   *     the custom gradients of `f` w.r.t. its inputs.
    */
   @doc({heading: 'Training', subheading: 'Gradients'})
   static customGrad<T extends Tensor>(f: CustomGradientFunc<T>):

--- a/src/ops/array_ops.ts
+++ b/src/ops/array_ops.ts
@@ -255,8 +255,8 @@ export class Ops {
    * Creates a tensor filled with a scalar value.
    * @param shape An array of integers defining the output tensor shape.
    * @param value The scalar value to fill the tensor with.
-   * @param dtype The type of an element in the resulting tensor. Can
-   *     be 'float32', 'int32' or 'bool'. Defaults to 'float'.
+   * @param dtype The type of an element in the resulting tensor. Defaults to
+   * 'float'.
    */
   @doc({heading: 'Tensors', subheading: 'Creation'})
   @operation
@@ -638,13 +638,10 @@ export class Ops {
   /**
    * Return an evenly spaced sequence of numbers over the given interval.
    *
-   * The stop value can be optionally excluded by passing setting [endpoint] to
-   * true.
-   *
    * @param start The start value of the sequence
    * @param stop The end value of the sequence
    * @param num The number of values to generate
-   * @param endpoint Optional, determines whether stop is included in the
+   * @param endpoint Determines whether stop is included in the
    * sequence. Defaults to true.
    */
   @operation
@@ -674,8 +671,8 @@ export class Ops {
    *
    * @param start An integer start value
    * @param stop An integer stop value
-   * @param step An optional integer increment (will default to 1 or -1)
-   * @param dtype An optional dtype
+   * @param step An integer increment (will default to 1 or -1)
+   * @param dtype
    */
   @operation
   @doc({heading: 'Tensors', subheading: 'Creation'})

--- a/src/ops/array_ops.ts
+++ b/src/ops/array_ops.ts
@@ -74,7 +74,7 @@ export class Ops {
   }
 
   /**
-   * Creates rank-0 tensor (scalar) with the provided value and dtype.
+   * Creates rank-0 `Tensor` (scalar) with the provided value and dtype.
    *
    * This method is mainly for self documentation and TypeScript typings as the
    * same functionality can be achieved with `tensor`. In general, we recommend
@@ -98,7 +98,7 @@ export class Ops {
   }
 
   /**
-   * Creates rank-1 tensor with the provided values, shape and dtype.
+   * Creates rank-1 `Tensor` with the provided values, shape and dtype.
    *
    * This method is mainly for self documentation and TypeScript typings as the
    * same functionality can be achieved with `tensor`. In general, we recommend
@@ -123,7 +123,7 @@ export class Ops {
   }
 
   /**
-   * Creates rank-2 tensor with the provided values, shape and dtype.
+   * Creates rank-2 `Tensor` with the provided values, shape and dtype.
    *
    * This method is mainly for self documentation and TypeScript typings as the
    * same functionality can be achieved with `tensor`. In general, we recommend
@@ -137,10 +137,11 @@ export class Ops {
    * // Pass a flat array and specify a shape.
    * dl.tensor2d([1, 2, 3, 4], [2, 2]).print();
    * ```
+   *
    * @param values The values of the tensor. Can be nested array of numbers,
    *     or a flat array, or a `TypedArray`.
-   * @param shape The shape of the tensor. Optional. If not provided,
-   *   it is inferred from `values`.
+   * @param shape The shape of the tensor. If not provided, it is inferred from
+   *     `values`.
    * @param dtype The data type.
    */
   @doc({heading: 'Tensors', subheading: 'Creation'})
@@ -158,7 +159,7 @@ export class Ops {
   }
 
   /**
-   * Creates rank-3 tensor with the provided values, shape and dtype.
+   * Creates rank-3 `Tensor` with the provided values, shape and dtype.
    *
    * This method is mainly for self documentation and TypeScript typings as
    * the same functionality can be achieved with `tensor`. In general, we
@@ -172,10 +173,11 @@ export class Ops {
    * // Pass a flat array and specify a shape.
    * dl.tensor3d([1, 2, 3, 4], [2, 2, 1]).print();
    * ```
+   *
    * @param values The values of the tensor. Can be nested array of numbers,
    *     or a flat array, or a `TypedArray`.
-   * @param shape The shape of the tensor. Optional. If not provided,
-   *   it is inferred from `values`.
+   * @param shape The shape of the tensor. If not provided,  it is inferred from
+   *     `values`.
    * @param dtype The data type.
    */
   @doc({heading: 'Tensors', subheading: 'Creation'})
@@ -193,7 +195,7 @@ export class Ops {
   }
 
   /**
-   * Creates rank-4 tensor with the provided values, shape and dtype.
+   * Creates rank-4 `Tensor` with the provided values, shape and dtype.
    *  ```js
    * // Pass a nested array.
    * dl.tensor4d([[[[1], [2]], [[3], [4]]]]).print();
@@ -202,6 +204,7 @@ export class Ops {
    * // Pass a flat array and specify a shape.
    * dl.tensor4d([1, 2, 3, 4], [1, 2, 2, 1]).print();
    * ```
+   *
    * @param values The values of the tensor. Can be nested array of numbers,
    *     or a flat array, or a `TypedArray`.
    * @param shape The shape of the tensor. Optional. If not provided,
@@ -223,7 +226,7 @@ export class Ops {
   }
 
   /**
-   * Creates a tensor with all elements set to 1.
+   * Creates a `Tensor` with all elements set to 1.
    *
    * @param shape An array of integers defining the output tensor shape.
    * @param dtype The type of an element in the resulting tensor. Defaults to
@@ -238,7 +241,7 @@ export class Ops {
   }
 
   /**
-   * Creates a tensor with all elements set to 0.
+   * Creates a `Tensor` with all elements set to 0.
    * @param shape An array of integers defining the output tensor shape.
    * @param dtype The type of an element in the resulting tensor. Can
    *     be 'float32', 'int32' or 'bool'. Defaults to 'float'.
@@ -252,7 +255,8 @@ export class Ops {
   }
 
   /**
-   * Creates a tensor filled with a scalar value.
+   * Creates a `Tensor` filled with a scalar value.
+   *
    * @param shape An array of integers defining the output tensor shape.
    * @param value The scalar value to fill the tensor with.
    * @param dtype The type of an element in the resulting tensor. Defaults to
@@ -270,7 +274,7 @@ export class Ops {
   }
 
   /**
-   * Creates a tensor with all elements set to 1 with the same shape as the
+   * Creates a `Tensor` with all elements set to 1 with the same shape as the
    * given tensor.
    * @param x A tensor.
    */
@@ -281,8 +285,9 @@ export class Ops {
   }
 
   /**
-   * Creates a tensor with all elements set to 0 with the same shape as the
+   * Creates a `Tensor` with all elements set to 0 with the same shape as the
    * given tensor.
+   *
    * @param x A tensor.
    */
   @doc({heading: 'Tensors', subheading: 'Creation'})
@@ -303,7 +308,8 @@ export class Ops {
   }
 
   /**
-   * Creates a tensor with values sampled from a normal distribution.
+   * Creates a `Tensor` with values sampled from a normal distribution.
+   *
    * @param shape An array of integers defining the output tensor shape.
    * @param mean The mean of the normal distribution.
    * @param stdDev The standard deviation of the normal distribution.
@@ -324,7 +330,8 @@ export class Ops {
   }
 
   /**
-   * Creates a tensor with values sampled from a truncated normal distribution.
+   * Creates a `Tensor` with values sampled from a truncated normal
+   * distribution.
    *
    * The generated values follow a normal distribution with specified mean and
    * standard deviation, except that values whose magnitude is more than 2
@@ -350,7 +357,7 @@ export class Ops {
   }
 
   /**
-   * Creates a tensor with values sampled from a uniform distribution.
+   * Creates a `Tensor` with values sampled from a uniform distribution.
    *
    * The generated values follow a uniform distribution in the range [minval,
    * maxval). The lower bound minval is included in the range, while the upper
@@ -372,7 +379,7 @@ export class Ops {
   }
 
   /**
-   * Creates a tensor with values sampled from a random number generator
+   * Creates a `Tensor` with values sampled from a random number generator
    * function defined by the user.
    *
    * @param shape An array of integers defining the output tensor shape.
@@ -404,7 +411,7 @@ export class Ops {
   }
 
   /**
-   * Draws samples from a multinomial distribution.
+   * Creates a `Tensor` with values drawn from a multinomial distribution.
    *
    * @param probabilities 1D array with normalized outcome probabilities, or
    *     2D array of shape `[batchSize, numOutcomes]`.
@@ -445,7 +452,7 @@ export class Ops {
   }
 
   /**
-   * Creates a one-hot tensor. The locations represented by `indices` take
+   * Creates a one-hot `Tensor`. The locations represented by `indices` take
    * value `onValue` (defaults to 1), while all other locations take value
    * `offValue` (defaults to 0).
    *
@@ -468,7 +475,7 @@ export class Ops {
   }
 
   /**
-   * Creates a tensor from an image.
+   * Creates a `Tensor` from an image.
    *
    * @param pixels The input image to construct the tensor from. Accepts image
    * of type `ImageData`, `HTMLImageElement`, `HTMLCanvasElement`, or
@@ -490,7 +497,7 @@ export class Ops {
   }
 
   /**
-   * Reshapes a tensor to a given shape.
+   * Reshapes a `Tensor` to a given shape.
    *
    * Given a input tensor, returns a new tensor with the same values as the
    * input tensor with shape `shape`.
@@ -504,6 +511,7 @@ export class Ops {
    * shape filled with the values of tensor. In this case, the number of
    * elements implied by shape must be the same as the number of elements in
    * tensor.
+   *
    * @param x A tensor.
    * @param shape An array of integers defining the output tensor shape.
    */
@@ -663,7 +671,7 @@ export class Ops {
   }
 
   /**
-   * Creates a new Tensor1D filled with the numbers in the range provided.
+   * Creates a new `Tensor1D` filled with the numbers in the range provided.
    *
    * The tensor is a is half-open interval meaning it includes start, but
    * excludes stop. Decrementing ranges and negative step values are also

--- a/src/ops/array_ops.ts
+++ b/src/ops/array_ops.ts
@@ -226,8 +226,8 @@ export class Ops {
    * Creates a tensor with all elements set to 1.
    *
    * @param shape An array of integers defining the output tensor shape.
-   * @param dtype The type of an element in the resulting tensor. Can
-   *     be 'float32', 'int32' or 'bool'. Defaults to 'float'.
+   * @param dtype The type of an element in the resulting tensor. Defaults to
+   *     'float'.
    */
   @doc({heading: 'Tensors', subheading: 'Creation'})
   @operation

--- a/src/ops/batchnorm.ts
+++ b/src/ops/batchnorm.ts
@@ -35,7 +35,6 @@ export class Ops {
    * @param scale A scale Tensor.
    * @param offset An offset Tensor.
    */
-  @doc({heading: 'Operations', subheading: 'Normalization'})
   @operation
   static batchNormalization2d(
       x: Tensor2D, mean: Tensor2D|Tensor1D, variance: Tensor2D|Tensor1D,
@@ -81,7 +80,6 @@ export class Ops {
    * @param scale A scale Tensor.
    * @param offset An offset Tensor.
    */
-  @doc({heading: 'Operations', subheading: 'Normalization'})
   @operation
   static batchNormalization3d(
       x: Tensor3D, mean: Tensor3D|Tensor1D, variance: Tensor3D|Tensor1D,
@@ -127,7 +125,6 @@ export class Ops {
    * @param scale A scale Tensor.
    * @param offset An offset Tensor.
    */
-  @doc({heading: 'Operations', subheading: 'Normalization'})
   @operation
   static batchNormalization4d(
       x: Tensor4D, mean: Tensor4D|Tensor1D, variance: Tensor4D|Tensor1D,

--- a/src/ops/batchnorm.ts
+++ b/src/ops/batchnorm.ts
@@ -168,7 +168,7 @@ export class Ops {
    * shapes:
    *   - The same shape as the input.
    *   - In the common case, the depth dimension is the last dimension of x, so
-   *     the values would be an Tensor1D of shape [depth].
+   *     the values would be an `Tensor1D` of shape [depth].
    *
    * @param x The input Tensor.
    * @param mean A mean Tensor.

--- a/src/ops/binary_ops.ts
+++ b/src/ops/binary_ops.ts
@@ -26,7 +26,7 @@ import {scalar} from './ops';
 
 export class Ops {
   /**
-   * Adds two Tensors element-wise, A + B. Supports broadcasting.
+   * Adds two `Tensor`s element-wise, A + B. Supports broadcasting.
    *
    * We also expose `addStrict` which has the same signature as this op and
    * asserts that `a` and `b` are the same shape (does not broadcast).
@@ -63,7 +63,7 @@ export class Ops {
   }
 
   /**
-   * Adds two Tensors element-wise, A + B.
+   * Adds two `Tensor`s element-wise, A + B.
    *
    * Inputs must be the same shape. For broadcasting support, use add() instead.
    *
@@ -77,7 +77,7 @@ export class Ops {
   }
 
   /**
-   * Subtracts two Tensors element-wise, A - B. Supports broadcasting.
+   * Subtracts two `Tensor`s element-wise, A - B. Supports broadcasting.
    *
    * We also expose `subStrict` which has the same signature as this op and
    * asserts that `a` and `b` are the same shape (does not broadcast).
@@ -115,7 +115,7 @@ export class Ops {
   }
 
   /**
-   * Subtracts two Tensors element-wise, A - B. Inputs must
+   * Subtracts two `Tensor`s element-wise, A - B. Inputs must
    * be the same shape.
    *
    * For broadcasting support, use sub() instead.
@@ -130,15 +130,15 @@ export class Ops {
   }
 
   /**
-   * Computes the power of one value to another. Supports broadcasting.
-   * Given a tensor x and a tensor y, this operation computes x^y for
+   * Computes the power of one `Tensor` to another. Supports broadcasting.
+   *
+   * Given a `Tensor` x and a `Tensor` y, this operation computes x^y for
    * corresponding elements in x and y.
    *
-   * For example:
    * ```js
    * const a = dl.tensor([[2, 2], [3, 3]])
    * const b = dl.tensor([[8, 16], [2, 3]])
-   * const y = dl.pow(a, b);  // [256, 65536, 9, 27]
+   * dl.pow(a, b).print();  // [256, 65536, 9, 27]
    * ```
    *
    * We also expose `powStrict` which has the same signature as this op and
@@ -176,13 +176,13 @@ export class Ops {
   }
 
   /**
-   * Computes the power of one value to another. Inputs must
+   * Computes the power of one `Tensor` to another. Inputs must
    * be the same shape.
    *
    * For broadcasting support, use pow() instead.
    *
-   * @param base The base Tensor to pow element-wise.
-   * @param exp The exponent Tensor to pow element-wise.
+   * @param base The base tensor to pow element-wise.
+   * @param exp The exponent tensor to pow element-wise.
    */
   @operation
   static powStrict<T extends Tensor>(base: T, exp: Tensor): T {
@@ -191,13 +191,13 @@ export class Ops {
   }
 
   /**
-   * Multiplies two Tensors element-wise, A * B. Supports broadcasting.
+   * Multiplies two `Tensor`s element-wise, A * B. Supports broadcasting.
    *
    * We also expose `mulStrict` which has the same signature as this op and
    * asserts that `a` and `b` are the same shape (does not broadcast).
    *
-   * @param a The first `Tensor`.
-   * @param b The second `Tensor`. Must have the same dtype as `a`.
+   * @param a The first tensor.
+   * @param b The second tensor. Must have the same dtype as `a`.
    */
   @doc({heading: 'Operations', subheading: 'Arithmetic'})
   @operation
@@ -229,12 +229,12 @@ export class Ops {
   }
 
   /**
-   * Multiplies two Tensors element-wise, A * B.
+   * Multiplies two `Tensor`s element-wise, A * B.
    *
    * Inputs must be the same shape. For broadcasting support, use mul().
    *
-   * @param a The first `Tensor`.
-   * @param b The second `Tensor`. Must have the same dtype as `a`.
+   * @param a The first tensor.
+   * @param b The second tensor. Must have the same dtype as `a`.
    */
   @operation
   static mulStrict<T extends Tensor>(a: T, b: T): T {
@@ -243,13 +243,13 @@ export class Ops {
   }
 
   /**
-   * Divides two Tensors element-wise, A / B. Supports broadcasting.
+   * Divides two `Tensor`s element-wise, A / B. Supports broadcasting.
    *
    * We also expose `divStrict` which has the same signature as this op and
    * asserts that `a` and `b` are the same shape (does not broadcast).
    *
-   * @param a The first `Tensor`.
-   * @param b The second `Tensor`. Must have the same dtype as `a`.
+   * @param a The first tensor.
+   * @param b The second tensor. Must have the same dtype as `a`.
    */
   @doc({heading: 'Operations', subheading: 'Arithmetic'})
   @operation
@@ -280,11 +280,11 @@ export class Ops {
   }
 
   /**
-   * Divides two Tensors element-wise, A / B. Inputs must
+   * Divides two `Tensor`s element-wise, A / B. Inputs must
    * be the same shape.
    *
-   * @param a The first Tensor to multiply element-wise.
-   * @param b The second Tensor to multiply element-wise.
+   * @param a The first tensor to multiply element-wise.
+   * @param b The second tensor to multiply element-wise.
    */
   @operation
   static divStrict<T extends Tensor>(a: T, b: T): T {
@@ -319,8 +319,8 @@ export class Ops {
    * Returns the min of a and b (`a < b ? a : b`) element-wise. Inputs must
    * be the same shape. For broadcasting support, use minimum().
    *
-   * @param a The first `Tensor`.
-   * @param b The second `Tensor`. Must have the same dtype as `a`.
+   * @param a The first tensor.
+   * @param b The second tensor. Must have the same dtype as `a`.
    */
   @operation
   static minimumStrict<T extends Tensor>(a: T, b: T): T {
@@ -356,8 +356,8 @@ export class Ops {
    * Returns the max of a and b (`a > b ? a : b`) element-wise. Inputs must
    * be the same shape. For broadcasting support, use maximum().
    *
-   * @param a The first `Tensor`.
-   * @param b The second `Tensor`. Must have the same dtype as `a`.
+   * @param a The first tensor.
+   * @param b The second tensor.. Must have the same dtype as `a`.
    */
   @operation
   static maximumStrict<T extends Tensor>(a: T, b: T): T {

--- a/src/ops/compare.ts
+++ b/src/ops/compare.ts
@@ -29,8 +29,8 @@ export class Ops {
    * We also expose `notEqualStrict` which has the same signature as this op and
    * asserts that `a` and `b` are the same shape (does not broadcast).
    *
-   * @param a The first input `Tensor`.
-   * @param b The second input `Tensor`. Must have the same dtype as `a`.
+   * @param a The first input tensor.
+   * @param b The second input tensor. Must have the same dtype as `a`.
    */
   @doc({heading: 'Operations', subheading: 'Logical'})
   @operation
@@ -44,8 +44,8 @@ export class Ops {
    * Strict version of `notEqual` that forces `a` and `b` to be of the same
    * shape.
    *
-   * @param a The first input `Tensor`.
-   * @param b The second input `Tensor`. Must have the same shape and dtype as
+   * @param a The first input tensor.
+   * @param b The second input tensor. Must have the same shape and dtype as
    *     `a`.
    */
   @operation
@@ -60,8 +60,8 @@ export class Ops {
    * We also expose `lessStrict` which has the same signature as this op and
    * asserts that `a` and `b` are the same shape (does not broadcast).
    *
-   * @param a The first input `Tensor`.
-   * @param b The second input `Tensor`. Must have the same dtype as `a`.
+   * @param a The first input tensor.
+   * @param b The second input tensor. Must have the same dtype as `a`.
    */
   @doc({heading: 'Operations', subheading: 'Logical'})
   @operation
@@ -75,8 +75,8 @@ export class Ops {
    * Strict version of `less` that forces `a` and `b` to be of the same
    * shape.
    *
-   * @param a The first input `Tensor`.
-   * @param b The second input `Tensor`. Must have the same shape and dtype as
+   * @param a The first input tensor.
+   * @param b The second input tensor. Must have the same shape and dtype as
    *     `a`.
    */
   @operation
@@ -91,8 +91,8 @@ export class Ops {
    * We also expose `equalStrict` which has the same signature as this op
    * and asserts that `a` and `b` are the same shape (does not broadcast).
    *
-   * @param a The first input `Tensor`.
-   * @param b The second input `Tensor`. Must have the same dtype as `a`.
+   * @param a The first input tensor.
+   * @param b The second input tensor. Must have the same dtype as `a`.
    */
   @doc({heading: 'Operations', subheading: 'Logical'})
   @operation
@@ -114,8 +114,8 @@ export class Ops {
    * We also expose `lessEqualStrict` which has the same signature as this op
    * and asserts that `a` and `b` are the same shape (does not broadcast).
    *
-   * @param a The first input `Tensor`.
-   * @param b The second input `Tensor`. Must have the same dtype as `a`.
+   * @param a The first input tensor.
+   * @param b The second input tensor. Must have the same dtype as `a`.
    */
   @doc({heading: 'Operations', subheading: 'Logical'})
   @operation
@@ -137,8 +137,8 @@ export class Ops {
    * We also expose `greaterStrict` which has the same signature as this
    * op and asserts that `a` and `b` are the same shape (does not broadcast).
    *
-   * @param a The first input `Tensor`.
-   * @param b The second input `Tensor`. Must have the same dtype as `a`.
+   * @param a The first input tensor.
+   * @param b The second input tensor. Must have the same dtype as `a`.
    */
   @doc({heading: 'Operations', subheading: 'Logical'})
   @operation
@@ -160,8 +160,8 @@ export class Ops {
    * We also expose `greaterStrict` which has the same signature as this
    * op and asserts that `a` and `b` are the same shape (does not broadcast).
    *
-   * @param a The first input `Tensor`.
-   * @param b The second input `Tensor`. Must have the same dtype as `a`.
+   * @param a The first input tensor.
+   * @param b The second input tensor. Must have the same dtype as `a`.
    */
   @doc({heading: 'Operations', subheading: 'Logical'})
   @operation

--- a/src/ops/conv.ts
+++ b/src/ops/conv.ts
@@ -25,6 +25,7 @@ import {operation} from './operation';
 export class Ops {
   /**
    * Computes a 1D convolution over the input x.
+   *
    * @param input The input tensor, of rank 3 or rank 2, of shape
    *     `[batch, width, inChannels]`. If rank 2, batch of 1 is assumed.
    * @param filter The filter, rank 3, of shape

--- a/src/ops/image_ops.ts
+++ b/src/ops/image_ops.ts
@@ -15,11 +15,11 @@
  * =============================================================================
  */
 
-import {operation} from './operation';
 import {doc} from '../doc';
 import {ENV} from '../environment';
 import {Tensor3D, Tensor4D} from '../tensor';
 import * as util from '../util';
+import {operation} from './operation';
 
 export class Ops {
   /**
@@ -29,10 +29,10 @@ export class Ops {
    *     `[batch, height, width, inChannels]`. If rank 3, batch of 1 is assumed.
    * @param size The new shape `[newHeight, newWidth]` to resize the
    *     images to. Each channel is resized individually.
-   * @param alignCorners An optional bool. Defaults to False. If true, rescale
-   *     input by (new_height - 1) / (height - 1), which exactly aligns the 4
+   * @param alignCorners Defaults to False. If true, rescale
+   *     input by `(new_height - 1) / (height - 1)`, which exactly aligns the 4
    *     corners of images and resized images. If false, rescale by
-   *     new_height/height. Treat similarly the width dimension.
+   *     `new_height / height`. Treat similarly the width dimension.
    */
   @doc({heading: 'Operations', subheading: 'Images', namespace: 'image'})
   @operation

--- a/src/ops/logical_ops.ts
+++ b/src/ops/logical_ops.ts
@@ -15,7 +15,6 @@
  * =============================================================================
  */
 
-import {operation} from './operation';
 import {doc} from '../doc';
 import {ENV} from '../environment';
 import {Tensor} from '../tensor';
@@ -23,12 +22,13 @@ import * as types from '../types';
 import {DataType} from '../types';
 import * as util from '../util';
 import * as broadcast_util from './broadcast_util';
+import {operation} from './operation';
 
 export class Ops {
   /**
-   * Returns the truth value of NOT element-wise.
+   * Returns the truth value of `NOT x` element-wise.
    *
-   * @param x The input Tensor.
+   * @param x The input tensor. Must be of dtype 'bool'.
    */
   @doc({heading: 'Operations', subheading: 'Logical'})
   @operation
@@ -40,8 +40,8 @@ export class Ops {
   /**
    * Returns the truth value of a AND b element-wise. Supports broadcasting.
    *
-   * @param a The first input `Tensor`. Must be of dtype bool.
-   * @param b The second input `Tensor`. Must be of dtype bool.
+   * @param a The first input tensor. Must be of dtype bool.
+   * @param b The second input tensor. Must be of dtype bool.
    */
   @doc({heading: 'Operations', subheading: 'Logical'})
   @operation
@@ -54,10 +54,10 @@ export class Ops {
   }
 
   /**
-   * Returns the truth value of a OR b element-wise. Supports broadcasting.
+   * Returns the truth value of `a OR b` element-wise. Supports broadcasting.
    *
-   * @param a The first input `Tensor`. Must be of dtype bool.
-   * @param b The second input `Tensor`. Must be of dtype bool.
+   * @param a The first input tensor. Must be of dtype bool.
+   * @param b The second input tensor. Must be of dtype bool.
    */
   @doc({heading: 'Operations', subheading: 'Logical'})
   @operation
@@ -70,10 +70,10 @@ export class Ops {
   }
 
   /**
-   * Returns the truth value of a XOR b element-wise. Supports broadcasting.
+   * Returns the truth value of `a XOR b` element-wise. Supports broadcasting.
    *
-   * @param a The first input `Tensor`. Must be of dtype bool.
-   * @param b The second input `Tensor`. Must be of dtype bool.
+   * @param a The first input tensor. Must be of dtype bool.
+   * @param b The second input tensor. Must be of dtype bool.
    */
   @doc({heading: 'Operations', subheading: 'Logical'})
   @operation
@@ -88,12 +88,12 @@ export class Ops {
   /**
    * Returns the elements, either `a` or `b` depending on the `condition`.
    *
-   * @param condition The input as `Tensor. Must be of dtype bool.
-   * @param a Input as `Tensor` which may have the same shape as
-   *     `condition`. If `condition` is rank 1, `a` may have a higher rank but
+   * If the condition is true, select from `a`, otherwise select from `b`.
+   *
+   * @param condition The input condition. Must be of dtype bool.
+   * @param a If `condition` is rank 1, `a` may have a higher rank but
    *     its first dimension must match the size of `condition`.
-   * @param b Input as `Tensor` with the same shape and type as `a`.
-   * @return A `Tensor` with the same type and shape as `a` and `b`.
+   * @param b A tensor with the same shape and type as `a`.
    */
   @doc({heading: 'Operations', subheading: 'Logical'})
   @operation

--- a/src/ops/lrn.ts
+++ b/src/ops/lrn.ts
@@ -15,18 +15,18 @@
  * =============================================================================
  */
 
-import {operation} from './operation';
 import {doc} from '../doc';
 import {ENV} from '../environment';
 import {Tensor3D, Tensor4D} from '../tensor';
 import * as util from '../util';
+import {operation} from './operation';
 
 export class LRN {
   /**
    * Normalizes the activation of a local neighborhood across or within
    * channels.
    *
-   * @param x The input Tensor. The 4-D input tensor is treated as a 3-D array
+   * @param x The input tensor. The 4-D input tensor is treated as a 3-D array
    *     of 1D vectors (along the last dimension), and each vector is
    *     normalized independently.
    * @param radius The number of adjacent channels or spatial locations of the
@@ -35,8 +35,7 @@ export class LRN {
    * @param bias A constant bias term for the basis.
    * @param alpha A scale factor, usually positive.
    * @param beta An exponent.
-   * @param normRegion A string from: ['acrossChannels', 'withinChannel'].
-   *     Default is 'acrossChannels'.
+   * @param normRegion Default is 'acrossChannels'.
    */
   @doc({heading: 'Operations', subheading: 'Normalization'})
   @operation

--- a/src/ops/lstm.ts
+++ b/src/ops/lstm.ts
@@ -15,9 +15,9 @@
  * =============================================================================
  */
 
-import {operation} from './operation';
 import {doc} from '../doc';
 import {Scalar, Tensor1D, Tensor2D} from '../tensor';
+import {operation} from './operation';
 
 /**
  * @docalias (data: Tensor2D, c: Tensor2D, h: Tensor2D): [Tensor2D, Tensor2D]
@@ -32,6 +32,7 @@ export class Ops {
    * Each cell output is used as input to the next cell.
    * This is only the forward mode.
    * Derived from tf.contrib.rn.MultiRNNCell.
+   *
    * @param lstmCells Array of LSTMCell functions.
    * @param data The input to the cell.
    * @param c Array of previous cell states.
@@ -63,13 +64,13 @@ export class Ops {
    * Computes the next state and output of a BasicLSTMCell.
    * This is only the forward mode.
    * Derived from tf.contrib.rnn.BasicLSTMCell.
+   *
    * @param forgetBias Forget bias for the cell.
    * @param lstmKernel The weights for the cell.
    * @param lstmBias The bias for the cell.
    * @param data The input to the cell.
    * @param c Previous cell state.
    * @param h Previous cell output.
-   * @return Tuple [nextCellState, cellOutput]
    */
   @doc({heading: 'Operations', subheading: 'RNN'})
   @operation

--- a/src/ops/lstm.ts
+++ b/src/ops/lstm.ts
@@ -29,8 +29,11 @@ export interface LSTMCell {
 export class Ops {
   /**
    * Computes the next states and outputs of a stack of LSTMCells.
+   *
    * Each cell output is used as input to the next cell.
-   * This is only the forward mode.
+   *
+   * Returns `[cellState, cellOutput]`.
+   *
    * Derived from tf.contrib.rn.MultiRNNCell.
    *
    * @param lstmCells Array of LSTMCell functions.
@@ -62,7 +65,9 @@ export class Ops {
 
   /**
    * Computes the next state and output of a BasicLSTMCell.
-   * This is only the forward mode.
+   *
+   * Returns `[newC, newH]`.
+   *
    * Derived from tf.contrib.rnn.BasicLSTMCell.
    *
    * @param forgetBias Forget bias for the cell.

--- a/src/ops/reduction_ops.ts
+++ b/src/ops/reduction_ops.ts
@@ -15,13 +15,13 @@
  * =============================================================================
  */
 
-import {operation} from './operation';
 import {doc} from '../doc';
 import {ENV} from '../environment';
 import {customGrad} from '../globals';
 import {Scalar, Tensor} from '../tensor';
 import * as util from '../util';
 import * as axis_util from './axis_util';
+import {operation} from './operation';
 import * as ops from './ops';
 
 export class Ops {
@@ -34,10 +34,10 @@ export class Ops {
    * If `axis` has no entries, all dimensions are reduced, and an array with a
    * single element is returned.
    *
-   * @param input The input Tensor.
-   * @param axis Optional. The dimension(s) to reduce. If null (the default),
+   * @param input The input tensor.
+   * @param axis The dimension(s) to reduce. If null (the default),
    *     reduces all dimensions.
-   * @param keepDims Optional. If true, retains reduced dimensions with length
+   * @param keepDims If true, retains reduced dimensions with length
    *     of 1. Defaults to false.
    */
   @doc({heading: 'Operations', subheading: 'Reduction'})
@@ -60,18 +60,18 @@ export class Ops {
   }
 
   /**
-   * Computes the sum of elements across dimensions of an array.
+   * Computes the sum of elements across dimensions of a `Tensor`.
    *
    * Reduces the input along the dimensions given in `axes`. Unless `keepDims`
-   * is true, the rank of the array is reduced by 1 for each entry in `axes`.
+   * is true, the rank of the `Tensor` is reduced by 1 for each entry in `axes`.
    * If `keepDims` is true, the reduced dimensions are retained with length 1.
-   * If axes has no entries, all dimensions are reduced, and an array with a
+   * If axes has no entries, all dimensions are reduced, and a `Tensor` with a
    * single element is returned.
    *
-   * @param x The input array to compute the sum over.
-   * @param axis Optional. The dimension(s) to reduce. By default it reduces
+   * @param x The input tensor to compute the sum over.
+   * @param axis The dimension(s) to reduce. By default it reduces
    *     all dimensions.
-   * @param keepDims Optional. If true, retains reduced dimensions with size 1.
+   * @param keepDims If true, retains reduced dimensions with size 1.
    */
   @doc({heading: 'Operations', subheading: 'Reduction'})
   @operation
@@ -113,18 +113,18 @@ export class Ops {
   }
 
   /**
-   * Computes the mean of elements across dimensions of an array.
+   * Computes the mean of elements across dimensions of a `Tensor`.
    *
    * Reduces `x` along the dimensions given in `axis`. Unless `keepDims` is
-   * true, the rank of the array is reduced by 1 for each entry in `axis`.
+   * true, the rank of the `Tensor` is reduced by 1 for each entry in `axis`.
    * If `keepDims` is true, the reduced dimensions are retained with length 1.
-   * If `axis` has no entries, all dimensions are reduced, and an array with a
-   * single element is returned.
+   * If `axis` has no entries, all dimensions are reduced, and a `Tensor` with
+   * a single element is returned.
    *
-   * @param x The input array.
-   * @param axis Optional. The dimension(s) to reduce. By default it reduces
+   * @param x The input tensor.
+   * @param axis The dimension(s) to reduce. By default it reduces
    *     all dimensions.
-   * @param keepDims Optional. If true, retains reduced dimensions with size 1.
+   * @param keepDims If true, retains reduced dimensions with size 1.
    */
   @doc({heading: 'Operations', subheading: 'Reduction'})
   @operation
@@ -168,9 +168,9 @@ export class Ops {
    * single element is returned.
    *
    * @param x The input Tensor.
-   * @param axis Optional. The dimension(s) to reduce. By default it reduces
+   * @param axis The dimension(s) to reduce. By default it reduces
    *     all dimensions.
-   * @param keepDims Optional. If true, retains reduced dimensions with size 1.
+   * @param keepDims If true, retains reduced dimensions with size 1.
    */
   @doc({heading: 'Operations', subheading: 'Reduction'})
   @operation
@@ -193,18 +193,18 @@ export class Ops {
   }
 
   /**
-   * Computes the maximum of elements across dimensions of an array.
+   * Computes the maximum of elements across dimensions of a `Tensor`.
    *
    * Reduces the input along the dimensions given in `axes`. Unless `keepDims`
-   * is true, the rank of the array is reduced by 1 for each entry in `axes`.
+   * is true, the rank of the `Tensor` is reduced by 1 for each entry in `axes`.
    * If `keepDims` is true, the reduced dimensions are retained with length 1.
-   * If `axes` has no entries, all dimensions are reduced, and an array with a
-   * single element is returned.
+   * If `axes` has no entries, all dimensions are reduced, and an `Tensor` with
+   * a single element is returned.
    *
-   * @param x The input array.
-   * @param axis Optional. The dimension(s) to reduce. By default it reduces
+   * @param x The input tensor.
+   * @param axis The dimension(s) to reduce. By default it reduces
    *     all dimensions.
-   * @param keepDims Optional. If true, retains reduced dimensions with size 1.
+   * @param keepDims If true, retains reduced dimensions with size 1.
    */
   @doc({heading: 'Operations', subheading: 'Reduction'})
   @operation
@@ -227,11 +227,13 @@ export class Ops {
   }
 
   /**
-   * Returns the indices of the minimum values along an `axis`. The result has
-   * the same shape as `input` with the dimension along `axis` removed.
+   * Returns the indices of the minimum values along an `axis`.
    *
-   * @param x The input array.
-   * @param axis Optional. The dimension to reduce. By default it reduces
+   * The result has the same shape as `input` with the dimension along `axis`
+   * removed.
+   *
+   * @param x The input tensor.
+   * @param axis The dimension to reduce. By default it reduces
    * across all axes and returns the flat index.
    *
    */
@@ -248,11 +250,13 @@ export class Ops {
   }
 
   /**
-   * Returns the indices of the maximum values along an `axis`. The result has
-   * the same shape as `input` with the dimension along `axis` removed.
+   * Returns the indices of the maximum values along an `axis`.
    *
-   * @param x The input array.
-   * @param axis Optional. The dimension to reduce. By default it reduces
+   * The result has the same shape as `input` with the dimension along `axis`
+   * removed.
+   *
+   * @param x The input tensor.
+   * @param axis The dimension to reduce. By default it reduces
    *     across all axes and returns the flat index
    */
   @doc({heading: 'Operations', subheading: 'Reduction'})
@@ -270,8 +274,9 @@ export class Ops {
 
   /**
    * Returns a 1 if the argMax of x1 and x2 are the same, otherwise 0.
-   * @param x1 The first input Tensor.
-   * @param x2 The second input Tensor.
+   *
+   * @param x1 The first input tensor.
+   * @param x2 The second input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Reduction'})
   @operation
@@ -285,8 +290,8 @@ export class Ops {
    * calculated by aggregating the contents of `x` across `axes`. If `x` is
    * 1-D and `axes = [0]` this is just the mean and variance of a vector.
    *
-   * @param x The input array.
-   * @param axis Optional. The dimension(s) along with to compute mean and
+   * @param x The input tensor.
+   * @param axis The dimension(s) along with to compute mean and
    *     variance. By default it reduces all dimensions.
    * @param keepDims If true, the moments have the same dimensionality as the
    *     input.

--- a/src/ops/reverse.ts
+++ b/src/ops/reverse.ts
@@ -24,7 +24,7 @@ import {operation} from './operation';
 
 export class Ops {
   /**
-   * Reverses a `Tensor1D.
+   * Reverses a `Tensor1D`.
    *
    * @param x The input tensor.
    */

--- a/src/ops/reverse.ts
+++ b/src/ops/reverse.ts
@@ -15,17 +15,18 @@
  * =============================================================================
  */
 
-import {operation} from './operation';
 import {doc} from '../doc';
 import {ENV} from '../environment';
 import {Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D} from '../tensor';
 import * as util from '../util';
 import * as axis_util from './axis_util';
+import {operation} from './operation';
 
 export class Ops {
   /**
-   * Reverses a 1D array
-   * @param x The input array.
+   * Reverses a `Tensor1D.
+   *
+   * @param x The input tensor.
    */
   static reverse1d(x: Tensor1D): Tensor1D {
     util.assert(x.rank === 1, `Error in reverse1D: x must be rank 1 but got
@@ -34,8 +35,9 @@ export class Ops {
   }
 
   /**
-   * Reverses a 2D array along a specified axis
-   * @param x The input array.
+   * Reverses a `Tensor2D` along a specified axis
+   *
+   * @param x The input tensor.
    * @param axis The set of dimensions to reverse. Must be in the
    *     range [-rank(x), rank(x)).
    */
@@ -46,8 +48,8 @@ export class Ops {
   }
 
   /**
-   * Reverses a 3D array along a specified axis
-   * @param x The input array.
+   * Reverses a `Tensor3D` along a specified axis
+   * @param x The input tensor.
    * @param axis The set of dimensions to reverse. Must be in the
    *     range [-rank(x), rank(x)).
    */
@@ -58,8 +60,8 @@ export class Ops {
   }
 
   /**
-   * Reverses a 4D array along a specified axis
-   * @param x The input array.
+   * Reverses a `Tensor4D` along a specified axis
+   * @param x The input tensor.
    * @param axis The set of dimensions to reverse. Must be in the
    *     range [-rank(x), rank(x)).
    */
@@ -70,9 +72,9 @@ export class Ops {
   }
 
   /**
-   * Reverses a Tensor along a specified axis.
+   * Reverses a `Tensor` along a specified axis.
    *
-   * @param x The input array.
+   * @param x The input tensor.
    * @param axis The set of dimensions to reverse. Must be in the
    *     range [-rank(x), rank(x)).
    */

--- a/src/ops/softmax.ts
+++ b/src/ops/softmax.ts
@@ -27,6 +27,7 @@ import * as ops from './ops';
 export class Ops {
   /**
    * Computes the softmax normalized vector given the logits.
+   *
    * @param logits The logits array.
    * @param dim The dimension softmax would be performed on. Defaults to -1
    *     which indicates the last dimension.

--- a/src/ops/transpose.ts
+++ b/src/ops/transpose.ts
@@ -15,25 +15,25 @@
  * =============================================================================
  */
 
-import {operation} from './operation';
 import {doc} from '../doc';
 import {ENV} from '../environment';
 import {Tensor} from '../tensor';
 import {Rank} from '../types';
 import * as util from '../util';
 import * as axis_util from './axis_util';
+import {operation} from './operation';
 
 export class Ops {
   /**
-   * Transposes the array. Permutes the dimensions according to `perm`.
+   * Transposes the `Tensor`. Permutes the dimensions according to `perm`.
    *
-   * The returned array's dimension `i` will correspond to the input dimension
-   * `perm[i]`. If `perm` is not given, it is set to `[n-1...0]`, where `n` is
-   * the rank of the input array. Hence by default, this operation performs a
-   * regular matrix transpose on 2-D input arrays.
+   * The returned `Tensor`'s dimension `i` will correspond to the input
+   * dimension `perm[i]`. If `perm` is not given, it is set to `[n-1...0]`,
+   * where `n` is the rank of the input `Tensor`. Hence by default, this
+   * operation performs a regular matrix transpose on 2-D input `Tensor`s.
    *
-   * @param x The array to transpose.
-   * @param perm Optional. The permutation of the dimensions of a.
+   * @param x The tensor to transpose.
+   * @param perm The permutation of the dimensions of a.
    */
   @doc({heading: 'Operations', subheading: 'Matrices'})
   @operation

--- a/src/ops/unary_ops.ts
+++ b/src/ops/unary_ops.ts
@@ -27,7 +27,8 @@ import * as selu_util from './selu_util';
 export class Ops {
   /**
    * Computes `-1 * x` element-wise.
-   * @param x The input array.
+   *
+   * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
   @operation
@@ -38,7 +39,7 @@ export class Ops {
   }
 
   /**
-   * Computes ceiling of input Tensor element-wise: `ceil(x)`
+   * Computes ceiling of input `Tensor` element-wise: `ceil(x)`
    *
    * @param x The input Tensor.
    */
@@ -54,7 +55,7 @@ export class Ops {
 
   /**
    * Computes floor of input `Tensor` element-wise: `floor(x)`.
-   * @param x The input Tensor.
+   * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
   @operation
@@ -68,8 +69,8 @@ export class Ops {
   }
 
   /**
-   * Computes exponential of the input Tensor element-wise. `e ^ x`
-   * @param x The input Tensor.
+   * Computes exponential of the input `Tensor` element-wise. `e ^ x`
+   * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
   @operation
@@ -80,8 +81,8 @@ export class Ops {
   }
 
   /**
-   * Computes natural logarithm of the input Tensor element-wise: `ln(x)`
-   * @param x The input Tensor.
+   * Computes natural logarithm of the input `Tensor` element-wise: `ln(x)`
+   * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
   @operation
@@ -92,8 +93,8 @@ export class Ops {
   }
 
   /**
-   * Computes square root of the input Tensor element-wise: `y = sqrt(x)`
-   * @param x The input Tensor.
+   * Computes square root of the input `Tensor` element-wise: `y = sqrt(x)`
+   * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
   @operation
@@ -119,7 +120,7 @@ export class Ops {
   /**
    * Computes absolute value element-wise: `abs(x)`
    *
-   * @param x The input Tensor.
+   * @param x The input `Tensor`.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
   @operation
@@ -131,7 +132,8 @@ export class Ops {
 
   /**
    * Clips values element-wise. `max(min(x, clipValueMax), clipValueMin)`
-   * @param x The input Tensor.
+   *
+   * @param x The input tensor.
    * @param clipValueMin Lower-bound of range to be clipped to.
    * @param clipValueMax Upper-bound of range to be clipped to.
    */
@@ -160,7 +162,8 @@ export class Ops {
 
   /**
    * Computes rectified linear element-wise: `max(x, 0)`
-   * @param x The input Tensor.
+   *
+   * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
   @operation
@@ -173,7 +176,8 @@ export class Ops {
 
   /**
    * Computes exponential linear element-wise, `x > 0 ? e ^ x - 1 : 0`
-   * @param x the input Tensor
+   *
+   * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
   @operation
@@ -195,6 +199,8 @@ export class Ops {
    * Computes scaled exponential linear element-wise.
    *
    * `x < 0 ? scale * alpha * (exp(x) - 1) : x`
+   *
+   * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
   @operation
@@ -226,9 +232,8 @@ export class Ops {
    * [http://web.stanford.edu/~awni/papers/relu_hybrid_icml2013_final.pdf](
    *     http://web.stanford.edu/~awni/papers/relu_hybrid_icml2013_final.pdf)
    *
-   * @param x the input Tensor
-   * @param alpha scaling factor for negative values, defaults to 0.2
-   * @return {Tensor}
+   * @param x The input tensor.
+   * @param alpha The scaling factor for negative values, defaults to 0.2.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
   @operation
@@ -244,9 +249,9 @@ export class Ops {
    * Computes leaky rectified linear element-wise with parametric alphas.
    *
    * `x < 0 ? alpha * x : f(x) = x`
-   * @param x the input Tensor
-   * @param alpha scaling factor Tensor for negative values
-   * @return {Tensor}
+   *
+   * @param x The input tensor.
+   * @param alpha Scaling factor for negative values.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
   @operation
@@ -266,7 +271,8 @@ export class Ops {
 
   /**
    * Computes sigmoid element-wise, `1 / (1 + exp(-x))`
-   * @param x The input Tensor.
+   *
+   * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
   @operation
@@ -278,7 +284,8 @@ export class Ops {
 
   /**
    * Computes sin of the input Tensor element-wise: `sin(x)`
-   * @param x The input Tensor.
+   *
+   * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
   @operation
@@ -289,8 +296,9 @@ export class Ops {
   }
 
   /**
-   * Computes cos of the input Tensor element-wise: `cos(x)`
-   * @param x The input Tensor.
+   * Computes cos of the input `Tensor` element-wise: `cos(x)`
+   *
+   * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
   @operation
@@ -301,8 +309,9 @@ export class Ops {
   }
 
   /**
-   * Computes tan of the input Tensor element-wise, `tan(x)`
-   * @param x The input Tensor.
+   * Computes tan of the input `Tensor` element-wise, `tan(x)`
+   *
+   * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
   @operation
@@ -313,8 +322,9 @@ export class Ops {
   }
 
   /**
-   * Computes asin of the input Tensor element-wise: `asin(x)`
-   * @param x The input Tensor.
+   * Computes asin of the input `Tensor` element-wise: `asin(x)`
+   *
+   * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
   @operation
@@ -327,8 +337,9 @@ export class Ops {
   }
 
   /**
-   * Computes acos of the input Tensor element-wise: `acos(x)`
-   * @param x The input Tensor.
+   * Computes acos of the input `Tensor` element-wise: `acos(x)`
+   *
+   * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
   @operation
@@ -341,8 +352,9 @@ export class Ops {
   }
 
   /**
-   * Computes atan of the input Tensor element-wise: `atan(x)`
-   * @param x The input Tensor.
+   * Computes atan of the input `Tensor` element-wise: `atan(x)`
+   *
+   * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
   @operation
@@ -353,8 +365,9 @@ export class Ops {
   }
 
   /**
-   * Computes hyperbolic sin of the input Tensor element-wise: `sinh(x)`
-   * @param x The input Tensor.
+   * Computes hyperbolic sin of the input `Tensor` element-wise: `sinh(x)`
+   *
+   * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
   @operation
@@ -365,8 +378,8 @@ export class Ops {
   }
 
   /**
-   * Computes hyperbolic cos of the input Tensor element-wise: `cosh(x)`
-   * @param x The input Tensor.
+   * Computes hyperbolic cos of the input `Tensor` element-wise: `cosh(x)`
+   * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
   @operation
@@ -377,8 +390,8 @@ export class Ops {
   }
 
   /**
-   * Computes hyperbolic tangent of the input Tensor element-wise: `tanh(x)`
-   * @param x The input Tensor.
+   * Computes hyperbolic tangent of the input `Tensor` element-wise: `tanh(x)`
+   * @param x The input tensor.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})
   @operation
@@ -389,9 +402,9 @@ export class Ops {
   }
 
   /**
-   * Computes step of the input Tensor element-wise: `x > 0 ? 1 : alpha * x`
+   * Computes step of the input `Tensor` element-wise: `x > 0 ? 1 : alpha * x`
    *
-   * @param x The input Tensor.
+   * @param x The input tensor.
    * @param alpha The gradient when input is negative.
    */
   @doc({heading: 'Operations', subheading: 'Basic math'})

--- a/src/optimizers/adadelta_optimizer.ts
+++ b/src/optimizers/adadelta_optimizer.ts
@@ -15,7 +15,6 @@
  * =============================================================================
  */
 
-import {doc} from '../doc';
 import {ENV} from '../environment';
 import {keep, tidy} from '../globals';
 import {Node} from '../graph/graph';

--- a/src/optimizers/adadelta_optimizer.ts
+++ b/src/optimizers/adadelta_optimizer.ts
@@ -30,13 +30,8 @@ import {NamedVariableMap} from '../types';
 import {Optimizer} from './optimizer';
 
 /**
- * Optimizer that implements the Adadelta algorithm.
- *
- * Use `dl.train.adadelta` to create an Adadelta optimizer.
- *
- * See: https://arxiv.org/abs/1212.5701
+ * @doclink Optimizer
  */
-@doc({heading: 'Training', subheading: 'Classes', namespace: 'train'})
 export class AdadeltaOptimizer extends Optimizer {
   private c: Scalar;
   private epsilon: Scalar;

--- a/src/optimizers/adadelta_optimizer.ts
+++ b/src/optimizers/adadelta_optimizer.ts
@@ -29,9 +29,7 @@ import {variable} from '../tensor';
 import {NamedVariableMap} from '../types';
 import {Optimizer} from './optimizer';
 
-/**
- * @doclink Optimizer
- */
+/** @doclink Optimizer */
 export class AdadeltaOptimizer extends Optimizer {
   private c: Scalar;
   private epsilon: Scalar;

--- a/src/optimizers/adagrad_optimizer.ts
+++ b/src/optimizers/adagrad_optimizer.ts
@@ -15,7 +15,6 @@
  * =============================================================================
  */
 
-import {doc} from '../doc';
 import {ENV} from '../environment';
 import {keep, tidy} from '../globals';
 import {Node} from '../graph/graph';

--- a/src/optimizers/adagrad_optimizer.ts
+++ b/src/optimizers/adagrad_optimizer.ts
@@ -30,9 +30,7 @@ import {NamedVariableMap} from '../types';
 
 import {Optimizer} from './optimizer';
 
-/**
- * @doclink Optimizer
- */
+/** @doclink Optimizer */
 export class AdagradOptimizer extends Optimizer {
   private c: Scalar;
   private epsilon: Scalar;

--- a/src/optimizers/adagrad_optimizer.ts
+++ b/src/optimizers/adagrad_optimizer.ts
@@ -31,11 +31,8 @@ import {NamedVariableMap} from '../types';
 import {Optimizer} from './optimizer';
 
 /**
- * Optimizer that implements the Adagrad optimization algorithm.
- *
- * Use `dl.train.adagrad` to create a Adagrad optimizer.
+ * @doclink Optimizer
  */
-@doc({heading: 'Training', subheading: 'Classes', namespace: 'train'})
 export class AdagradOptimizer extends Optimizer {
   private c: Scalar;
   private epsilon: Scalar;

--- a/src/optimizers/momentum_optimizer.ts
+++ b/src/optimizers/momentum_optimizer.ts
@@ -15,7 +15,6 @@
  * =============================================================================
  */
 
-import {doc} from '../doc';
 import {ENV} from '../environment';
 import {keep, tidy} from '../globals';
 import {Node} from '../graph/graph';

--- a/src/optimizers/momentum_optimizer.ts
+++ b/src/optimizers/momentum_optimizer.ts
@@ -29,9 +29,7 @@ import {variable} from '../tensor';
 import {NamedVariableMap} from '../types';
 import {SGDOptimizer} from './sgd_optimizer';
 
-/**
- * @doclink Optimizer
- */
+/** @doclink Optimizer */
 export class MomentumOptimizer extends SGDOptimizer {
   private m: Scalar;
   private accumulations: NamedVariableMap;

--- a/src/optimizers/momentum_optimizer.ts
+++ b/src/optimizers/momentum_optimizer.ts
@@ -30,11 +30,8 @@ import {NamedVariableMap} from '../types';
 import {SGDOptimizer} from './sgd_optimizer';
 
 /**
- * Optimizer that implements momentum gradient descent.
- *
- * Use `dl.train.momentum` to create a momentum optimizer.
+ * @doclink Optimizer
  */
-@doc({heading: 'Training', subheading: 'Classes', namespace: 'train'})
 export class MomentumOptimizer extends SGDOptimizer {
   private m: Scalar;
   private accumulations: NamedVariableMap;

--- a/src/optimizers/optimizer.ts
+++ b/src/optimizers/optimizer.ts
@@ -27,6 +27,7 @@ import * as ops from '../ops/ops';
 import {Scalar, Tensor, Variable} from '../tensor';
 import {NamedTensorMap} from '../types';
 
+@doc({heading: 'Training', subheading: 'Classes', namespace: 'train'})
 export abstract class Optimizer {
   protected variableNodes: VariableNode[];
   protected specifiedVariableNodes: VariableNode[]|null;
@@ -48,15 +49,7 @@ export abstract class Optimizer {
    * the trainable variables in varList will be updated by minimize. Defaults to
    * all trainable variables.
    */
-  @doc({
-    heading: 'Training',
-    subheading: 'Optimizers',
-    subclasses:
-        [
-          'SGDOptimizer', 'MomentumOptimizer', 'AdadeltaOptimizer',
-          'AdagradOptimizer'
-        ]
-  })
+  @doc({heading: 'Training', subheading: 'Optimizers'})
   minimize(f: () => Scalar, returnCost = false, varList?: Variable[]): Scalar
       |null {
     const {value, grads} = this.computeGradients(f, varList);

--- a/src/optimizers/optimizer_constructors.ts
+++ b/src/optimizers/optimizer_constructors.ts
@@ -24,7 +24,7 @@ import {SGDOptimizer} from './sgd_optimizer';
 
 export class OptimizerConstructors {
   /**
-   * Constructs a `dl.train.SGDOptimizer` that uses stochastic gradient descent.
+   * Constructs a `SGDOptimizer` that uses stochastic gradient descent.
    *
    * @param learningRate The learning rate to use for the SGD algorithm.
    */
@@ -34,7 +34,7 @@ export class OptimizerConstructors {
   }
 
   /**
-   * Constructs a `dl.train.MomentumOptimizer` that uses momentum gradient
+   * Constructs a `MomentumOptimizer` that uses momentum gradient
    * descent.
    *
    * @param learningRate The learning rate to use for the momentum gradient
@@ -48,7 +48,7 @@ export class OptimizerConstructors {
   }
 
   /**
-   * Constructs a `dl.train.RMSPropOptimizer` that uses RMSProp gradient
+   * Constructs a `RMSPropOptimizer` that uses RMSProp gradient
    * descent. This implementation uses plain momentum and is not centered
    * version of RMSProp.
    *
@@ -72,7 +72,7 @@ export class OptimizerConstructors {
   }
 
   /**
-   * Constructs a `dl.train.AdadeltaOptimizer` that uses the Adadelta algorithm.
+   * Constructs a `AdadeltaOptimizer` that uses the Adadelta algorithm.
    * See https://arxiv.org/abs/1212.5701
    *
    * @param learningRate
@@ -88,7 +88,7 @@ export class OptimizerConstructors {
   }
 
   /**
-   * Constructs a `dl.train.AdagradOptimizer` that uses the Adagrad algorithm.
+   * Constructs a `AdagradOptimizer` that uses the Adagrad algorithm.
    * See http://www.jmlr.org/papers/volume12/duchi11a/duchi11a.pdf or
    * http://ruder.io/optimizing-gradient-descent/index.html#adagrad
    *

--- a/src/optimizers/rmsprop_optimizer.ts
+++ b/src/optimizers/rmsprop_optimizer.ts
@@ -15,7 +15,6 @@
  * =============================================================================
  */
 
-import {doc} from '../doc';
 import {ENV} from '../environment';
 import {keep, tidy} from '../globals';
 import {Node} from '../graph/graph';

--- a/src/optimizers/rmsprop_optimizer.ts
+++ b/src/optimizers/rmsprop_optimizer.ts
@@ -31,11 +31,8 @@ import {NamedVariableMap} from '../types';
 import {Optimizer} from './optimizer';
 
 /**
- * Optimizer that implements the RMSProp optimization algorithm.
- *
- * Use `dl.train.rmsprop` to create a RMSProp ptimizer.
+ * @doclink Optimizer
  */
-@doc({heading: 'Training', subheading: 'Classes', namespace: 'train'})
 export class RMSPropOptimizer extends Optimizer {
   private c: Scalar;
   private epsilon: Scalar;

--- a/src/optimizers/rmsprop_optimizer.ts
+++ b/src/optimizers/rmsprop_optimizer.ts
@@ -30,9 +30,7 @@ import {variable} from '../tensor';
 import {NamedVariableMap} from '../types';
 import {Optimizer} from './optimizer';
 
-/**
- * @doclink Optimizer
- */
+/** @doclink Optimizer */
 export class RMSPropOptimizer extends Optimizer {
   private c: Scalar;
   private epsilon: Scalar;

--- a/src/optimizers/sgd_optimizer.ts
+++ b/src/optimizers/sgd_optimizer.ts
@@ -15,7 +15,6 @@
  * =============================================================================
  */
 
-import {doc} from '../doc';
 import {ENV} from '../environment';
 import {keep, tidy} from '../globals';
 import {Node} from '../graph/graph';

--- a/src/optimizers/sgd_optimizer.ts
+++ b/src/optimizers/sgd_optimizer.ts
@@ -29,9 +29,7 @@ import {NamedTensorMap} from '../types';
 
 import {Optimizer} from './optimizer';
 
-/**
- * @doclink Optimizer
- */
+/** @doclink Optimizer */
 export class SGDOptimizer extends Optimizer {
   protected c: Scalar;
 

--- a/src/optimizers/sgd_optimizer.ts
+++ b/src/optimizers/sgd_optimizer.ts
@@ -30,11 +30,8 @@ import {NamedTensorMap} from '../types';
 import {Optimizer} from './optimizer';
 
 /**
- * Optimizer that implements stochastic gradient descent.
- *
- * Use `dl.train.sgd` to create an SGD optimizer.
+ * @doclink Optimizer
  */
-@doc({heading: 'Training', subheading: 'Classes', namespace: 'train'})
 export class SGDOptimizer extends Optimizer {
   protected c: Scalar;
 

--- a/src/tensor.ts
+++ b/src/tensor.ts
@@ -816,9 +816,8 @@ export class Tensor<R extends Rank = Rank> {
 }
 
 /**
- * A type alias for a rank-0 `Tensor`.
+ * @doclink Tensor
  */
-@doc({heading: 'Tensors', subheading: 'Classes'})
 export class Scalar extends Tensor<Rank.R0> {
   static new(value: number|boolean, dtype?: DataType): Scalar {
     return ops.scalar(value, dtype);
@@ -826,9 +825,8 @@ export class Scalar extends Tensor<Rank.R0> {
 }
 
 /**
- * A type alias for a rank-1 `Tensor`.
+ * @doclink Tensor
  */
-@doc({heading: 'Tensors', subheading: 'Classes'})
 export class Tensor1D extends Tensor<Rank.R1> {
   static new<D extends DataType = 'float32'>(
       values: DataTypeMap[D]|number[]|boolean[], dtype?: D): Tensor1D {
@@ -837,9 +835,8 @@ export class Tensor1D extends Tensor<Rank.R1> {
 }
 
 /**
- * A type alias for a rank-2 `Tensor`.
+ * @doclink Tensor
  */
-@doc({heading: 'Tensors', subheading: 'Classes'})
 export class Tensor2D extends Tensor<Rank.R2> {
   static new<D extends DataType = 'float32'>(
       shape: [number, number],
@@ -850,9 +847,8 @@ export class Tensor2D extends Tensor<Rank.R2> {
 }
 
 /**
- * A type alias for a rank-3 `Tensor`.
+ * @doclink Tensor
  */
-@doc({heading: 'Tensors', subheading: 'Classes'})
 export class Tensor3D extends Tensor<Rank.R3> {
   static new<D extends DataType = 'float32'>(
       shape: [number, number, number],
@@ -863,9 +859,8 @@ export class Tensor3D extends Tensor<Rank.R3> {
 }
 
 /**
- * A type alias for a rank-4 `Tensor`.
+ * @doclink Tensor
  */
-@doc({heading: 'Tensors', subheading: 'Classes'})
 export class Tensor4D extends Tensor<Rank.R4> {
   static new<D extends DataType = 'float32'>(
       shape: [number, number, number, number],

--- a/src/tensor.ts
+++ b/src/tensor.ts
@@ -115,8 +115,10 @@ export class TensorBuffer<R extends Rank> {
 export type DataId = object;  // object instead of {} to force non-primitive.
 
 /**
- * A Tensor object represents an immutable, multidimensional array of numbers
+ * A `Tensor` object represents an immutable, multidimensional array of numbers
  * that has a shape and a data type.
+ *
+ * See `tensor` for details on how to create a `Tensor`.
  */
 @doc({heading: 'Tensors', subheading: 'Classes'})
 export class Tensor<R extends Rank = Rank> {
@@ -355,7 +357,7 @@ export class Tensor<R extends Rank = Rank> {
   }
 
   /**
-   * Asynchronously downloads the values from the Tensor. Returns a promise of
+   * Asynchronously downloads the values from the `Tensor`. Returns a promise of
    * `TypedArray` that resolves when the computation has finished.
    */
   @doc({heading: 'Tensors', subheading: 'Classes'})
@@ -365,7 +367,7 @@ export class Tensor<R extends Rank = Rank> {
   }
 
   /**
-   * Synchronously downloads the values from the Tensor. This blocks the UI
+   * Synchronously downloads the values from the `Tensor`. This blocks the UI
    * thread until the values are ready, which can cause performance issues.
    */
   @doc({heading: 'Tensors', subheading: 'Classes'})
@@ -869,7 +871,7 @@ export class Variable<R extends Rank = Rank> extends Tensor<R> {
   name: string;
 
   /**
-   * Private constructor since we can not add logic before calling super().
+   * Private constructor since we can not add logic before calling `super()`.
    * Instead, we expose static `Variable.variable` method below, which will be
    * added to global namespace.
    */

--- a/src/tensor.ts
+++ b/src/tensor.ts
@@ -815,18 +815,14 @@ export class Tensor<R extends Rank = Rank> {
   }
 }
 
-/**
- * @doclink Tensor
- */
+/** @doclink Tensor */
 export class Scalar extends Tensor<Rank.R0> {
   static new(value: number|boolean, dtype?: DataType): Scalar {
     return ops.scalar(value, dtype);
   }
 }
 
-/**
- * @doclink Tensor
- */
+/** @doclink Tensor */
 export class Tensor1D extends Tensor<Rank.R1> {
   static new<D extends DataType = 'float32'>(
       values: DataTypeMap[D]|number[]|boolean[], dtype?: D): Tensor1D {
@@ -834,9 +830,7 @@ export class Tensor1D extends Tensor<Rank.R1> {
   }
 }
 
-/**
- * @doclink Tensor
- */
+/** @doclink Tensor */
 export class Tensor2D extends Tensor<Rank.R2> {
   static new<D extends DataType = 'float32'>(
       shape: [number, number],
@@ -846,9 +840,7 @@ export class Tensor2D extends Tensor<Rank.R2> {
   }
 }
 
-/**
- * @doclink Tensor
- */
+/** @doclink Tensor */
 export class Tensor3D extends Tensor<Rank.R3> {
   static new<D extends DataType = 'float32'>(
       shape: [number, number, number],
@@ -858,9 +850,7 @@ export class Tensor3D extends Tensor<Rank.R3> {
   }
 }
 
-/**
- * @doclink Tensor
- */
+/** @doclink Tensor */
 export class Tensor4D extends Tensor<Rank.R4> {
   static new<D extends DataType = 'float32'>(
       shape: [number, number, number, number],

--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -28,10 +28,10 @@ export class Tracking {
    * the function.
    *
    * Using this method helps avoid memory leaks. In general, wrap calls to
-   * operations in dl.tidy() for automatic memory cleanup.
+   * operations in `tidy` for automatic memory cleanup.
    *
    * When in safe mode, you must enclose all `Tensor` creation and ops
-   * inside a `dl.tidy()` to prevent memory leaks.
+   * inside a `tidy` to prevent memory leaks.
    *
    * @param nameOrFn The name of the closure, or the function to execute.
    *     If a name is provided, the 2nd argument should be the function.
@@ -40,7 +40,6 @@ export class Tracking {
    *     using the provided name.
    * @param fn The function to execute.
    * @param gradMode If true, starts a tape and doesn't dispose tensors.
-   *     See dl.gradScope for details.
    */
   @doc({heading: 'Performance', subheading: 'Memory'})
   static tidy<T extends ScopeResult>(
@@ -79,7 +78,7 @@ export class Tracking {
   }
 
   /**
-   * Keeps a Tensor generated inside a dl.tidy() from being disposed
+   * Keeps a Tensor generated inside a `tidy` from being disposed
    * automatically.
    * @param result The Tensor to keep from being disposed.
    */
@@ -89,8 +88,8 @@ export class Tracking {
   }
 
   /**
-   * Executes f() and returns a promise that resolves with the elapsed time of
-   * f() in milliseconds.
+   * Executes `f()` and returns a promise that resolves with the elapsed time of
+   * `f()` in milliseconds.
    * @param f The function to execute and time.
    */
   @doc({heading: 'Performance', subheading: 'Timing'})

--- a/website/api/index.html
+++ b/website/api/index.html
@@ -294,7 +294,7 @@
                 <div class="method-name">
                   <code>{{symbolName}}{{paramStr}}</code>
                 </div>
-                <div class="method-docs documentation">
+                <div class="method-docs">
                   {{#optional}}(Optional){{/optional}} {{{markdown documentation}}}
 
                   <div class="parameter-heading mdl-typography--subhead">Parameters:</div>

--- a/website/api/index.html
+++ b/website/api/index.html
@@ -136,19 +136,26 @@
       border-bottom: 1px solid rgb(96,125,139);
     }
 
-    .documentation pre, .documentation a {
-      background: #f7f7f7;
+    .documentation pre, .param-docs pre {
+      background: #f4f4f4;
     }
 
-    code {
-      background: #f7f7f7;
+    code, .markdown {
+      background: #f4f4f4;
       color: #37474f;
       padding: 2px 4px;
       font: 500 90%/2 Roboto Mono, monospace;
+    }
+    code {
       word-break: break-word;
     }
-    .documentation a {
-      padding: 2px 4px;
+    .markdown {
+      display: inline-block;
+    }
+
+    .documentation a, .returns a, .param-docs a {
+      background: #f4f4f4;
+      padding: 4px 6px;
       font: 500 90%/2 Roboto Mono, monospace;
     }
 
@@ -272,7 +279,7 @@
                 {{#parameters}}
                 <li class="parameter">
                   <span class="param-name">
-                    <code>{{name}}: {{type}}</code>
+                    <div class="markdown">{{name}}: {{{markdownInner type}}}</div>
                   </span>
                   <span class="param-docs">
                     {{#optional}}(Optional){{/optional}} {{{markdownInner documentation}}}
@@ -281,7 +288,7 @@
                 {{/parameters}}
               </ul>
               <div class="returns mdl-typography--subhead">
-                Returns: <code>{{returnType}}</code>
+                Returns: <div class="markdown">{{{markdownInner returnType}}}</div>
               </div>
               {{/isFunction}} {{#isClass}}
               <h6>Methods:</h6>
@@ -290,7 +297,7 @@
                 <div class="method-name">
                   <code>{{symbolName}}{{paramStr}}</code>
                 </div>
-                <div class="method-docs">
+                <div class="method-docs documentation">
                   {{#optional}}(Optional){{/optional}} {{{markdown documentation}}}
 
                   <div class="parameter-heading mdl-typography--subhead">Parameters:</div>

--- a/website/api/index.html
+++ b/website/api/index.html
@@ -305,7 +305,7 @@
                     {{#parameters}}
                     <li class="parameter">
                       <span class="param-name">
-                        <code>{{name}}: {{type}}</code>
+                        <div class="markdown">{{name}}: {{{markdownInner type}}}</div>
                       </span>
                       <span class="param-docs">
                         {{#optional}}(Optional){{/optional}} {{{markdownInner documentation}}}

--- a/website/api/index.html
+++ b/website/api/index.html
@@ -291,11 +291,11 @@
               <h6>Methods:</h6>
               {{#methods}}
               <div class="method">
-                <div class="method-name">
+                <span class="method-name">
                   <code>{{symbolName}}{{paramStr}}</code>
-                </div>
-                <div class="method-docs">
-                  {{#optional}}(Optional){{/optional}} {{{markdown documentation}}}
+                </span>
+                <span class="method-docs">
+                  {{#optional}}(Optional){{/optional}} {{{markdownInner documentation}}}
 
                   <div class="parameter-heading mdl-typography--subhead">Parameters:</div>
                   <ul>
@@ -310,7 +310,7 @@
                     </li>
                     {{/parameters}}
                   </ul>
-                </div>
+                </span>
               </div>
               {{/methods}} {{/isClass}}
 

--- a/website/api/index.html
+++ b/website/api/index.html
@@ -140,7 +140,7 @@
       background: #f4f4f4;
     }
 
-    code, .param-name {
+    code, .param-name, .return-type {
       background: #f4f4f4;
       color: #37474f;
       padding: 2px 4px;
@@ -150,7 +150,7 @@
       word-break: break-word;
     }
 
-    .documentation a, .returns a,  .param-name a {
+    .documentation a, .returns a,  .param-name a, .method-docs a, .param-docs a {
       background: #f4f4f4;
       padding: 4px 6px;
       font: 500 90%/2 Roboto Mono, monospace;
@@ -285,7 +285,7 @@
                 {{/parameters}}
               </ul>
               <div class="returns mdl-typography--subhead">
-                Returns: {{{markdownInner returnType}}}
+                Returns: <span class="return-type">{{{markdownInner returnType}}}</span>
               </div>
               {{/isFunction}} {{#isClass}}
               <h6>Methods:</h6>

--- a/website/api/index.html
+++ b/website/api/index.html
@@ -232,7 +232,7 @@
             <div class="sub-section-title mdl-typography--subhead">{{name}}</div>
             {{#symbols}}
             <div class="symbol">
-              <a href="#{{#isClass}}class:{{/isClass}}dl.{{displayName}}">dl.{{displayName}}</a>
+              <a href="#{{urlHash}}">{{displayName}}</a>
             </div>
             {{/symbols}}
           </div>
@@ -252,7 +252,7 @@
             {{#symbols}}
             <div class="symbol">
               <h5>#
-                <a name="{{#isClass}}class:{{/isClass}}dl.{{displayName}}" href="#{{#isClass}}class:{{/isClass}}dl.{{displayName}}">dl.{{displayName}}</a>{{paramStr}}
+                <a name="{{urlHash}}" href="#{{urlHash}}">{{displayName}}</a>{{paramStr}}
                 {{#isClass}}
                   <span class="class-chip mdl-chip">
                     <span class="mdl-chip__text">Class</span>

--- a/website/api/index.html
+++ b/website/api/index.html
@@ -140,7 +140,7 @@
       background: #f4f4f4;
     }
 
-    code, .markdown {
+    code, .param-name {
       background: #f4f4f4;
       color: #37474f;
       padding: 2px 4px;
@@ -149,11 +149,8 @@
     code {
       word-break: break-word;
     }
-    .markdown {
-      display: inline-block;
-    }
 
-    .documentation a, .returns a, .param-docs a {
+    .documentation a, .returns a,  .param-name a {
       background: #f4f4f4;
       padding: 4px 6px;
       font: 500 90%/2 Roboto Mono, monospace;
@@ -279,7 +276,7 @@
                 {{#parameters}}
                 <li class="parameter">
                   <span class="param-name">
-                    <div class="markdown">{{name}}: {{{markdownInner type}}}</div>
+                    {{name}}: {{{markdownInner type}}}
                   </span>
                   <span class="param-docs">
                     {{#optional}}(Optional){{/optional}} {{{markdownInner documentation}}}
@@ -288,7 +285,7 @@
                 {{/parameters}}
               </ul>
               <div class="returns mdl-typography--subhead">
-                Returns: <div class="markdown">{{{markdownInner returnType}}}</div>
+                Returns: {{{markdownInner returnType}}}
               </div>
               {{/isFunction}} {{#isClass}}
               <h6>Methods:</h6>
@@ -305,7 +302,7 @@
                     {{#parameters}}
                     <li class="parameter">
                       <span class="param-name">
-                        <div class="markdown">{{name}}: {{{markdownInner type}}}</div>
+                        {{name}}: {{{markdownInner type}}}
                       </span>
                       <span class="param-docs">
                         {{#optional}}(Optional){{/optional}} {{{markdownInner documentation}}}

--- a/website/api/index.html
+++ b/website/api/index.html
@@ -136,7 +136,7 @@
       border-bottom: 1px solid rgb(96,125,139);
     }
 
-    .documentation pre {
+    .documentation pre, .documentation a {
       background: #f7f7f7;
     }
 
@@ -146,6 +146,10 @@
       padding: 2px 4px;
       font: 500 90%/2 Roboto Mono, monospace;
       word-break: break-word;
+    }
+    .documentation a {
+      padding: 2px 4px;
+      font: 500 90%/2 Roboto Mono, monospace;
     }
 
     .documentation {

--- a/website/api/view.ts
+++ b/website/api/view.ts
@@ -35,18 +35,21 @@ export type DocSymbol = DocFunction|DocClass;
 
 export interface DocClass {
   symbolName: string;
-  displayName: string;
+  namespace: string;
   documentation: string;
   fileName: string;
   githubUrl: string;
   methods: DocFunction[];
 
   isClass: true;
+
+  displayName?: string;
+  urlHash?: string;  // Filled in by the linker.
 }
 
 export interface DocFunction {
   symbolName: string;
-  displayName: string;
+  namespace: string;
   documentation: string;
   fileName: string;
   githubUrl: string;
@@ -56,6 +59,10 @@ export interface DocFunction {
   returnType: string;
 
   isFunction: true;
+
+  // Filled in by the linker.
+  displayName?: string;
+  urlHash?: string;
 }
 
 export interface DocFunctionParam {

--- a/website/api/view.ts
+++ b/website/api/view.ts
@@ -43,8 +43,9 @@ export interface DocClass {
 
   isClass: true;
 
+  // Filled in by the linker.
   displayName?: string;
-  urlHash?: string;  // Filled in by the linker.
+  urlHash?: string;
 }
 
 export interface DocFunction {

--- a/website/scripts/api-parser.ts
+++ b/website/scripts/api-parser.ts
@@ -57,12 +57,7 @@ export function parse():
             'tensor', 'scalar', 'tensor1d', 'tensor2d', 'tensor3d', 'tensor4d'
           ]
         },
-        {
-          name: 'Classes',
-          pin: [
-            'Tensor', 'Scalar', 'Tensor1D', 'Tensor2D', 'Tensor3D', 'Tensor4D'
-          ]
-        },
+        {name: 'Classes', pin: ['Tensor', 'Variable', 'TensorBuffer']},
         {name: 'Transformations'}, {name: 'Slicing and Joining'}
       ]
     },
@@ -82,13 +77,7 @@ export function parse():
       subheadings: [
         {name: 'Gradients'},
         {name: 'Optimizers', pin: ['sgd', 'momentum', 'adagrad', 'adadelta']},
-        {name: 'Losses'}, {
-          name: 'Classes',
-          pin: [
-            'SGDOptimizer', 'MomentumOptimizer', 'AdagradOptimizer',
-            'AdadeltaOptimizer'
-          ]
-        }
+        {name: 'Losses'}, {name: 'Classes'}
       ]
     },
     {

--- a/website/scripts/api-parser.ts
+++ b/website/scripts/api-parser.ts
@@ -202,13 +202,11 @@ export function serializeClass(
 
   const name = symbol.getName();
 
-  const displayName = util.getDisplayName(docInfo, name);
-
   const {displayFilename, githubUrl} =
       util.getFileInfo(node, sourceFile, repoPath, SRC_ROOT);
   const docClass: DocClass = {
     symbolName: name,
-    displayName,
+    namespace: docInfo.namespace,
     documentation: ts.displayPartsToString(symbol.getDocumentationComment()),
     fileName: displayFilename,
     githubUrl,
@@ -240,7 +238,6 @@ export function serializeMethod(
   }
 
   const methodName = node.name.getText();
-  const displayName = util.getDisplayName(docInfo, methodName);
 
   const symbol = checker.getSymbolAtLocation(node.name);
   const type =
@@ -278,7 +275,7 @@ export function serializeMethod(
 
   const method: DocFunction = {
     symbolName: symbol.name,
-    displayName,
+    namespace: docInfo.namespace,
     paramStr,
     parameters,
     returnType,

--- a/website/scripts/api-parser.ts
+++ b/website/scripts/api-parser.ts
@@ -74,18 +74,13 @@ export function parse(): Docs {
       name: 'Training',
       description: '',
       subheadings: [
-        {name: 'Gradients'}, {
-          name: 'Optimizers',
-          pin: [
-            'train.sgd', 'train.momentum', 'train.adagrad', 'train.adadelta'
-
-          ]
-        },
+        {name: 'Gradients'},
+        {name: 'Optimizers', pin: ['sgd', 'momentum', 'adagrad', 'adadelta']},
         {name: 'Losses'}, {
           name: 'Classes',
           pin: [
-            'train.SGDOptimizer', 'train.MomentumOptimizer',
-            'train.AdagradOptimizer', 'train.AdadeltaOptimizer'
+            'SGDOptimizer', 'MomentumOptimizer', 'AdagradOptimizer',
+            'AdadeltaOptimizer'
           ]
         }
       ]

--- a/website/scripts/api-parser.ts
+++ b/website/scripts/api-parser.ts
@@ -52,12 +52,16 @@ export function parse(): Docs {
           name: 'Creation',
           description: `This section describes how to construct tensors.`,
           pin: [
-            'tensor', 'Tensor', 'scalar', 'tensor1d', 'tensor2d', 'tensor3d',
-            'tensor4d'
+            'tensor', 'scalar', 'tensor1d', 'tensor2d', 'tensor3d', 'tensor4d'
           ]
         },
-        {name: 'Classes'}, {name: 'Transformations'},
-        {name: 'Slicing and Joining'}
+        {
+          name: 'Classes',
+          pin: [
+            'Tensor', 'Scalar', 'Tensor1D', 'Tensor2D', 'Tensor3D', 'Tensor4D'
+          ]
+        },
+        {name: 'Transformations'}, {name: 'Slicing and Joining'}
       ]
     },
     {

--- a/website/scripts/api-util.ts
+++ b/website/scripts/api-util.ts
@@ -165,7 +165,7 @@ export function sortMethods(docHeadings: DocHeading[]) {
           // Loop backwards so we remove symbols.
           for (let k = subheading.symbols.length - 1; k >= 0; k--) {
             const symbol = subheading.symbols[k];
-            if (symbol.displayName === pinnedSymbolName) {
+            if (symbol.symbolName === pinnedSymbolName) {
               pinnedSymbols.push(symbol);
               subheading.symbols.splice(k, 1);
             }
@@ -175,9 +175,9 @@ export function sortMethods(docHeadings: DocHeading[]) {
 
       // Sort non-pinned symbols by name.
       subheading.symbols.sort((a, b) => {
-        if (a.displayName < b.displayName) {
+        if (a.symbolName < b.symbolName) {
           return -1;
-        } else if (a.displayName > b.displayName) {
+        } else if (a.symbolName > b.symbolName) {
           return 1;
         }
         return 0;
@@ -369,11 +369,12 @@ export function linkSymbols(docs: Docs, toplevelNamespace: string) {
       subheading.symbols.forEach(symbol => {
         const namespace = toplevelNamespace + '.' +
             (symbol.namespace != null ? symbol.namespace + '.' : '');
+        symbol.displayName = namespace + symbol.symbolName;
 
         if (symbol['isClass'] != null) {
-          symbol.urlHash = `class:${toplevelNamespace}.${symbol.displayName}`;
+          symbol.urlHash = `class:${symbol.displayName}`;
         } else {
-          symbol.urlHash = toplevelNamespace + '.' + symbol.displayName;
+          symbol.urlHash = symbol.displayName;
         }
 
         symbols.push(symbol.symbolName);

--- a/website/scripts/api-util.ts
+++ b/website/scripts/api-util.ts
@@ -284,8 +284,7 @@ export function getIdentifierGenericMap(
   const identifierGenericMap = {};
 
   node.forEachChild(child => {
-    // TypeParameterDeclarations look like <T extends
-    // Tensor|NamedTensorMap>.
+    // TypeParameterDeclarations look like <T extends Tensor|NamedTensorMap>.
     if (ts.isTypeParameterDeclaration(child)) {
       let identifier;
       let generic;

--- a/website/scripts/api-util.ts
+++ b/website/scripts/api-util.ts
@@ -188,11 +188,6 @@ export function sortMethods(docHeadings: DocHeading[]) {
   }
 }
 
-// Returns display names like 'dl.train.Optimizer'.
-export function getDisplayName(docInfo: DocInfo, name: string) {
-  return (docInfo.namespace != null ? docInfo.namespace + '.' : '') + name;
-}
-
 export function kind(node: ts.Node): string {
   const keys = Object.keys(ts.SyntaxKind);
   for (let i = 0; i < keys.length; i++) {
@@ -250,7 +245,7 @@ export function parameterTypeToString(
   // node, falling back to using the checker to serialize the type.
   let typeStr;
   symbol.valueDeclaration.forEachChild(child => {
-    if (ts.isTypeNode(child) && child.kind != ts.SyntaxKind.NullKeyword) {
+    if (ts.isTypeNode(child) && child.kind !== ts.SyntaxKind.NullKeyword) {
       typeStr = child.getText();
     }
   });
@@ -362,4 +357,29 @@ export function replaceDocTypeAlias(
     }
   });
   return docTypeString;
+}
+
+// Link symbols together. This should be used outside of the parser.
+export function linkSymbols(docs: Docs, toplevelNamespace: string) {
+  console.log('--------linking------');
+  // Find all the symbols.
+  const symbols = [];
+  docs.headings.forEach(heading => {
+    heading.subheadings.forEach(subheading => {
+      subheading.symbols.forEach(symbol => {
+        const namespace = toplevelNamespace + '.' +
+            (symbol.namespace != null ? symbol.namespace + '.' : '');
+
+        if (symbol['isClass'] != null) {
+          symbol.urlHash = `class:${toplevelNamespace}.${symbol.displayName}`;
+        } else {
+          symbol.urlHash = toplevelNamespace + '.' + symbol.displayName;
+        }
+
+        symbols.push(symbol.symbolName);
+      });
+    });
+  });
+
+  const symbolUrls = [];
 }

--- a/website/scripts/api-util.ts
+++ b/website/scripts/api-util.ts
@@ -357,7 +357,11 @@ export interface SymbolAndUrl {
   symbolName: string;
   url: string;
 }
-// Link symbols together with markdown links.
+
+/**
+ * Adds markdown links for reference symbols in documentation, parameter types,
+ * and return types.
+ */
 export function linkSymbols(
     docs: Docs, symbols: SymbolAndUrl[], toplevelNamespace: string,
     docLinkAliases: {[symbolName: string]: string}) {

--- a/website/scripts/make-api.ts
+++ b/website/scripts/make-api.ts
@@ -37,9 +37,33 @@ const HTML_OUT_DIR = '/tmp/deeplearn-new-website/api/';
 
 shell.mkdir('-p', HTML_OUT_DIR);
 
-const docs = parser.parse();
+const {docs, docLinkAliases} = parser.parse();
 
-util.linkSymbols(docs, TOPLEVEL_NAMESPACE);
+// Predefine some custom type links.
+const symbols: util.SymbolAndUrl[] = [
+  {
+    symbolName: 'TypedArray',
+    url: 'https://developer.mozilla.org/en-US/docs/Web/' +
+        'JavaScript/Reference/Global_Objects/TypedArray'
+  },
+  {
+    symbolName: 'ImageData',
+    url: 'https://developer.mozilla.org/en-US/docs/Web/API/ImageData'
+  },
+  {
+    symbolName: 'HTMLImageElement',
+    url: 'https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement'
+  },
+  {
+    symbolName: 'HTMLCanvasElement',
+    url: 'https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement'
+  },
+  {
+    symbolName: 'HTMLVideoElement',
+    url: 'https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement'
+  }
+];
+util.linkSymbols(docs, symbols, TOPLEVEL_NAMESPACE, docLinkAliases);
 
 const md = new MarkdownIt();
 

--- a/website/scripts/make-api.ts
+++ b/website/scripts/make-api.ts
@@ -31,6 +31,7 @@ import * as ts from 'typescript';
 import * as parser from './api-parser';
 import * as util from './api-util';
 
+const TOPLEVEL_NAMESPACE = 'dl';
 const API_TEMPLATE_PATH = './website/api/index.html';
 const HTML_OUT_DIR = '/tmp/deeplearn-new-website/api/';
 
@@ -38,15 +39,17 @@ shell.mkdir('-p', HTML_OUT_DIR);
 
 const docs = parser.parse();
 
+util.linkSymbols(docs, TOPLEVEL_NAMESPACE);
+
 const md = new MarkdownIt();
 
 // Add some helper functions
-HandleBars.registerHelper('markdown', function(attr) {
+HandleBars.registerHelper('markdown', attr => {
   return md.render(attr);
 });
 
 // Renders a string to markdown but removes the outer <p> tag
-HandleBars.registerHelper('markdownInner', function(attr) {
+HandleBars.registerHelper('markdownInner', attr => {
   const asMd =
       md.render(attr.trim()).replace(/<p>/, '').replace(/(<\/p>\s*)$/, '');
 

--- a/website/scripts/make-api.ts
+++ b/website/scripts/make-api.ts
@@ -44,23 +44,28 @@ const symbols: util.SymbolAndUrl[] = [
   {
     symbolName: 'TypedArray',
     url: 'https://developer.mozilla.org/en-US/docs/Web/' +
-        'JavaScript/Reference/Global_Objects/TypedArray'
+        'JavaScript/Reference/Global_Objects/TypedArray',
+    type: 'class'
   },
   {
     symbolName: 'ImageData',
-    url: 'https://developer.mozilla.org/en-US/docs/Web/API/ImageData'
+    url: 'https://developer.mozilla.org/en-US/docs/Web/API/ImageData',
+    type: 'class'
   },
   {
     symbolName: 'HTMLImageElement',
-    url: 'https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement'
+    url: 'https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement',
+    type: 'class'
   },
   {
     symbolName: 'HTMLCanvasElement',
-    url: 'https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement'
+    url: 'https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement',
+    type: 'class'
   },
   {
     symbolName: 'HTMLVideoElement',
-    url: 'https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement'
+    url: 'https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement',
+    type: 'class'
   }
 ];
 util.linkSymbols(docs, symbols, TOPLEVEL_NAMESPACE, docLinkAliases);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,7 +6,7 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-1.1.0.tgz#93b1be91f63c184450385272c47b6496fd028e02"
 
-"@types/fetch-mock@^5.12.2":
+"@types/fetch-mock@~5.12.2":
   version "5.12.2"
   resolved "https://registry.yarnpkg.com/@types/fetch-mock/-/fetch-mock-5.12.2.tgz#8c96517ff74303031c65c5da2d99858e34c844d2"
 
@@ -75,7 +75,7 @@
   version "0.0.30"
   resolved "https://registry.yarnpkg.com/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz#9aa30c04db212a9a0649d6ae6fd50accc40748a1"
 
-"@types/utf8@^2.1.6":
+"@types/utf8@~2.1.6":
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/@types/utf8/-/utf8-2.1.6.tgz#430cabb71a42d0a3613cce5621324fe4f5a25753"
 
@@ -1300,7 +1300,7 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
-fetch-mock@^5.13.1:
+fetch-mock@~5.13.1:
   version "5.13.1"
   resolved "https://registry.yarnpkg.com/fetch-mock/-/fetch-mock-5.13.1.tgz#955794a77f3d972f1644b9ace65a0fdfd60f1df7"
   dependencies:
@@ -3705,7 +3705,7 @@ useragent@^2.1.12:
     lru-cache "2.2.x"
     tmp "0.0.x"
 
-utf8@^2.1.2:
+utf8@~2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/utf8/-/utf8-2.1.2.tgz#1fa0d9270e9be850d9b05027f63519bf46457d96"
 


### PR DESCRIPTION
This PR:
* Links symbols together in doc generator.
* Add @doclink jsdoc tag which allows you to have types with a name link to others. Used to link Tensor1D => Tensor, and other subclasses which will become aliases.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/710)
<!-- Reviewable:end -->
