### PR TITLE
Add a 'custom' backend to allow more than 'cpu' and 'gpu' backends.

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -186,7 +186,7 @@ function isWebGLGetBufferSubDataAsyncExtensionEnabled(webGLVersion: number) {
 }
 
 /** @docalias 'webgl'|'cpu' */
-export type BackendType = 'webgl'|'cpu';
+export type BackendType = 'webgl'|'cpu'|string;
 
 /** List of currently supported backends ordered by preference. */
 const SUPPORTED_BACKENDS: BackendType[] = ['webgl', 'cpu'];

--- a/src/environment_test.ts
+++ b/src/environment_test.ts
@@ -258,7 +258,7 @@ describe('Backend', () => {
   });
 
   it('default custom background null', () => {
-    expect(ENV.findBackend('custom')).toBeNull();
+    expect(ENV.findBackend('custom')).not.toBeDefined();
   });
 
   it('allow custom backend', () => {

--- a/src/environment_test.ts
+++ b/src/environment_test.ts
@@ -258,7 +258,7 @@ describe('Backend', () => {
   });
 
   it('default custom background null', () => {
-    expect(ENV.findBackend('webgl')).toBeNull();
+    expect(ENV.findBackend('custom')).toBeNull();
   });
 
   it('allow custom backend', () => {

--- a/src/environment_test.ts
+++ b/src/environment_test.ts
@@ -263,7 +263,7 @@ describe('Backend', () => {
 
   it('allow custom backend', () => {
     const backend = new MathBackendCPU();
-    const success = ENV.addCustomBackend('custom', () => backend);
+    const success = ENV.registerBackend('custom', () => backend);
     expect(success).toBeTruthy();
     expect(ENV.findBackend('custom')).toEqual(backend);
   });

--- a/src/environment_test.ts
+++ b/src/environment_test.ts
@@ -256,4 +256,15 @@ describe('Backend', () => {
     expect(ENV.findBackend('webgl') == null).toBe(true);
     expect(ENV.getBestBackendType()).toBe('cpu');
   });
+
+  it('default custom background null', () => {
+    expect(ENV.findBackend('webgl')).toBeNull();
+  });
+
+  it('allow custom backend', () => {
+    const backend = new MathBackendCPU();
+    const success = ENV.addCustomBackend('custom', () => backend);
+    expect(success).toBeTruthy();
+    expect(ENV.findBackend('custom')).toEqual(backend);
+  });
 });


### PR DESCRIPTION
First idea at enabling the environment to allow a custom backend. I don't think I need to get into the weeds about setting the best-backend just yet. Happy to take another approach - but type def'ing constants is hard to work with outside of the package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/791)
<!-- Reviewable:end -->
