### PR TITLE
Add tensor.toString()

### DIFF
--- a/src/ops/array_ops.ts
+++ b/src/ops/array_ops.ts
@@ -19,9 +19,11 @@ import {doc} from '../doc';
 import {ENV} from '../environment';
 // tslint:disable-next-line:max-line-length
 import {Scalar, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D, TensorBuffer} from '../tensor';
+import * as tensor_util from '../tensor_util';
 // tslint:disable-next-line:max-line-length
 import {ArrayData, DataType, DataTypeMap, Rank, ShapeMap, TensorLike, TensorLike1D, TensorLike2D, TensorLike3D, TensorLike4D, TypedArray} from '../types';
 import * as util from '../util';
+
 import {Concat} from './concat';
 import {operation} from './operation';
 import {MPRandGauss} from './rand';
@@ -955,38 +957,7 @@ export class Ops {
    */
   @doc({heading: 'Tensors', subheading: 'Creation'})
   static print<T extends Tensor>(x: T, verbose = false): void {
-    const C = class Tensor {
-      shape: number[];
-      values: number[];
-      dtype: string;
-      size: number;
-    };
-
-    const displayTensor = new C();
-    displayTensor.shape = x.shape;
-    displayTensor.values = Array.from(x.dataSync());
-    displayTensor.toString = function() {
-      const fields = [
-        `values: [${this.values.join(', ')}]`, `shape: [${x.shape.join(', ')}]`,
-        `rank: ${x.rank}`
-      ];
-      if (verbose) {
-        fields.push(`dtype: '${this.dtype}'`);
-        fields.push(`size: ${this.size}`);
-      }
-      for (let i = 0; i < fields.length; i++) {
-        fields[i] = '  ' + fields[i];
-      }
-
-      return 'TensorInfo {\n' + fields.join(',\n') + '\n}';
-    };
-
-    if (verbose) {
-      displayTensor.dtype = x.dtype;
-      displayTensor.size = x.size;
-    }
-
-    console.log(displayTensor);
+    console.log(tensor_util.tensorToString(x));
   }
 }
 

--- a/src/ops/array_ops.ts
+++ b/src/ops/array_ops.ts
@@ -957,7 +957,7 @@ export class Ops {
    */
   @doc({heading: 'Tensors', subheading: 'Creation'})
   static print<T extends Tensor>(x: T, verbose = false): void {
-    console.log(tensor_util.tensorToString(x));
+    console.log(tensor_util.tensorToString(x, verbose));
   }
 }
 

--- a/src/tensor.ts
+++ b/src/tensor.ts
@@ -19,6 +19,7 @@ import {doc} from './doc';
 import {ENV} from './environment';
 import * as ops from './ops/ops';
 import {RandNormalDataTypes} from './ops/rand';
+import * as tensor_util from './tensor_util';
 import {DataType, DataTypeMap, Rank, ShapeMap, TypedArray} from './types';
 import * as util from './util';
 
@@ -492,6 +493,12 @@ export class Tensor<R extends Rank = Rank> {
   clone<T extends Tensor>(this: T): T {
     this.throwIfDisposed();
     return ops.clone(this);
+  }
+
+  /** Returns a human-readable description of the tensor. Useful for logging. */
+  @doc({heading: 'Tensors', subheading: 'Classes'})
+  toString(): string {
+    return tensor_util.tensorToString(this);
   }
 
   // Below is chain API that is not exposed to docs to avoid repetition. To

--- a/src/tensor.ts
+++ b/src/tensor.ts
@@ -498,7 +498,7 @@ export class Tensor<R extends Rank = Rank> {
   /** Returns a human-readable description of the tensor. Useful for logging. */
   @doc({heading: 'Tensors', subheading: 'Classes'})
   toString(): string {
-    return tensor_util.tensorToString(this, true);
+    return tensor_util.tensorToString(this, true /* verbose */);
   }
 
   // Below is chain API that is not exposed to docs to avoid repetition. To

--- a/src/tensor.ts
+++ b/src/tensor.ts
@@ -498,7 +498,7 @@ export class Tensor<R extends Rank = Rank> {
   /** Returns a human-readable description of the tensor. Useful for logging. */
   @doc({heading: 'Tensors', subheading: 'Classes'})
   toString(): string {
-    return tensor_util.tensorToString(this);
+    return tensor_util.tensorToString(this, true);
   }
 
   // Below is chain API that is not exposed to docs to avoid repetition. To

--- a/src/tensor_test.ts
+++ b/src/tensor_test.ts
@@ -822,23 +822,101 @@ describeWithFlags('tensor', ALL_ENVS, () => {
 });
 
 describe('tensor.toString', () => {
+  it('scalar', () => {
+    const str = dl.scalar(5).toString();
+    expect(str).toEqual(
+        'Tensor\n' +
+        '  dtype: float32\n' +
+        '  rank: 0\n' +
+        '  shape: []\n' +
+        '  values:\n' +
+        '    5');
+  });
+
   it('1d tensor', () => {
-    const a = dl.zeros([4]);
-    console.log(a.toString());
+    const str = dl.zeros([4]).toString();
+    expect(str).toEqual(
+        'Tensor\n' +
+        '  dtype: float32\n' +
+        '  rank: 1\n' +
+        '  shape: [4]\n' +
+        '  values:\n' +
+        '    [0, 0, 0, 0]');
   });
 
   it('2d tensor', () => {
-    const a = dl.linspace(0, 100, 9).reshape([3, 3]);
-    console.log(a.toString());
+    const str = dl.zeros([3, 3]).toString();
+    expect(str).toEqual(
+        'Tensor\n' +
+        '  dtype: float32\n' +
+        '  rank: 2\n' +
+        '  shape: [3,3]\n' +
+        '  values:\n' +
+        '    [[0, 0, 0],\n' +
+        '     [0, 0, 0],\n' +
+        '     [0, 0, 0]]');
   });
 
   it('3d tensor', () => {
-    const a = dl.zeros([3, 3, 2]);
-    console.log(a.toString());
+    const str = dl.zeros([3, 3, 2]).toString();
+    expect(str).toEqual(
+        'Tensor\n' +
+        '  dtype: float32\n' +
+        '  rank: 3\n' +
+        '  shape: [3,3,2]\n' +
+        '  values:\n' +
+        '    [[[0, 0],\n' +
+        '      [0, 0],\n' +
+        '      [0, 0]],\n\n' +
+        '     [[0, 0],\n' +
+        '      [0, 0],\n' +
+        '      [0, 0]],\n\n' +
+        '     [[0, 0],\n' +
+        '      [0, 0],\n' +
+        '      [0, 0]]]');
   });
 
-  it('4d tensor', () => {
-    const a = dl.zeros([3, 3, 2, 2]);
-    console.log(a.toString());
+  it('1d long tensor', () => {
+    const str = dl.zeros([100]).toString();
+    expect(str).toEqual(
+        'Tensor\n' +
+        '  dtype: float32\n' +
+        '  rank: 1\n' +
+        '  shape: [100]\n' +
+        '  values:\n' +
+        '    [0, 0, 0, ..., 0, 0, 0]');
+  });
+
+  it('2d long tensor', () => {
+    const str = dl.zeros([100, 100]).toString();
+    expect(str).toEqual(
+        'Tensor\n' +
+        '  dtype: float32\n' +
+        '  rank: 2\n' +
+        '  shape: [100,100]\n' +
+        '  values:\n' +
+        '    [[0, 0, 0, ..., 0, 0, 0],\n' +
+        '     [0, 0, 0, ..., 0, 0, 0],\n' +
+        '     [0, 0, 0, ..., 0, 0, 0],\n' +
+        '     ...,\n' +
+        '     [0, 0, 0, ..., 0, 0, 0],\n' +
+        '     [0, 0, 0, ..., 0, 0, 0],\n' +
+        '     [0, 0, 0, ..., 0, 0, 0]]');
+  });
+
+  it('2d with padding to align columns', () => {
+    const str = dl.tensor([
+                    [0.8597712, 3, 0.2740789], [0.6696132, 0.4825962, 2.75],
+                    [1.991, 0.0640865, 0.2983858]
+                  ]).toString();
+    expect(str).toEqual(
+        'Tensor\n' +
+        '  dtype: float32\n' +
+        '  rank: 2\n' +
+        '  shape: [3,3]\n' +
+        '  values:\n' +
+        '    [[0.8597712, 3        , 0.2740789],\n' +
+        '     [0.6696132, 0.4825962, 2.75     ],\n' +
+        '     [1.9910001, 0.0640865, 0.2983858]]');
   });
 });

--- a/src/tensor_test.ts
+++ b/src/tensor_test.ts
@@ -820,3 +820,25 @@ describeWithFlags('tensor', ALL_ENVS, () => {
     expect(b.shape).toEqual([4]);
   });
 });
+
+describe('tensor.toString', () => {
+  it('1d tensor', () => {
+    const a = dl.zeros([4]);
+    console.log(a.toString());
+  });
+
+  it('2d tensor', () => {
+    const a = dl.linspace(0, 100, 9).reshape([3, 3]);
+    console.log(a.toString());
+  });
+
+  it('3d tensor', () => {
+    const a = dl.zeros([3, 3, 2]);
+    console.log(a.toString());
+  });
+
+  it('4d tensor', () => {
+    const a = dl.zeros([3, 3, 2, 2]);
+    console.log(a.toString());
+  });
+});

--- a/src/tensor_util.ts
+++ b/src/tensor_util.ts
@@ -69,7 +69,7 @@ function subTensorToString(
   const size = shape[0];
   const rank = shape.length;
   if (rank === 0) {
-    return [vals[0] + ''];
+    return [vals[0].toString()];
   }
 
   if (rank === 1) {

--- a/src/tensor_util.ts
+++ b/src/tensor_util.ts
@@ -124,14 +124,17 @@ function computeMaxSizePerColumn(t: Tensor): number[] {
   return padPerCol;
 }
 
-export function tensorToString(t: Tensor) {
+export function tensorToString(t: Tensor, verbose: boolean) {
   const vals = t.dataSync();
   const padPerCol = computeMaxSizePerColumn(t);
   const valsLines = subTensorToString(vals, t.shape, t.strides, padPerCol);
-  const lines = [
-    'Tensor', `  dtype: ${t.dtype}`, `  rank: ${t.rank}`,
-    `  shape: [${t.shape}]`, `  values:`,
-    valsLines.map(l => '    ' + l).join('\n')
-  ];
+  const lines = ['Tensor'];
+  if (verbose) {
+    lines.push(`  dtype: ${t.dtype}`);
+    lines.push(`  rank: ${t.rank}`);
+    lines.push(`  shape: [${t.shape}]`);
+    lines.push(`  values:`);
+  }
+  lines.push(valsLines.map(l => '    ' + l).join('\n'));
   return lines.join('\n');
 }

--- a/src/tensor_util.ts
+++ b/src/tensor_util.ts
@@ -20,11 +20,11 @@ import {TypedArray} from './types';
 import * as util from './util';
 
 // Maximum number of values before we decide to show ellipsis.
-const LIMIT_NUM_VALS = 20;
+const FORMAT_LIMIT_NUM_VALS = 20;
 // Number of first and last values to show when displaying a, b,...,y, z.
-const NUM_FIRST_LAST_VALS = 3;
+const FORMAT_NUM_FIRST_LAST_VALS = 3;
 // Number of significant digits to show.
-const NUM_SIG_DIGITS = 7;
+const FORMAT_NUM_SIG_DIGITS = 7;
 
 export function tensorToString(t: Tensor, verbose: boolean) {
   const vals = t.dataSync();
@@ -60,7 +60,8 @@ function computeMaxSizePerColumn(t: Tensor): number[] {
 }
 
 function valToString(val: number, pad: number) {
-  return util.rightPad(parseFloat(val.toFixed(NUM_SIG_DIGITS)).toString(), pad);
+  return util.rightPad(
+      parseFloat(val.toFixed(FORMAT_NUM_SIG_DIGITS)).toString(), pad);
 }
 
 function subTensorToString(
@@ -73,17 +74,18 @@ function subTensorToString(
   }
 
   if (rank === 1) {
-    if (size > LIMIT_NUM_VALS) {
-      const firstVals = Array.from(vals.subarray(0, NUM_FIRST_LAST_VALS));
+    if (size > FORMAT_LIMIT_NUM_VALS) {
+      const firstVals =
+          Array.from(vals.subarray(0, FORMAT_NUM_FIRST_LAST_VALS));
       const lastVals =
-          Array.from(vals.subarray(size - NUM_FIRST_LAST_VALS, size));
+          Array.from(vals.subarray(size - FORMAT_NUM_FIRST_LAST_VALS, size));
       return [
         '[' + firstVals.map((x, i) => valToString(x, padPerCol[i])).join(', ') +
         ', ..., ' +
         lastVals
             .map(
-                (x, i) =>
-                    valToString(x, padPerCol[size - NUM_FIRST_LAST_VALS + i]))
+                (x, i) => valToString(
+                    x, padPerCol[size - FORMAT_NUM_FIRST_LAST_VALS + i]))
             .join(', ') +
         ']'
       ];
@@ -100,8 +102,8 @@ function subTensorToString(
   const substrides = strides.slice(1);
   const stride = strides[0];
   const lines: string[] = [];
-  if (size > LIMIT_NUM_VALS) {
-    for (let i = 0; i < NUM_FIRST_LAST_VALS; i++) {
+  if (size > FORMAT_LIMIT_NUM_VALS) {
+    for (let i = 0; i < FORMAT_NUM_FIRST_LAST_VALS; i++) {
       const start = i * stride;
       const end = start + stride;
       lines.push(...subTensorToString(
@@ -109,7 +111,7 @@ function subTensorToString(
           false /* isLast */));
     }
     lines.push('...');
-    for (let i = size - NUM_FIRST_LAST_VALS; i < size; i++) {
+    for (let i = size - FORMAT_NUM_FIRST_LAST_VALS; i < size; i++) {
       const start = i * stride;
       const end = start + stride;
       lines.push(...subTensorToString(

--- a/src/tensor_util.ts
+++ b/src/tensor_util.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {Tensor} from './tensor';
+import {TypedArray} from './types';
+
+const LIMIT_NUM_VALS = 20;
+
+function subTensorToString(
+    vals: TypedArray, shape: number[], strides: number[], depth = 0,
+    isFirst = true): string {
+  const size = shape[0];
+  const rank = shape.length;
+  let prefix = '';
+  if (!isFirst) {
+    for (let i = 0; i < depth; i++) {
+      prefix += ' ';
+    }
+  }
+  if (rank <= 1) {
+    return prefix + '[' + vals.join(', ') + ']';
+  }
+  const subshape = shape.slice(1);
+  const substrides = strides.slice(1);
+  const stride = strides[0];
+  const elems = [];
+  for (let i = 0; i < size; i++) {
+    const start = i * stride;
+    const end = start + stride;
+    elems.push(subTensorToString(
+        vals.subarray(start, end), subshape, substrides, depth + 1, i === 0));
+  }
+  let newlineSep = '';
+  for (let i = 1; i < rank; i++) {
+    newlineSep += '\n';
+  }
+  return prefix + '[' + elems.join(',' + newlineSep) + ']';
+}
+
+export function tensorToString(t: Tensor) {
+  const vals = t.dataSync();
+  const lines = [
+    'Tensor', `  dtype: ${t.dtype}`, `  rank: ${t.rank}`, `  shape: ${t.shape}`,
+    `  values:`, subTensorToString(vals, t.shape, t.strides)
+  ];
+  return lines.join('\n');
+}


### PR DESCRIPTION
tensor.toString() returns a multi-line string that prints the dtype, shape, and the values with numpy-style formatting.

Does ellipsis when too many elements:
```
dl.zeros([100,100]).toString()
"Tensor
  dtype: float32
  rank: 2
  shape: [100,100]
  values:
    [[0, 0, 0, ..., 0, 0, 0],
     [0, 0, 0, ..., 0, 0, 0],
     [0, 0, 0, ..., 0, 0, 0],
     ...,
     [0, 0, 0, ..., 0, 0, 0],
     [0, 0, 0, ..., 0, 0, 0],
     [0, 0, 0, ..., 0, 0, 0]]"
```

Does column alignment with padding:
```
dl.randomUniform([2, 2]).toString()
"Tensor
  dtype: float32
  rank: 2
  shape: [2,2]
  values:
    [[0.56943  , 0.1292416],
     [0.7907254, 0.0305711]]"
```
Fixes #738

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/748)
<!-- Reviewable:end -->
