### PR TITLE
Add support for calculating convolution parameters when using atrous/dilated convolution

### DIFF
--- a/src/ops/conv_util_test.ts
+++ b/src/ops/conv_util_test.ts
@@ -21,8 +21,9 @@ describe('conv_util computeConvInfo', () => {
   it('1x1 conv over 1x1 array with same pad', () => {
     const inShape: [number, number, number, number] = [1, 1, 1, 1];
     const stride = 1;
-    const convInfo =
-        conv_util.computeConv2DInfo(inShape, [1, 1, 1, 1], stride, 'same');
+    const dilation = 1;
+    const convInfo = conv_util.computeConv2DInfo(
+        inShape, [1, 1, 1, 1], stride, dilation, 'same');
     expect(convInfo.batchSize).toEqual(1);
     expect(convInfo.outHeight).toEqual(1);
     expect(convInfo.outWidth).toEqual(1);
@@ -32,8 +33,9 @@ describe('conv_util computeConvInfo', () => {
   it('2x2 conv over 3x3 array with same pad', () => {
     const inShape: [number, number, number, number] = [1, 3, 3, 1];
     const stride = 1;
-    const convInfo =
-        conv_util.computeConv2DInfo(inShape, [2, 2, 1, 1], stride, 'same');
+    const dilation = 1;
+    const convInfo = conv_util.computeConv2DInfo(
+        inShape, [2, 2, 1, 1], stride, dilation, 'same');
     expect(convInfo.batchSize).toEqual(1);
     expect(convInfo.outHeight).toEqual(3);
     expect(convInfo.outWidth).toEqual(3);
@@ -48,8 +50,9 @@ describe('conv_util computeConvInfo', () => {
   it('2x2 conv over 3x3 array with same pad', () => {
     const inShape: [number, number, number, number] = [1, 3, 3, 1];
     const stride = 1;
-    const convInfo =
-        conv_util.computeConv2DInfo(inShape, [2, 2, 1, 1], stride, 'same');
+    const dilation = 1;
+    const convInfo = conv_util.computeConv2DInfo(
+        inShape, [2, 2, 1, 1], stride, dilation, 'same');
     expect(convInfo.batchSize).toEqual(1);
     expect(convInfo.outHeight).toEqual(3);
     expect(convInfo.outWidth).toEqual(3);
@@ -59,19 +62,38 @@ describe('conv_util computeConvInfo', () => {
   it('2x2 conv over 3x3 array with valid pad', () => {
     const inShape: [number, number, number, number] = [1, 3, 3, 1];
     const stride = 1;
-    const convInfo =
-        conv_util.computeConv2DInfo(inShape, [2, 2, 1, 1], stride, 'valid');
+    const dilation = 1;
+    const convInfo = conv_util.computeConv2DInfo(
+        inShape, [2, 2, 1, 1], stride, dilation, 'valid');
     expect(convInfo.batchSize).toEqual(1);
     expect(convInfo.outHeight).toEqual(2);
     expect(convInfo.outWidth).toEqual(2);
     expect(convInfo.outChannels).toEqual(1);
   });
 
+  it('3x3 conv over 5x5 array with same pad with stride 2', () => {
+    const inShape: [number, number, number, number] = [1, 5, 5, 1];
+    const stride = 2;
+    const dilation = 1;
+    const convInfo = conv_util.computeConv2DInfo(
+        inShape, [3, 3, 1, 1], stride, dilation, 'same');
+    expect(convInfo.batchSize).toEqual(1);
+    expect(convInfo.outHeight).toEqual(3);
+    expect(convInfo.outWidth).toEqual(3);
+    expect(convInfo.outChannels).toEqual(1);
+
+    expect(convInfo.padInfo.left).toBe(1);
+    expect(convInfo.padInfo.right).toBe(1);
+    expect(convInfo.padInfo.top).toBe(1);
+    expect(convInfo.padInfo.bottom).toBe(1);
+  });
+
   it('2x2 conv over 3x3 array with valid pad with stride 2', () => {
     const inShape: [number, number, number, number] = [1, 3, 3, 1];
     const stride = 2;
-    const convInfo =
-        conv_util.computeConv2DInfo(inShape, [2, 2, 1, 1], stride, 'valid');
+    const dilation = 1;
+    const convInfo = conv_util.computeConv2DInfo(
+        inShape, [2, 2, 1, 1], stride, dilation, 'valid');
     expect(convInfo.batchSize).toEqual(1);
     expect(convInfo.outHeight).toEqual(1);
     expect(convInfo.outWidth).toEqual(1);
@@ -81,8 +103,9 @@ describe('conv_util computeConvInfo', () => {
   it('2x1 conv over 3x3 array with valid pad with stride 1', () => {
     const inShape: [number, number, number, number] = [1, 3, 3, 1];
     const stride = 1;
-    const convInfo =
-        conv_util.computeConv2DInfo(inShape, [2, 1, 1, 1], stride, 'valid');
+    const dilation = 1;
+    const convInfo = conv_util.computeConv2DInfo(
+        inShape, [2, 1, 1, 1], stride, dilation, 'valid');
     expect(convInfo.batchSize).toEqual(1);
     expect(convInfo.outHeight).toEqual(2);
     expect(convInfo.outWidth).toEqual(3);
@@ -92,8 +115,9 @@ describe('conv_util computeConvInfo', () => {
   it('2x1 conv over 3x3 array with valid pad with strides h=2, w=1', () => {
     const inShape: [number, number, number, number] = [1, 3, 3, 1];
     const strides: [number, number] = [2, 1];
-    const convInfo =
-        conv_util.computeConv2DInfo(inShape, [2, 1, 1, 1], strides, 'valid');
+    const dilation = 1;
+    const convInfo = conv_util.computeConv2DInfo(
+        inShape, [2, 1, 1, 1], strides, dilation, 'valid');
     expect(convInfo.batchSize).toEqual(1);
     expect(convInfo.outHeight).toEqual(1);
     expect(convInfo.outWidth).toEqual(3);
@@ -103,8 +127,9 @@ describe('conv_util computeConvInfo', () => {
   it('1x2 conv over 3x3 array with valid pad with stride 1', () => {
     const inShape: [number, number, number, number] = [1, 3, 3, 1];
     const stride = 1;
-    const convInfo =
-        conv_util.computeConv2DInfo(inShape, [1, 2, 1, 1], stride, 'valid');
+    const dilation = 1;
+    const convInfo = conv_util.computeConv2DInfo(
+        inShape, [1, 2, 1, 1], stride, dilation, 'valid');
     expect(convInfo.batchSize).toEqual(1);
     expect(convInfo.outHeight).toEqual(3);
     expect(convInfo.outWidth).toEqual(2);
@@ -114,10 +139,98 @@ describe('conv_util computeConvInfo', () => {
   it('1x2 conv over 3x3 array with valid pad with stride 1, batch=5', () => {
     const inShape: [number, number, number, number] = [5, 3, 3, 1];
     const stride = 1;
-    const convInfo =
-        conv_util.computeConv2DInfo(inShape, [1, 2, 1, 1], stride, 'valid');
+    const dilation = 1;
+    const convInfo = conv_util.computeConv2DInfo(
+        inShape, [1, 2, 1, 1], stride, dilation, 'valid');
     expect(convInfo.batchSize).toEqual(5);
     expect(convInfo.outHeight).toEqual(3);
+    expect(convInfo.outWidth).toEqual(2);
+    expect(convInfo.outChannels).toEqual(1);
+  });
+
+  it('2x2 conv over 3x3 array with same pad with dilations 2', () => {
+    const inShape: [number, number, number, number] = [1, 3, 3, 1];
+    const stride = 1;
+    const dilations = 2;
+    const convInfo = conv_util.computeConv2DInfo(
+        inShape, [2, 2, 1, 1], stride, dilations, 'same');
+    expect(convInfo.batchSize).toEqual(1);
+    expect(convInfo.outHeight).toEqual(3);
+    expect(convInfo.outWidth).toEqual(3);
+    expect(convInfo.outChannels).toEqual(1);
+    // pad evenly on all sides
+    expect(convInfo.padInfo.left).toBe(1);
+    expect(convInfo.padInfo.right).toBe(1);
+    expect(convInfo.padInfo.top).toBe(1);
+    expect(convInfo.padInfo.bottom).toBe(1);
+  });
+
+  it('2x1 conv over 3x3 array with same pad with dilations 2', () => {
+    const inShape: [number, number, number, number] = [1, 3, 3, 1];
+    const stride = 1;
+    const dilations = 2;
+    const convInfo = conv_util.computeConv2DInfo(
+        inShape, [2, 1, 1, 1], stride, dilations, 'same');
+    expect(convInfo.batchSize).toEqual(1);
+    expect(convInfo.outHeight).toEqual(3);
+    expect(convInfo.outWidth).toEqual(3);
+    expect(convInfo.outChannels).toEqual(1);
+    // pad top and bottom
+    expect(convInfo.padInfo.left).toBe(0);
+    expect(convInfo.padInfo.right).toBe(0);
+    expect(convInfo.padInfo.top).toBe(1);
+    expect(convInfo.padInfo.bottom).toBe(1);
+  });
+
+  it('3x4 conv over 8x8 array with same pad with dilations h=4 w=3', () => {
+    const inShape: [number, number, number, number] = [1, 8, 8, 1];
+    const stride = 1;
+    const dilations: [number, number] = [4, 3];
+    const convInfo = conv_util.computeConv2DInfo(
+        inShape, [3, 4, 1, 1], stride, dilations, 'same');
+    expect(convInfo.batchSize).toEqual(1);
+    expect(convInfo.outHeight).toEqual(8);
+    expect(convInfo.outWidth).toEqual(8);
+    expect(convInfo.outChannels).toEqual(1);
+
+    expect(convInfo.padInfo.left).toBe(4);
+    expect(convInfo.padInfo.right).toBe(5);
+    expect(convInfo.padInfo.top).toBe(4);
+    expect(convInfo.padInfo.bottom).toBe(4);
+  });
+
+  it('2x1 conv over 3x3 array with valid pad with dilations 2', () => {
+    const inShape: [number, number, number, number] = [1, 3, 3, 1];
+    const stride = 1;
+    const dilations = 2;
+    const convInfo = conv_util.computeConv2DInfo(
+        inShape, [2, 1, 1, 1], stride, dilations, 'valid');
+    expect(convInfo.batchSize).toEqual(1);
+    expect(convInfo.outHeight).toEqual(1);
+    expect(convInfo.outWidth).toEqual(3);
+    expect(convInfo.outChannels).toEqual(1);
+  });
+
+  it('2x2 conv over 3x3 array with valid pad with dilations 2', () => {
+    const inShape: [number, number, number, number] = [1, 3, 3, 1];
+    const stride = 1;
+    const dilations = 2;
+    const convInfo = conv_util.computeConv2DInfo(
+        inShape, [2, 2, 1, 1], stride, dilations, 'valid');
+    expect(convInfo.batchSize).toEqual(1);
+    expect(convInfo.outHeight).toEqual(1);
+    expect(convInfo.outWidth).toEqual(1);
+    expect(convInfo.outChannels).toEqual(1);
+  });
+
+  it('2x2 conv over 4x4 array with valid pad with dilations 2', () => {
+    const inShape: [number, number, number, number] = [1, 4, 4, 1];
+    const stride = 1;
+    const dilations = 2;
+    const convInfo = conv_util.computeConv2DInfo(
+        inShape, [2, 2, 1, 1], stride, dilations, 'valid');
+    expect(convInfo.batchSize).toEqual(1);
+    expect(convInfo.outHeight).toEqual(2);
     expect(convInfo.outWidth).toEqual(2);
     expect(convInfo.outChannels).toEqual(1);
   });
@@ -130,9 +243,11 @@ describe('conv_util computeConv2DInfo with depthwise=true', () => {
     const fSize = 1;
     const chMul = 1;
     const stride = 1;
+    const dilation = 1;
     const pad = 'same';
     const convInfo = conv_util.computeConv2DInfo(
-        inShape, [fSize, fSize, inChannels, chMul], stride, pad, null, true);
+        inShape, [fSize, fSize, inChannels, chMul], stride, dilation, pad, null,
+        true);
     expect(convInfo.batchSize).toEqual(1);
     expect(convInfo.outHeight).toEqual(1);
     expect(convInfo.outWidth).toEqual(1);
@@ -148,9 +263,11 @@ describe('conv_util computeConv2DInfo with depthwise=true', () => {
     const fSize = 2;
     const chMul = 3;
     const stride = 1;
+    const dilation = 1;
     const pad = 'same';
     const convInfo = conv_util.computeConv2DInfo(
-        inShape, [fSize, fSize, inChannels, chMul], stride, pad, null, true);
+        inShape, [fSize, fSize, inChannels, chMul], stride, dilation, pad, null,
+        true);
     expect(convInfo.batchSize).toEqual(1);
     expect(convInfo.outHeight).toEqual(3);
     expect(convInfo.outWidth).toEqual(3);
@@ -166,9 +283,11 @@ describe('conv_util computeConv2DInfo with depthwise=true', () => {
     const fSize = 2;
     const chMul = 3;
     const stride = 1;
+    const dilation = 1;
     const pad = 'valid';
     const convInfo = conv_util.computeConv2DInfo(
-        inShape, [fSize, fSize, inChannels, chMul], stride, pad, null, true);
+        inShape, [fSize, fSize, inChannels, chMul], stride, dilation, pad, null,
+        true);
     expect(convInfo.batchSize).toEqual(1);
     expect(convInfo.outHeight).toEqual(2);
     expect(convInfo.outWidth).toEqual(2);
@@ -182,9 +301,10 @@ describe('conv_util computeConvInfo channelsFirst', () => {
     const outDepth = 4;
     const inShape: [number, number, number, number] = [1, inDepth, 3, 3];
     const stride = 1;
+    const dilation = 1;
     const convInfo = conv_util.computeConv2DInfo(
-        inShape, [2, 2, inDepth, outDepth], stride, 'same', null, false,
-        'channelsFirst');
+        inShape, [2, 2, inDepth, outDepth], stride, dilation, 'same', null,
+        false, 'channelsFirst');
     expect(convInfo.batchSize).toEqual(1);
     expect(convInfo.outHeight).toEqual(3);
     expect(convInfo.outWidth).toEqual(3);
@@ -202,9 +322,10 @@ describe('conv_util computeConvInfo channelsFirst', () => {
     const outDepth = 16;
     const inShape: [number, number, number, number] = [1, inDepth, 3, 3];
     const stride = 1;
+    const dilation = 1;
     const convInfo = conv_util.computeConv2DInfo(
-        inShape, [2, 2, inDepth, outDepth], stride, 'valid', null, false,
-        'channelsFirst');
+        inShape, [2, 2, inDepth, outDepth], stride, dilation, 'valid', null,
+        false, 'channelsFirst');
     expect(convInfo.batchSize).toEqual(1);
     expect(convInfo.outHeight).toEqual(2);
     expect(convInfo.outWidth).toEqual(2);
@@ -227,32 +348,36 @@ describe('conv_util computeConvInfo roundingMode', () => {
   const fSize = 2;
   const chMul = 12;
   const stride = 2;
+  const dilation = 1;
   const pad = 1;
 
   it('should fail computing the output dimension of Conv Layer', () => {
     expect(
         () => conv_util.computeConv2DInfo(
-            inShape, [fSize, fSize, inChannels, chMul], stride, pad))
+            inShape, [fSize, fSize, inChannels, chMul], stride, dilation, pad))
         .toThrowError();
   });
 
   it('Floor the output dimension of Conv Layer', () => {
     const convInfo = conv_util.computeConv2DInfo(
-        inShape, [fSize, fSize, inChannels, chMul], stride, pad, 'floor');
+        inShape, [fSize, fSize, inChannels, chMul], stride, dilation, pad,
+        'floor');
 
     expect(convInfo.outShape).toEqual([batchSize, 3, 3, chMul]);
   });
 
   it('Round the output dimension of Conv Layer', () => {
     const convInfo = conv_util.computeConv2DInfo(
-        inShape, [fSize, fSize, inChannels, chMul], stride, pad, 'round');
+        inShape, [fSize, fSize, inChannels, chMul], stride, dilation, pad,
+        'round');
 
     expect(convInfo.outShape).toEqual([batchSize, 4, 4, chMul]);
   });
 
   it('Ceil the output dimension of Conv Layer', () => {
     const convInfo = conv_util.computeConv2DInfo(
-        inShape, [fSize, fSize, inChannels, chMul], stride, pad, 'ceil');
+        inShape, [fSize, fSize, inChannels, chMul], stride, dilation, pad,
+        'ceil');
 
     expect(convInfo.outShape).toEqual([batchSize, 4, 4, chMul]);
   });

--- a/src/tensor.ts
+++ b/src/tensor.ts
@@ -857,11 +857,11 @@ export class Tensor<R extends Rank = Rank> {
   }
   depthwiseConv2D<T extends Tensor3D|Tensor4D>(
       this: T, filter: Tensor4D, strides: [number, number]|number,
-      pad: 'valid'|'same'|number, rates: [number, number]|number = [1, 1],
+      pad: 'valid'|'same'|number, dilations: [number, number]|number = [1, 1],
       dimRoundingMode?: 'floor'|'round'|'ceil'): T {
     (this as Tensor).throwIfDisposed();
     return ops.depthwiseConv2d(
-        this, filter, strides, pad, rates, dimRoundingMode);
+        this, filter, strides, pad, dilations, dimRoundingMode);
   }
 
   // Pooling.


### PR DESCRIPTION
This PR will be the start of adding support for 2d Atrous convolution, as described in [Rethinking Atrous Convolution for Semantic Image Segmentation](https://arxiv.org/abs/1706.05587), by modifying `conv_util.computeConv2DInfo` to take arguments for dilation height and width and calculate the convolution info when there is dilation/atrous convolution.

Atrous convolution is currently available in Tensorflow, either by using [tf.nn.conv2d](https://www.tensorflow.org/api_docs/python/tf/nn/conv2d) and setting the `strides` parameter, or by using [tf.nn.atrous_conv2d](https://www.tensorflow.org/api_docs/python/tf/nn/atrous_conv2d) which is a wrapper around `conv2d`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/767)
<!-- Reviewable:end -->
