### PR TITLE
Update typescript compiler to newest (2.7.2)

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -15,8 +15,10 @@
         }
       },
       {
-        "type": "npm",
-        "script": "build",
+        "command": "yarn",
+        "label": "build",
+        "type": "shell",
+        "args": ["build", "--pretty", "false"],
         "problemMatcher": [
           "$tsc"
         ]

--- a/demos/package.json
+++ b/demos/package.json
@@ -74,7 +74,7 @@
     "polymer-bundler": "~3.0.1",
     "tone-piano": "0.0.5",
     "tsify": "~3.0.3",
-    "typescript": "2.6.1",
+    "typescript": "2.7.2",
     "uglifyjs": "~2.4.11",
     "watchify": "~3.9.0"
   },

--- a/demos/yarn.lock
+++ b/demos/yarn.lock
@@ -6491,9 +6491,9 @@ typedarray@^0.0.6, typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.1.tgz#ef39cdea27abac0b500242d6726ab90e0c846631"
+typescript@2.7.2:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
 
 typical@^2.6.0:
   version "2.6.1"

--- a/models/knn_image_classifier/package.json
+++ b/models/knn_image_classifier/package.json
@@ -22,7 +22,7 @@
     "mkdirp": "~0.5.1",
     "tsify": "~3.0.3",
     "tslint": "~5.8.0",
-    "typescript": "~2.6.1",
+    "typescript": "2.7.2",
     "uglifyjs": "~2.4.11",
     "watchify": "~3.9.0"
   },

--- a/models/knn_image_classifier/yarn.lock
+++ b/models/knn_image_classifier/yarn.lock
@@ -1970,9 +1970,9 @@ typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@~2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.1.tgz#ef39cdea27abac0b500242d6726ab90e0c846631"
+typescript@2.7.2:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
 
 uglifyjs@~2.4.11:
   version "2.4.11"

--- a/models/mobilenet/package.json
+++ b/models/mobilenet/package.json
@@ -19,7 +19,7 @@
     "mkdirp": "~0.5.1",
     "tsify": "~3.0.3",
     "tslint": "~5.8.0",
-    "typescript": "~2.6.1",
+    "typescript": "2.7.2",
     "uglifyjs": "~2.4.11",
     "watchify": "~3.9.0"
   },

--- a/models/mobilenet/yarn.lock
+++ b/models/mobilenet/yarn.lock
@@ -1970,9 +1970,9 @@ typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@~2.6.1:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.2.tgz#3c5b6fd7f6de0914269027f03c0946758f7673a4"
+typescript@2.7.2:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
 
 uglifyjs@~2.4.11:
   version "2.4.11"

--- a/models/squeezenet/package.json
+++ b/models/squeezenet/package.json
@@ -19,7 +19,7 @@
     "mkdirp": "~0.5.1",
     "tsify": "~3.0.3",
     "tslint": "~5.8.0",
-    "typescript": "~2.6.1",
+    "typescript": "2.7.2",
     "uglifyjs": "~2.4.11",
     "watchify": "~3.9.0"
   },

--- a/models/squeezenet/yarn.lock
+++ b/models/squeezenet/yarn.lock
@@ -1970,9 +1970,9 @@ typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@~2.6.1:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.2.tgz#3c5b6fd7f6de0914269027f03c0946758f7673a4"
+typescript@2.7.2:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
 
 uglifyjs@~2.4.11:
   version "2.4.11"

--- a/models/yolo_mobilenet/package.json
+++ b/models/yolo_mobilenet/package.json
@@ -19,7 +19,7 @@
     "mkdirp": "~0.5.1",
     "tsify": "~3.0.3",
     "tslint": "~5.8.0",
-    "typescript": "~2.6.1",
+    "typescript": "2.7.2",
     "uglifyjs": "~2.4.11",
     "watchify": "~3.9.0"
   },

--- a/models/yolo_mobilenet/yarn.lock
+++ b/models/yolo_mobilenet/yarn.lock
@@ -1970,9 +1970,9 @@ typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@~2.6.1:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.2.tgz#3c5b6fd7f6de0914269027f03c0946758f7673a4"
+typescript@2.7.2:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
 
 uglifyjs@~2.4.11:
   version "2.4.11"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "tsify": "~3.0.1",
     "tslint": "~5.8.0",
     "tslint-no-circular-imports": "~0.2.0",
-    "typescript": "2.6.1",
+    "typescript": "2.7.2",
     "uglify-js": "~3.0.28",
     "watchify": "~3.9.0"
   },

--- a/src/ops/array_ops_test.ts
+++ b/src/ops/array_ops_test.ts
@@ -538,7 +538,7 @@ describeWithFlags('rand', ALL_ENVS, () => {
   });
 
   it('should return a random 2D float32 array', () => {
-    const shape: [number] = [3, 4];
+    const shape = [3, 4];
 
     // Enusre defaults to float32 w/o type:
     let result = dl.rand(shape, () => util.randUniform(0, 2.5));
@@ -551,21 +551,21 @@ describeWithFlags('rand', ALL_ENVS, () => {
   });
 
   it('should return a random 2D int32 array', () => {
-    const shape: [number] = [3, 4];
+    const shape = [3, 4];
     const result = dl.rand(shape, () => util.randUniform(0, 2), 'int32');
     expect(result.dtype).toBe('int32');
     expectValuesInRange(result, 0, 2);
   });
 
   it('should return a random 2D bool array', () => {
-    const shape: [number] = [3, 4];
+    const shape = [3, 4];
     const result = dl.rand(shape, () => util.randUniform(0, 1), 'bool');
     expect(result.dtype).toBe('bool');
     expectValuesInRange(result, 0, 1);
   });
 
   it('should return a random 3D float32 array', () => {
-    const shape: [number] = [3, 4, 5];
+    const shape = [3, 4, 5];
 
     // Enusre defaults to float32 w/o type:
     let result = dl.rand(shape, () => util.randUniform(0, 2.5));
@@ -578,21 +578,21 @@ describeWithFlags('rand', ALL_ENVS, () => {
   });
 
   it('should return a random 3D int32 array', () => {
-    const shape: [number] = [3, 4, 5];
+    const shape = [3, 4, 5];
     const result = dl.rand(shape, () => util.randUniform(0, 2), 'int32');
     expect(result.dtype).toBe('int32');
     expectValuesInRange(result, 0, 2);
   });
 
   it('should return a random 3D bool array', () => {
-    const shape: [number] = [3, 4, 5];
+    const shape = [3, 4, 5];
     const result = dl.rand(shape, () => util.randUniform(0, 1), 'bool');
     expect(result.dtype).toBe('bool');
     expectValuesInRange(result, 0, 1);
   });
 
   it('should return a random 4D float32 array', () => {
-    const shape: [number] = [3, 4, 5, 6];
+    const shape = [3, 4, 5, 6];
 
     // Enusre defaults to float32 w/o type:
     let result = dl.rand(shape, () => util.randUniform(0, 2.5));
@@ -605,14 +605,14 @@ describeWithFlags('rand', ALL_ENVS, () => {
   });
 
   it('should return a random 4D int32 array', () => {
-    const shape: [number] = [3, 4, 5, 6];
+    const shape = [3, 4, 5, 6];
     const result = dl.rand(shape, () => util.randUniform(0, 2), 'int32');
     expect(result.dtype).toBe('int32');
     expectValuesInRange(result, 0, 2);
   });
 
   it('should return a random 4D bool array', () => {
-    const shape: [number] = [3, 4, 5, 6];
+    const shape = [3, 4, 5, 6];
     const result = dl.rand(shape, () => util.randUniform(0, 1), 'bool');
     expect(result.dtype).toBe('bool');
     expectValuesInRange(result, 0, 1);

--- a/src/ops/multinomial_test.ts
+++ b/src/ops/multinomial_test.ts
@@ -99,8 +99,8 @@ describeWithFlags('multinomial', ALL_ENVS, () => {
   });
 
   it('passing Tensor3D throws error', () => {
-    const probs = dl.zeros([3, 2, 2]) as Tensor1D;
-    expect(() => multinomial(probs, 3)).toThrowError();
+    const probs = dl.zeros([3, 2, 2]);
+    expect(() => multinomial(probs as Tensor1D, 3)).toThrowError();
   });
 
   function computeProbs(

--- a/src/ops/pad_test.ts
+++ b/src/ops/pad_test.ts
@@ -55,7 +55,8 @@ describeWithFlags('pad1d', ALL_ENVS, () => {
   it('Should handle invalid paddings', () => {
     const a = dl.tensor1d([1, 2, 3, 4], 'int32');
     const f = () => {
-      dl.pad1d(a, [2, 2, 2]);
+      // tslint:disable-next-line:no-any
+      dl.pad1d(a, [2, 2, 2] as any);
     };
     expect(f).toThrowError();
   });
@@ -122,7 +123,8 @@ describeWithFlags('pad2d', ALL_ENVS, () => {
   it('Should handle invalid paddings', () => {
     const a = dl.tensor2d([[1], [2]], [2, 1], 'int32');
     const f = () => {
-      dl.pad2d(a, [[2, 2, 2], [1, 1, 1]]);
+      // tslint:disable-next-line:no-any
+      dl.pad2d(a, [[2, 2, 2], [1, 1, 1]] as any);
     };
     expect(f).toThrowError();
   });

--- a/src/tensor_test.ts
+++ b/src/tensor_test.ts
@@ -60,7 +60,8 @@ describeWithFlags('tensor', ALL_ENVS, () => {
     expect(t.shape).toEqual([3]);
     expectNumbersClose(t.get(1), 3);
 
-    expect(() => dl.tensor3d([1, 2], [1, 2, 3, 5])).toThrowError();
+    // tslint:disable-next-line:no-any
+    expect(() => dl.tensor3d([1, 2], [1, 2, 3, 5] as any)).toThrowError();
 
     const t4 = dl.tensor4d([1, 2, 3, 4], [1, 2, 1, 2]);
     expectNumbersClose(t4.get(0, 0, 0, 0), 1);

--- a/starter/typescript/package.json
+++ b/starter/typescript/package.json
@@ -9,7 +9,7 @@
     "mkdirp": "~0.5.1",
     "tsify": "~3.0.3",
     "tslint": "~5.8.0",
-    "typescript": "~2.6.1",
+    "typescript": "2.7.2",
     "uglifyjs": "~2.4.11",
     "watchify": "~3.9.0"
   },

--- a/starter/typescript/yarn.lock
+++ b/starter/typescript/yarn.lock
@@ -1778,9 +1778,9 @@ typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@~2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.1.tgz#ef39cdea27abac0b500242d6726ab90e0c846631"
+typescript@2.7.2:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
 
 uglifyjs@~2.4.11:
   version "2.4.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3517,9 +3517,9 @@ typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.1.tgz#ef39cdea27abac0b500242d6726ab90e0c846631"
+typescript@2.7.2:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
 
 typescript@^2.5.2:
   version "2.6.2"


### PR DESCRIPTION
Newest compiler (2.7,2) has improved inference.

An example: [1, 2, 3] is no longer assignable to [number, number], because the length property doesn't match). Fixes a few instances of that kind in our codebase.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/749)
<!-- Reviewable:end -->
