### PR TITLE
Resize input image in squeezenet demo

### DIFF
--- a/models/squeezenet/demo.html
+++ b/models/squeezenet/demo.html
@@ -22,8 +22,9 @@
     resultElement.innerText = 'Predicting...';
 
     const pixels = dl.fromPixels(cat);
+    const resized = dl.image.resizeBilinear(pixels, [227, 227]);
 
-    const result = squeezeNet.predict(pixels);
+    const result = squeezeNet.predict(resized);
 
     resultElement.innerText = '';
 

--- a/models/squeezenet/squeezenet.ts
+++ b/models/squeezenet/squeezenet.ts
@@ -48,6 +48,11 @@ export class SqueezeNet {
    * @return The pre-softmax logits.
    */
   predict(input: Tensor3D): Tensor1D {
+    if (input.shape[0] !== 227 || input.shape[1] !== 227 ||
+        input.shape[2] !== 3) {
+      throw new Error(
+          `The input Tensor shape is [${input.shape}]. Should be [227,227,3]`);
+    }
     return this.predictWithActivation(input).logits;
   }
 


### PR DESCRIPTION
For some reason my browser is pulling in the cat image as a 226x226 image causing the squeezenet demo to fail. This change forces the input size to be 227x227. This fixes the demo for me and should make the required image size more explicit for other newcomers.

<img width="1552" alt="screen shot 2018-02-25 at 1 35 54 pm" src="https://user-images.githubusercontent.com/4348863/36645665-e23e343e-1a31-11e8-9357-83c7e6958c45.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/779)
<!-- Reviewable:end -->
