### PR TITLE
Fixes documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ we provide CPU fallbacks.
 ## Resources
 
 * [Tutorials](https://deeplearnjs.org/docs/tutorials/index.html)
-* [API Reference](https://deeplearnjs.org/docs/api/globals.html)
+* [API Reference](https://deeplearnjs.org/docs/api/index.html)
 * [Demos](https://deeplearnjs.org/index.html#demos)
 * [Roadmap](https://deeplearnjs.org/docs/roadmap.html)
 


### PR DESCRIPTION
This PR fixes documentation link in `README.md`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/745)
<!-- Reviewable:end -->
