### PR TITLE
Improve dl.time

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -54,7 +54,7 @@ export interface TensorManager {
 }
 
 export type MemoryInfo = {
-  numTensors: number; numDataBuffers: number; numBytes: number; backendInfo: {};
+  numTensors: number; numDataBuffers: number; numBytes: number;
   unreliable?: boolean;
 };
 
@@ -170,17 +170,11 @@ export class Engine implements TensorManager {
   }
 
   memory(): MemoryInfo {
-    const backendInfo = this.backend.memory();
-    const memInfo: MemoryInfo = {
-      numTensors: this.numTensors,
-      numDataBuffers: this.numDataBuffers,
-      numBytes: this.numBytes,
-      backendInfo,
-    };
-    if (backendInfo.unreliable) {
-      memInfo.unreliable = true;
-    }
-    return memInfo;
+    const info = this.backend.memory() as MemoryInfo;
+    info.numTensors = this.numTensors;
+    info.numDataBuffers = this.numDataBuffers;
+    info.numBytes = this.numBytes;
+    return info;
   }
 
   private shouldRecord(): boolean {

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -254,7 +254,6 @@ export class Environment {
    *    - On CPU, true. Due to automatic garbage collection, these numbers
    *     represent undisposed tensors, i.e. not wrapped in `dl.tidy()`, or
    *     lacking a call to `tensor.dispose()`.
-   * - `backendInfo`: Backend-specific information.
    */
   @doc({heading: 'Performance', subheading: 'Memory'})
   static memory(): MemoryInfo {

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,8 @@ export {AdamOptimizer} from './graph/optimizers/adam_optimizer';
 export {AdamaxOptimizer} from './graph/optimizers/adamax_optimizer';
 export {CostReduction, FeedEntry, Session} from './graph/session';
 export {MathBackendCPU, NDArrayMathCPU} from './kernels/backend_cpu';
-export {MathBackendWebGL, NDArrayMathGPU} from './kernels/backend_webgl';
+// tslint:disable-next-line:max-line-length
+export {MathBackendWebGL, NDArrayMathGPU, WebGLTimingInfo} from './kernels/backend_webgl';
 export {MatrixOrientation} from './kernels/types/matmul';
 export {GPGPUContext} from './kernels/webgl/gpgpu_context';
 export {NDArrayMath} from './math';

--- a/src/kernels/backend.ts
+++ b/src/kernels/backend.ts
@@ -22,7 +22,7 @@ import {DataId, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D} from '../tensor'
 import {DataType, Rank, TypedArray} from '../types';
 
 // Required information for all backends.
-export interface BackendTimingInfo { backendComputeMs: number; }
+export interface BackendTimingInfo { kernelMs: number; }
 
 export interface TensorStorage {
   read(dataId: DataId): Promise<TypedArray>;

--- a/src/kernels/backend.ts
+++ b/src/kernels/backend.ts
@@ -21,6 +21,9 @@ import {Conv2DInfo} from '../ops/conv_util';
 import {DataId, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D} from '../tensor';
 import {DataType, Rank, TypedArray} from '../types';
 
+// Required information for all backends.
+export interface BackendTimingInfo { backendComputeMs: number; }
+
 export interface TensorStorage {
   read(dataId: DataId): Promise<TypedArray>;
   readSync(dataId: DataId): TypedArray;
@@ -29,12 +32,13 @@ export interface TensorStorage {
   fromPixels(
       pixels: ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement,
       numChannels: number): Tensor3D;
-  time(query: () => void): Promise<number>;
   register(dataId: DataId, shape: number[], dtype: DataType): void;
   memory(): {unreliable: boolean;};  // Backend-specific information.
 }
 
-export interface BackendTimer { time(f: () => void): Promise<number>; }
+export interface BackendTimer {
+  time(f: () => void): Promise<BackendTimingInfo>;
+}
 
 /**
  * The interface that defines the kernels that should be implemented when

--- a/src/kernels/backend_cpu.ts
+++ b/src/kernels/backend_cpu.ts
@@ -16,6 +16,7 @@
  */
 
 import * as seedrandom from 'seedrandom';
+
 import {ENV} from '../environment';
 import {NDArrayMath} from '../math';
 import * as axis_util from '../ops/axis_util';
@@ -30,7 +31,8 @@ import {DataId, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D} from '../tensor'
 import * as types from '../types';
 import {DataType, DataTypeMap, Rank, TypedArray} from '../types';
 import * as util from '../util';
-import {KernelBackend} from './backend';
+
+import {BackendTimingInfo, KernelBackend} from './backend';
 
 export class MathBackendCPU implements KernelBackend {
   private data = new WeakMap<DataId, DataTypeMap[DataType]>();
@@ -117,10 +119,11 @@ export class MathBackendCPU implements KernelBackend {
     }
   }
 
-  async time(f: () => void): Promise<number> {
+  async time(f: () => void): Promise<BackendTimingInfo> {
     const start = performance.now();
     f();
-    return performance.now() - start;
+    const backendComputeMs = performance.now() - start;
+    return {backendComputeMs};
   }
   memory() {
     return {

--- a/src/kernels/backend_cpu.ts
+++ b/src/kernels/backend_cpu.ts
@@ -120,8 +120,8 @@ export class MathBackendCPU implements KernelBackend {
   async time(f: () => void): Promise<BackendTimingInfo> {
     const start = performance.now();
     f();
-    const backendComputeMs = performance.now() - start;
-    return {backendComputeMs};
+    const kernelMs = performance.now() - start;
+    return {kernelMs};
   }
   memory() {
     return {

--- a/src/kernels/backend_cpu.ts
+++ b/src/kernels/backend_cpu.ts
@@ -16,7 +16,6 @@
  */
 
 import * as seedrandom from 'seedrandom';
-
 import {ENV} from '../environment';
 import {NDArrayMath} from '../math';
 import * as axis_util from '../ops/axis_util';
@@ -31,7 +30,6 @@ import {DataId, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D} from '../tensor'
 import * as types from '../types';
 import {DataType, DataTypeMap, Rank, TypedArray} from '../types';
 import * as util from '../util';
-
 import {BackendTimingInfo, KernelBackend} from './backend';
 
 export class MathBackendCPU implements KernelBackend {

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -223,16 +223,15 @@ export class MathBackendWebGL implements KernelBackend {
       this.programTimersStack = null;
     }
 
-    const backendComputeMs =
-        await Promise.all(flattenedActiveTimers).then(results => {
-          let sum = 0;
-          results.forEach(result => sum += result);
-          return sum;
-        });
+    const kernelMs = await Promise.all(flattenedActiveTimers).then(results => {
+      let sum = 0;
+      results.forEach(result => sum += result);
+      return sum;
+    });
     const res: WebGLTimingInfo = {
       uploadWaitMs: this.uploadWaitMs,
       downloadWaitMs: this.downloadWaitMs,
-      backendComputeMs,
+      kernelMs,
       wallMs: null  // will be filled by the engine
     };
     this.uploadWaitMs = 0;

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -73,7 +73,8 @@ export interface CPUTimerQuery {
 }
 
 export interface WebGLTimingInfo extends TimingInfo {
-  backend: {uploadWaitMs: number; downloadWaitMs: number};
+  uploadWaitMs: number;
+  downloadWaitMs: number;
 }
 
 export class MathBackendWebGL implements KernelBackend {
@@ -229,10 +230,8 @@ export class MathBackendWebGL implements KernelBackend {
           return sum;
         });
     const res: WebGLTimingInfo = {
-      backend: {
-        uploadWaitMs: this.uploadWaitMs,
-        downloadWaitMs: this.downloadWaitMs,
-      },
+      uploadWaitMs: this.uploadWaitMs,
+      downloadWaitMs: this.downloadWaitMs,
       backendComputeMs,
       wallMs: null  // will be filled by the engine
     };

--- a/src/profiler.ts
+++ b/src/profiler.ts
@@ -15,12 +15,11 @@
  * =============================================================================
  */
 
-import * as util from './util';
-import {Tensor} from './tensor';
-import {TypedArray} from './types';
-
 import {BackendTimer} from './kernels/backend';
 import {Kernel} from './kernels/kernel_registry';
+import {Tensor} from './tensor';
+import {TypedArray} from './types';
+import * as util from './util';
 
 export class Profiler {
   constructor(private backendTimer: BackendTimer, private logger?: Logger) {
@@ -39,8 +38,9 @@ export class Profiler {
     const vals = result.dataSync();
     util.checkForNaN(vals, result.dtype, kernelName);
 
-    timer.then((timeMs: number) => {
-      this.logger.logKernelProfile(kernelName, result, vals, timeMs);
+    timer.then(timing => {
+      this.logger.logKernelProfile(
+          kernelName, result, vals, timing.backendComputeMs);
     });
 
     return result as T;

--- a/src/profiler.ts
+++ b/src/profiler.ts
@@ -39,8 +39,7 @@ export class Profiler {
     util.checkForNaN(vals, result.dtype, kernelName);
 
     timer.then(timing => {
-      this.logger.logKernelProfile(
-          kernelName, result, vals, timing.backendComputeMs);
+      this.logger.logKernelProfile(kernelName, result, vals, timing.kernelMs);
     });
 
     return result as T;

--- a/src/profiler_test.ts
+++ b/src/profiler_test.ts
@@ -28,10 +28,10 @@ class TestBackendTimer implements BackendTimer {
 
   async time(query: () => void): Promise<BackendTimingInfo> {
     query();
-    const backendComputeMs = await new Promise<number>(
+    const kernelMs = await new Promise<number>(
         resolve => setTimeout(
             resolve(this.queryTimeMs * this.counter++), this.delayMs));
-    return {backendComputeMs};
+    return {kernelMs};
   }
 }
 

--- a/src/profiler_test.ts
+++ b/src/profiler_test.ts
@@ -16,21 +16,22 @@
  */
 
 import * as dl from './index';
-import {Tensor} from './tensor';
-import {BackendTimer} from './kernels/backend';
+import {BackendTimer, BackendTimingInfo} from './kernels/backend';
 import {Kernel} from './kernels/kernel_registry';
-import {Logger, Profiler} from './profiler';
 import {TypedArray} from './kernels/webgl/tex_util';
+import {Logger, Profiler} from './profiler';
+import {Tensor} from './tensor';
 
 class TestBackendTimer implements BackendTimer {
   private counter = 1;
   constructor(private delayMs: number, private queryTimeMs: number) {}
 
-  time(query: () => void): Promise<number> {
+  async time(query: () => void): Promise<BackendTimingInfo> {
     query();
-    return new Promise<number>(
+    const backendComputeMs = await new Promise<number>(
         resolve => setTimeout(
             resolve(this.queryTimeMs * this.counter++), this.delayMs));
+    return {backendComputeMs};
   }
 }
 

--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -16,6 +16,7 @@
  */
 
 import {doc} from './doc';
+import {TimingInfo} from './engine';
 import {ENV} from './environment';
 // tslint:disable-next-line:max-line-length
 import {ScopeFn, ScopeResult, ScopeResultImmediate} from './tape_util';
@@ -93,7 +94,7 @@ export class Tracking {
    * @param f The function to execute and time.
    */
   @doc({heading: 'Performance', subheading: 'Timing'})
-  static time(f: () => void): Promise<number> {
+  static time(f: () => void): Promise<TimingInfo> {
     return ENV.engine.time(f);
   }
 }

--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -91,7 +91,7 @@ export class Tracking {
   /**
    * Executes `f()` and returns a promise that resolves with timing information.
    *
-   * The result is an object with the following properties (all times in ms):
+   * The result is an object with the following properties:
    *
    * - `wallMs`: wall execution time.
    * - `kernelMs`: kernel execution time, ignoring data transfer.

--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -89,8 +89,16 @@ export class Tracking {
   }
 
   /**
-   * Executes `f()` and returns a promise that resolves with the elapsed time of
-   * `f()` in milliseconds.
+   * Executes `f()` and returns a promise that resolves with timing information.
+   *
+   * The result is an object with the following properties (all times in ms):
+   *
+   * - `wallMs`: wall execution time.
+   * - `backendComputeMs`: kernel execution time, ignoring data transfer.
+   * - On `WebGL` the following additional properties exist:
+   *   - `uploadWaitMs`: cpu blocking time on texture uploads.
+   *   - `downloadWaitMs`: cpu blocking time on texture downloads (readPixels).
+   *
    * @param f The function to execute and time.
    */
   @doc({heading: 'Performance', subheading: 'Timing'})

--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -94,7 +94,7 @@ export class Tracking {
    * The result is an object with the following properties (all times in ms):
    *
    * - `wallMs`: wall execution time.
-   * - `backendComputeMs`: kernel execution time, ignoring data transfer.
+   * - `kernelMs`: kernel execution time, ignoring data transfer.
    * - On `WebGL` the following additional properties exist:
    *   - `uploadWaitMs`: cpu blocking time on texture uploads.
    *   - `downloadWaitMs`: cpu blocking time on texture downloads (readPixels).

--- a/src/tracking_test.ts
+++ b/src/tracking_test.ts
@@ -24,8 +24,8 @@ describeWithFlags('time webgl', WEBGL_ENVS, () => {
     const time = await dl.time(() => a.square()) as dl.WebGLTimingInfo;
     expect(time.uploadWaitMs > 0);
     expect(time.downloadWaitMs === 0);
-    expect(time.backendComputeMs > 0);
-    expect(time.wallMs >= time.backendComputeMs);
+    expect(time.kernelMs > 0);
+    expect(time.wallMs >= time.kernelMs);
   });
 
   it('upload + compute + dataSync', async () => {
@@ -34,8 +34,8 @@ describeWithFlags('time webgl', WEBGL_ENVS, () => {
         await dl.time(() => a.square().dataSync()) as dl.WebGLTimingInfo;
     expect(time.uploadWaitMs > 0);
     expect(time.downloadWaitMs > 0);
-    expect(time.backendComputeMs > 0);
-    expect(time.wallMs >= time.backendComputeMs);
+    expect(time.kernelMs > 0);
+    expect(time.wallMs >= time.kernelMs);
   });
 
   it('upload + compute + data', async () => {
@@ -44,8 +44,8 @@ describeWithFlags('time webgl', WEBGL_ENVS, () => {
         dl.WebGLTimingInfo;
     expect(time.uploadWaitMs > 0);
     expect(time.downloadWaitMs > 0);
-    expect(time.backendComputeMs > 0);
-    expect(time.wallMs >= time.backendComputeMs);
+    expect(time.kernelMs > 0);
+    expect(time.wallMs >= time.kernelMs);
   });
 
   it('preupload (not included) + compute + data', async () => {
@@ -56,8 +56,8 @@ describeWithFlags('time webgl', WEBGL_ENVS, () => {
     // The tensor was already on gpu.
     expect(time.uploadWaitMs === 0);
     expect(time.downloadWaitMs === 0);
-    expect(time.backendComputeMs > 0);
-    expect(time.wallMs >= time.backendComputeMs);
+    expect(time.kernelMs > 0);
+    expect(time.wallMs >= time.kernelMs);
   });
 });
 
@@ -65,7 +65,7 @@ describeWithFlags('time cpu', CPU_ENVS, () => {
   it('simple upload', async () => {
     const a = dl.zeros([10, 10]);
     const time = await dl.time(() => a.square());
-    expect(time.backendComputeMs > 0);
-    expect(time.wallMs >= time.backendComputeMs);
+    expect(time.kernelMs > 0);
+    expect(time.wallMs >= time.kernelMs);
   });
 });

--- a/src/tracking_test.ts
+++ b/src/tracking_test.ts
@@ -16,13 +16,12 @@
  */
 
 import * as dl from './index';
-import {WebGLTimingInfo} from './kernels/backend_webgl';
 import {CPU_ENVS, describeWithFlags, WEBGL_ENVS} from './test_util';
 
 describeWithFlags('time webgl', WEBGL_ENVS, () => {
   it('upload + compute', async () => {
     const a = dl.zeros([10, 10]);
-    const time = await dl.time(() => a.square()) as WebGLTimingInfo;
+    const time = await dl.time(() => a.square()) as dl.WebGLTimingInfo;
     expect(time.backend.uploadWaitMs > 0);
     expect(time.backend.downloadWaitMs === 0);
     expect(time.backendComputeMs > 0);
@@ -31,7 +30,8 @@ describeWithFlags('time webgl', WEBGL_ENVS, () => {
 
   it('upload + compute + dataSync', async () => {
     const a = dl.zeros([10, 10]);
-    const time = await dl.time(() => a.square().dataSync()) as WebGLTimingInfo;
+    const time =
+        await dl.time(() => a.square().dataSync()) as dl.WebGLTimingInfo;
     expect(time.backend.uploadWaitMs > 0);
     expect(time.backend.downloadWaitMs > 0);
     expect(time.backendComputeMs > 0);
@@ -40,8 +40,8 @@ describeWithFlags('time webgl', WEBGL_ENVS, () => {
 
   it('upload + compute + data', async () => {
     const a = dl.zeros([10, 10]);
-    const time =
-        await dl.time(async () => await a.square().data()) as WebGLTimingInfo;
+    const time = await dl.time(async () => await a.square().data()) as
+        dl.WebGLTimingInfo;
     expect(time.backend.uploadWaitMs > 0);
     expect(time.backend.downloadWaitMs > 0);
     expect(time.backendComputeMs > 0);
@@ -52,7 +52,7 @@ describeWithFlags('time webgl', WEBGL_ENVS, () => {
     const a = dl.zeros([10, 10]);
     // Pre-upload a on gpu.
     a.square();
-    const time = await dl.time(() => a.sqrt()) as WebGLTimingInfo;
+    const time = await dl.time(() => a.sqrt()) as dl.WebGLTimingInfo;
     // The tensor was already on gpu.
     expect(time.backend.uploadWaitMs === 0);
     expect(time.backend.downloadWaitMs === 0);

--- a/src/tracking_test.ts
+++ b/src/tracking_test.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import * as dl from './index';
+import {WebGLTimingInfo} from './kernels/backend_webgl';
+import {CPU_ENVS, describeWithFlags, WEBGL_ENVS} from './test_util';
+
+describeWithFlags('time webgl', WEBGL_ENVS, () => {
+  it('upload + compute', async () => {
+    const a = dl.zeros([10, 10]);
+    const time = await dl.time(() => a.square()) as WebGLTimingInfo;
+    expect(time.backend.uploadWaitMs > 0);
+    expect(time.backend.downloadWaitMs === 0);
+    expect(time.backendComputeMs > 0);
+    expect(time.wallMs >= time.backendComputeMs);
+  });
+
+  it('upload + compute + dataSync', async () => {
+    const a = dl.zeros([10, 10]);
+    const time = await dl.time(() => a.square().dataSync()) as WebGLTimingInfo;
+    expect(time.backend.uploadWaitMs > 0);
+    expect(time.backend.downloadWaitMs > 0);
+    expect(time.backendComputeMs > 0);
+    expect(time.wallMs >= time.backendComputeMs);
+  });
+
+  it('upload + compute + data', async () => {
+    const a = dl.zeros([10, 10]);
+    const time =
+        await dl.time(async () => await a.square().data()) as WebGLTimingInfo;
+    expect(time.backend.uploadWaitMs > 0);
+    expect(time.backend.downloadWaitMs > 0);
+    expect(time.backendComputeMs > 0);
+    expect(time.wallMs >= time.backendComputeMs);
+  });
+
+  it('preupload (not included) + compute + data', async () => {
+    const a = dl.zeros([10, 10]);
+    // Pre-upload a on gpu.
+    a.square();
+    const time = await dl.time(() => a.sqrt()) as WebGLTimingInfo;
+    // The tensor was already on gpu.
+    expect(time.backend.uploadWaitMs === 0);
+    expect(time.backend.downloadWaitMs === 0);
+    expect(time.backendComputeMs > 0);
+    expect(time.wallMs >= time.backendComputeMs);
+  });
+});
+
+describeWithFlags('time cpu', CPU_ENVS, () => {
+  it('simple upload', async () => {
+    const a = dl.zeros([10, 10]);
+    const time = await dl.time(() => a.square());
+    expect(time.backendComputeMs > 0);
+    expect(time.wallMs >= time.backendComputeMs);
+  });
+});

--- a/src/tracking_test.ts
+++ b/src/tracking_test.ts
@@ -22,8 +22,8 @@ describeWithFlags('time webgl', WEBGL_ENVS, () => {
   it('upload + compute', async () => {
     const a = dl.zeros([10, 10]);
     const time = await dl.time(() => a.square()) as dl.WebGLTimingInfo;
-    expect(time.backend.uploadWaitMs > 0);
-    expect(time.backend.downloadWaitMs === 0);
+    expect(time.uploadWaitMs > 0);
+    expect(time.downloadWaitMs === 0);
     expect(time.backendComputeMs > 0);
     expect(time.wallMs >= time.backendComputeMs);
   });
@@ -32,8 +32,8 @@ describeWithFlags('time webgl', WEBGL_ENVS, () => {
     const a = dl.zeros([10, 10]);
     const time =
         await dl.time(() => a.square().dataSync()) as dl.WebGLTimingInfo;
-    expect(time.backend.uploadWaitMs > 0);
-    expect(time.backend.downloadWaitMs > 0);
+    expect(time.uploadWaitMs > 0);
+    expect(time.downloadWaitMs > 0);
     expect(time.backendComputeMs > 0);
     expect(time.wallMs >= time.backendComputeMs);
   });
@@ -42,8 +42,8 @@ describeWithFlags('time webgl', WEBGL_ENVS, () => {
     const a = dl.zeros([10, 10]);
     const time = await dl.time(async () => await a.square().data()) as
         dl.WebGLTimingInfo;
-    expect(time.backend.uploadWaitMs > 0);
-    expect(time.backend.downloadWaitMs > 0);
+    expect(time.uploadWaitMs > 0);
+    expect(time.downloadWaitMs > 0);
     expect(time.backendComputeMs > 0);
     expect(time.wallMs >= time.backendComputeMs);
   });
@@ -54,8 +54,8 @@ describeWithFlags('time webgl', WEBGL_ENVS, () => {
     a.square();
     const time = await dl.time(() => a.sqrt()) as dl.WebGLTimingInfo;
     // The tensor was already on gpu.
-    expect(time.backend.uploadWaitMs === 0);
-    expect(time.backend.downloadWaitMs === 0);
+    expect(time.uploadWaitMs === 0);
+    expect(time.downloadWaitMs === 0);
     expect(time.backendComputeMs > 0);
     expect(time.wallMs >= time.backendComputeMs);
   });


### PR DESCRIPTION
`dl.time()` now returns an object with the following properties (all times in ms):
   - `wallMs`: wall execution time.
   - `kernelMs`: kernel execution time, ignoring data transfer.
   - On `WebGL` the following additional properties exist:
     - `uploadWaitMs`: cpu blocking time on texture uploads.
     - `downloadWaitMs`: cpu blocking time on texture downloads (readPixels).
 
Also update MemoryInfo to be a flat object, that is backends add backend specific properties to the top-level object.

Fixes #667

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/715)
<!-- Reviewable:end -->
