### PR TITLE
Fixes adam optimizer to wrap variable construction in tidy() and assert 1 remaining tensor in unit tests.

### DIFF
--- a/src/optimizers/adam_optimizer.ts
+++ b/src/optimizers/adam_optimizer.ts
@@ -52,9 +52,11 @@ export class AdamOptimizer extends Optimizer {
     // b1, b2 keep initial value of beta* hyperparameters.
     this.beta1 = keep(scalar(beta1));
     this.beta2 = keep(scalar(beta2));
-    // accB* will be updated by batch.
-    this.accBeta1 = variable(scalar(beta1));
-    this.accBeta2 = variable(scalar(beta2));
+    tidy(() => {
+      // accB* will be updated by batch.
+      this.accBeta1 = variable(scalar(beta1));
+      this.accBeta2 = variable(scalar(beta2));
+    });
     this.oneMinusBeta1 = keep(scalar(1 - beta1));
     this.oneMinusBeta2 = keep(scalar(1 - beta2));
     this.one = keep(scalar(1));

--- a/src/optimizers/adam_optimizer_test.ts
+++ b/src/optimizers/adam_optimizer_test.ts
@@ -79,8 +79,8 @@ describeWithFlags('AdamOptimizer', ALL_ENVS, () => {
     x.dispose();
     optimizer.dispose();
 
-    // There should be no more Tensors.
-    expect(dl.memory().numTensors).toBe(0);
+    // The only tensor remaining should be the argument to variable().
+    expect(dl.memory().numTensors).toBe(1);
   });
 
   it('graph', () => {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/717)
<!-- Reviewable:end -->
