### PR TITLE
2d atrous convolution and atrous depthwise convolution

### DIFF
--- a/src/kernels/webgl/conv_gpu.ts
+++ b/src/kernels/webgl/conv_gpu.ts
@@ -29,6 +29,8 @@ export class Conv2DProgram implements GPGPUProgram {
     const padLeft = convInfo.padInfo.left;
     const strideHeight = convInfo.strideHeight;
     const strideWidth = convInfo.strideWidth;
+    const dilationHeight = convInfo.dilationHeight;
+    const dilationWidth = convInfo.dilationWidth;
     const filterHeight = convInfo.filterHeight;
     const filterWidth = convInfo.filterWidth;
 
@@ -52,14 +54,14 @@ export class Conv2DProgram implements GPGPUProgram {
         // ? = to be determined. : = across all values in that axis.
         float dotProd = 0.0;
         for (int wR = 0; wR < ${filterHeight}; wR++) {
-          int xR = xRCorner + wR;
+          int xR = xRCorner + wR * ${dilationHeight};
 
           if (xR < 0 || xR >= ${convInfo.inHeight}) {
             continue;
           }
 
           for (int wC = 0; wC < ${filterWidth}; wC++) {
-            int xC = xCCorner + wC;
+            int xC = xCCorner + wC * ${dilationWidth};
 
             if (xC < 0 || xC >= ${convInfo.inWidth}) {
               continue;

--- a/src/kernels/webgl/conv_gpu_depthwise.ts
+++ b/src/kernels/webgl/conv_gpu_depthwise.ts
@@ -32,6 +32,8 @@ export class DepthwiseConv2DProgram implements GPGPUProgram {
     const padLeft = convInfo.padInfo.left;
     const strideHeight = convInfo.strideHeight;
     const strideWidth = convInfo.strideWidth;
+    const dilationHeight = convInfo.dilationHeight;
+    const dilationWidth = convInfo.dilationWidth;
     const filterHeight = convInfo.filterHeight;
     const filterWidth = convInfo.filterWidth;
     const channelMul = convInfo.outChannels / convInfo.inChannels;
@@ -56,14 +58,14 @@ export class DepthwiseConv2DProgram implements GPGPUProgram {
         float dotProd = 0.0;
         // TODO(dsmilkov): Flatten the two for loops and vec4 the operations.
         for (int wR = 0; wR < ${filterHeight}; wR++) {
-          int xR = xRCorner + wR;
+          int xR = xRCorner + wR * ${dilationHeight};
 
           if (xR < 0 || xR >= ${xNumRows}) {
             continue;
           }
 
           for (int wC = 0; wC < ${filterWidth}; wC++) {
-            int xC = xCCorner + wC;
+            int xC = xCCorner + wC * ${dilationWidth};
 
             if (xC < 0 || xC >= ${xNumCols}) {
               continue;

--- a/src/ops/conv.ts
+++ b/src/ops/conv.ts
@@ -431,8 +431,8 @@ export class ConvOps {
   @operation
   static depthwiseConv2d<T extends Tensor3D|Tensor4D>(
       input: T, filter: Tensor4D, strides: [number, number]|number,
-      pad: 'valid'|'same'|number, dilations: [number, number]|number = [1, 1],
-      dataFormat: 'NHWC'|'NCHW' = 'NHWC',
+      pad: 'valid'|'same'|number, dataFormat: 'NHWC'|'NCHW' = 'NHWC',
+      dilations: [number, number]|number = [1, 1],
       dimRoundingMode?: 'floor'|'round'|'ceil'): T {
     let input4D = input as Tensor4D;
     let reshapedTo4D = false;

--- a/src/ops/conv.ts
+++ b/src/ops/conv.ts
@@ -40,6 +40,12 @@ export class ConvOps {
    *   - For more info, see this guide:
    *     [https://www.tensorflow.org/api_guides/python/nn#Convolution](
    *          https://www.tensorflow.org/api_guides/python/nn#Convolution)
+   * @param dataFormat An optional string from "NWC", "NCW". Defaults to "NWC",
+   *     the data is stored in the order of [batch, in_width, in_channels]. Only
+   *     "NWC" is currently supported.
+   * @param dilation The dilation rate in which we sample input values in
+   *     atrous convolution. Defaults to `1`. If it is greater than 1, then
+   *     stride must be `1`.
    * @param dimRoundingMode The rounding mode used when computing output
    *     dimensions if pad is a number. If none is provided, it will not round
    *     and error if the output is of fractional size.
@@ -48,6 +54,7 @@ export class ConvOps {
   @operation
   static conv1d<T extends Tensor2D|Tensor3D>(
       input: T, filter: Tensor3D, stride: number, pad: 'valid'|'same'|number,
+      dataFormat: 'NWC'|'NCW' = 'NWC', dilation = 1,
       dimRoundingMode?: 'floor'|'round'|'ceil'): T {
     let input3D = input as Tensor3D;
     let reshapedTo3D = false;
@@ -74,15 +81,27 @@ export class ConvOps {
         input3D.shape[2] === filter.shape[1],
         `Error in conv1d: depth of input (${input3D.shape[2]}) must match  ` +
             `input depth for filter ${filter.shape[1]}.`);
+    util.assert(
+        eitherStridesOrDilationsAreOne(stride, dilation),
+        'Error in conv1D: Either stride or dilation must be 1.' +
+            `Got stride ${stride} and dilation '${dilation}'`);
+    util.assert(
+        dataFormat === 'NWC',
+        `Error in conv1d: got dataFormat of ${
+            dataFormat} but only NWC is currently supported.`);
 
     const filter4D =
         filter.as4D(1, filter.shape[0], filter.shape[1], filter.shape[2]);
     const input4D =
         input3D.as4D(input3D.shape[0], 1, input3D.shape[1], input3D.shape[2]);
     const strides: [number, number] = [1, stride];
+    const dilations: [number, number] = [1, dilation];
 
-    const res =
-        ConvOps.conv2d(input4D, filter4D, strides, pad, dimRoundingMode);
+    const conv2dDataFormat = 'NHWC';
+
+    const res = ConvOps.conv2d(
+        input4D, filter4D, strides, pad, conv2dDataFormat, dilations,
+        dimRoundingMode);
 
     if (reshapedTo3D) {
       return res.as2D(res.shape[2], res.shape[3]) as T;
@@ -108,6 +127,15 @@ export class ConvOps {
    *   - For more info, see this guide:
    *     [https://www.tensorflow.org/api_guides/python/nn#Convolution](
    *          https://www.tensorflow.org/api_guides/python/nn#Convolution)
+   * @param dataFormat: An optional string from: "NHWC", "NCHW". Defaults to
+   *     "NHWC". Specify the data format of the input and output data. With the
+   *     default format "NHWC", the data is stored in the order of: [batch,
+   *     height, width, channels]. Only "NHWC" is currently supported.
+   * @param dilations The dilation rates: `[dilationHeight, dilationWidth]`
+   *     in which we sample input values across the height and width dimensions
+   *     in atrous convolution. Defaults to `[1, 1]`. If `dilations` is a single
+   *     number, then `dilationHeight == dilationWidth`. If it is greater than
+   *     1, then all values of `strides` must be 1.
    * @param dimRoundingMode The rounding mode used when computing output
    *     dimensions if pad is a number. If none is provided, it will not round
    *     and error if the output is of fractional size.
@@ -116,7 +144,9 @@ export class ConvOps {
   @operation
   static conv2d<T extends Tensor3D|Tensor4D>(
       x: T, filter: Tensor4D, strides: [number, number]|number,
-      pad: 'valid'|'same'|number, dimRoundingMode?: 'floor'|'round'|'ceil'): T {
+      pad: 'valid'|'same'|number, dataFormat: 'NHWC'|'NCHW' = 'NHWC',
+      dilations: [number, number]|number = [1, 1],
+      dimRoundingMode?: 'floor'|'round'|'ceil'): T {
     let x4D = x as Tensor4D;
     let reshapedTo4D = false;
 
@@ -142,13 +172,24 @@ export class ConvOps {
         x4D.shape[3] === filter.shape[2],
         `Error in conv2d: depth of input (${x4D.shape[3]}) must match  ` +
             `input depth for filter ${filter.shape[2]}.`);
-
-    const dilations = 1;
+    util.assert(
+        eitherStridesOrDilationsAreOne(strides, dilations),
+        'Error in conv2D: Either strides or dilations must be 1.' +
+            `Got strides ${strides} and dilations '${dilations}'`);
+    util.assert(
+        dataFormat === 'NHWC',
+        `Error in conv2d: got dataFormat of ${
+            dataFormat} but only NHWC is currently supported.`);
 
     const convInfo = conv_util.computeConv2DInfo(
         x4D.shape, filter.shape, strides, dilations, pad, dimRoundingMode);
 
     const grad = (dy: Tensor4D) => {
+      util.assert(
+          tupleValuesAreOne(dilations),
+          'Error in gradient of conv2D: dilation rates greater than 1 are not' +
+              `yet supported in gradients. Got dilations '${dilations}'`);
+
       return {
         x: () => ConvOps.conv2dDerInput(x4D.shape, dy, filter, strides, pad),
         filter: () =>
@@ -375,9 +416,13 @@ export class ConvOps {
    *          https://www.tensorflow.org/api_guides/python/nn#Convolution)
    * @param dilations The dilation rates: `[dilationHeight, dilationWidth]`
    *     in which we sample input values across the height and width dimensions
-   *     in atrous convolution. Defaults to `[1, 1]`. If `dilations` is a single
+   *     in atrous convolution. Defaults to `[1, 1]`. If `rate` is a single
    *     number, then `dilationHeight == dilationWidth`. If it is greater than
    *     1, then all values of `strides` must be 1.
+   * @param dataFormat: An optional string from: "NHWC", "NCHW". Defaults to
+   *     "NHWC". Specify the data format of the input and output data. With the
+   *     default format "NHWC", the data is stored in the order of: [batch,
+   *     height, width, channels]. Only "NHWC" is currently supported.
    * @param dimRoundingMode The rounding mode used when computing output
    *     dimensions if pad is a number. If none is provided, it will not round
    *     and error if the output is of fractional size.
@@ -387,6 +432,7 @@ export class ConvOps {
   static depthwiseConv2d<T extends Tensor3D|Tensor4D>(
       input: T, filter: Tensor4D, strides: [number, number]|number,
       pad: 'valid'|'same'|number, dilations: [number, number]|number = [1, 1],
+      dataFormat: 'NHWC'|'NCHW' = 'NHWC',
       dimRoundingMode?: 'floor'|'round'|'ceil'): T {
     let input4D = input as Tensor4D;
     let reshapedTo4D = false;
@@ -410,11 +456,11 @@ export class ConvOps {
     if (dilations == null) {
       dilations = [1, 1];
     }
-    const [dilationHeight, dilationWidth] = parseTupleParam(dilations);
     util.assert(
-        dilationHeight === 1 && dilationWidth === 1,
-        'Error in depthwiseConv2D: dilation rates greater than 1 are not yet ' +
-            `supported. Got dilations '${dilations}'`);
+        eitherStridesOrDilationsAreOne(strides, dilations),
+        'Error in depthwiseConv2d: Either strides or dilations must be 1.' +
+            `Got strides ${strides} and dilations '${dilations}'`);
+
     if (dimRoundingMode != null) {
       util.assert(
           util.isInt(pad as number),
@@ -437,4 +483,15 @@ export class ConvOps {
 
 function parseTupleParam(param: number|[number, number]): [number, number] {
   return typeof param === 'number' ? [param, param] : param;
+}
+
+function tupleValuesAreOne(param: number|[number, number]): boolean {
+  const [dimA, dimB] = parseTupleParam(param);
+  return dimA === 1 && dimB === 1;
+}
+
+function eitherStridesOrDilationsAreOne(
+    strides: number|[number, number],
+    dilations: number|[number, number]): boolean {
+  return tupleValuesAreOne(strides) || tupleValuesAreOne(dilations);
 }

--- a/src/ops/conv1d_test.ts
+++ b/src/ops/conv1d_test.ts
@@ -21,38 +21,97 @@ import {ALL_ENVS, describeWithFlags, expectArraysClose} from '../test_util';
 import {Rank} from '../types';
 
 describeWithFlags('conv1d', ALL_ENVS, () => {
-  it('conv1d input=2x2x1,d2=1,f=1,s=1,p=same', () => {
+  it('conv1d input=2x2x1,d2=1,f=1,s=1,d=1,p=same', () => {
     const inputDepth = 1;
     const inputShape: [number, number, number] = [2, 2, inputDepth];
     const outputDepth = 1;
     const fSize = 1;
     const pad = 'same';
     const stride = 1;
+    const dataFormat = 'NWC';
+    const dilation = 1;
 
     const x = dl.tensor3d([1, 2, 3, 4], inputShape);
     const w = dl.tensor3d([3], [fSize, inputDepth, outputDepth]);
 
-    const result = dl.conv1d(x, w, stride, pad);
+    const result = dl.conv1d(x, w, stride, pad, dataFormat, dilation);
 
     expect(result.shape).toEqual([2, 2, 1]);
     expectArraysClose(result, [3, 6, 9, 12]);
   });
 
-  it('conv1d input=4x1,d2=1,f=2x1x1,s=1,p=valid', () => {
+  it('conv1d input=4x1,d2=1,f=2x1x1,s=1,d=1,p=valid', () => {
     const inputDepth = 1;
     const inputShape: [number, number] = [4, inputDepth];
     const outputDepth = 1;
     const fSize = 2;
     const pad = 'valid';
     const stride = 1;
+    const dataFormat = 'NWC';
+    const dilation = 1;
 
     const x = dl.tensor2d([1, 2, 3, 4], inputShape);
     const w = dl.tensor3d([2, 1], [fSize, inputDepth, outputDepth]);
 
-    const result = dl.conv1d(x, w, stride, pad);
+    const result = dl.conv1d(x, w, stride, pad, dataFormat, dilation);
 
     expect(result.shape).toEqual([3, 1]);
     expectArraysClose(result, [4, 7, 10]);
+  });
+
+  it('conv1d input=4x1,d2=1,f=2x1x1,s=1,d=2,p=valid', () => {
+    const inputDepth = 1;
+    const inputShape: [number, number] = [4, inputDepth];
+    const outputDepth = 1;
+    const fSize = 2;
+    const fSizeDilated = 3;
+    const pad = 'valid';
+    const stride = 1;
+    const dataFormat = 'NWC';
+    const dilation = 2;
+    const dilationWEffective = 1;
+
+    const x = dl.tensor2d([1, 2, 3, 4], inputShape);
+    const w = dl.tensor3d([2, 1], [fSize, inputDepth, outputDepth]);
+    // adding a dilation rate is equivalent to using a filter
+    // with 0s for the dilation rate
+    const wDilated =
+        dl.tensor3d([2, 0, 1], [fSizeDilated, inputDepth, outputDepth]);
+
+    const result = dl.conv1d(x, w, stride, pad, dataFormat, dilation);
+    const expectedResult =
+        dl.conv1d(x, wDilated, stride, pad, dataFormat, dilationWEffective);
+
+    expect(result.shape).toEqual(expectedResult.shape);
+    expectArraysClose(result, expectedResult);
+  });
+
+  it('conv1d input=14x1,d2=1,f=3x1x1,s=1,d=3,p=valid', () => {
+    const inputDepth = 1;
+    const inputShape: [number, number] = [14, inputDepth];
+    const outputDepth = 1;
+    const fSize = 3;
+    const fSizeDilated = 7;
+    const pad = 'valid';
+    const stride = 1;
+    const dataFormat = 'NWC';
+    const dilation = 3;
+    const dilationWEffective = 1;
+
+    const x = dl.tensor2d(
+        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], inputShape);
+    const w = dl.tensor3d([3, 2, 1], [fSize, inputDepth, outputDepth]);
+    // adding a dilation rate is equivalent to using a filter
+    // with 0s for the dilation rate
+    const wDilated = dl.tensor3d(
+        [3, 0, 0, 2, 0, 0, 1], [fSizeDilated, inputDepth, outputDepth]);
+
+    const result = dl.conv1d(x, w, stride, pad, dataFormat, dilation);
+    const expectedResult =
+        dl.conv1d(x, wDilated, stride, pad, dataFormat, dilationWEffective);
+
+    expect(result.shape).toEqual(expectedResult.shape);
+    expectArraysClose(result, expectedResult);
   });
 
   it('throws when x is not rank 3', () => {
@@ -61,12 +120,15 @@ describeWithFlags('conv1d', ALL_ENVS, () => {
     const fSize = 2;
     const pad = 0;
     const stride = 1;
+    const dataFormat = 'NWC';
+    const dilation = 1;
 
     // tslint:disable-next-line:no-any
     const x: any = dl.tensor2d([1, 2, 3, 4], [2, 2]);
     const w = dl.tensor3d([3, 1], [fSize, inputDepth, outputDepth]);
 
-    expect(() => dl.conv1d(x, w, stride, pad)).toThrowError();
+    expect(() => dl.conv1d(x, w, stride, pad, dataFormat, dilation))
+        .toThrowError();
   });
 
   it('throws when weights is not rank 3', () => {
@@ -74,12 +136,15 @@ describeWithFlags('conv1d', ALL_ENVS, () => {
     const inputShape: [number, number, number] = [2, 2, inputDepth];
     const pad = 0;
     const stride = 1;
+    const dataFormat = 'NWC';
+    const dilation = 1;
 
     const x = dl.tensor3d([1, 2, 3, 4], inputShape);
     // tslint:disable-next-line:no-any
     const w: any = dl.tensor4d([3, 1, 5, 0], [2, 2, 1, 1]);
 
-    expect(() => dl.conv1d(x, w, stride, pad)).toThrowError();
+    expect(() => dl.conv1d(x, w, stride, pad, dataFormat, dilation))
+        .toThrowError();
   });
 
   it('throws when x depth does not match weight depth', () => {
@@ -90,10 +155,30 @@ describeWithFlags('conv1d', ALL_ENVS, () => {
     const fSize = 2;
     const pad = 0;
     const stride = 1;
+    const dataFormat = 'NWC';
+    const dilation = 1;
 
     const x = dl.tensor3d([1, 2, 3, 4], inputShape);
     const w = dl.randomNormal<Rank.R3>([fSize, wrongInputDepth, outputDepth]);
 
-    expect(() => dl.conv1d(x, w, stride, pad)).toThrowError();
+    expect(() => dl.conv1d(x, w, stride, pad, dataFormat, dilation))
+        .toThrowError();
+  });
+
+  it('throws when both stride and dilation are greater than 1', () => {
+    const inputDepth = 1;
+    const inputShape: [number, number, number] = [2, 2, inputDepth];
+    const outputDepth = 1;
+    const fSize = 1;
+    const pad = 'same';
+    const stride = 2;
+    const dataFormat = 'NWC';
+    const dilation = 2;
+
+    const x = dl.tensor3d([1, 2, 3, 4], inputShape);
+    const w = dl.tensor3d([3], [fSize, inputDepth, outputDepth]);
+
+    expect(() => dl.conv1d(x, w, stride, pad, dataFormat, dilation))
+        .toThrowError();
   });
 });

--- a/src/ops/conv2d_depthwise_test.ts
+++ b/src/ops/conv2d_depthwise_test.ts
@@ -70,7 +70,7 @@ describeWithFlags('depthwiseConv2D', ALL_ENVS, () => {
         [fSizeDilated, fSizeDilated, inDepth, chMul],
     );
 
-    const result = dl.depthwiseConv2d(x, w, stride, pad, dilation);
+    const result = dl.depthwiseConv2d(x, w, stride, pad, 'NHWC', dilation);
 
     const expectedResult = dl.depthwiseConv2d(x, wDilated, stride, pad);
 
@@ -210,7 +210,7 @@ describeWithFlags('depthwiseConv2D', ALL_ENVS, () => {
 
     const x = dl.zeros<Rank.R3>([3, 3, inDepth]);
     const w = dl.zeros<Rank.R4>([fSize, fSize, inDepth, chMul]);
-    const result = dl.depthwiseConv2d(x, w, stride, pad, dilations);
+    const result = dl.depthwiseConv2d(x, w, stride, pad, 'NHWC', dilations);
     expect(result.shape).toEqual([3, 3, inDepth * chMul]);
   });
 });

--- a/src/ops/conv2d_depthwise_test.ts
+++ b/src/ops/conv2d_depthwise_test.ts
@@ -78,7 +78,7 @@ describeWithFlags('depthwiseConv2D', ALL_ENVS, () => {
     expectArraysClose(result, expectedResult);
   });
 
-  it('input=1x3x3x2,f=2,s=1,p=same,chMul=1', () => {
+  it('input=1x3x3x2,f=2,s=1,d=1,p=same,chMul=1', () => {
     const fSize = 2;
     const pad = 'same';
     const stride = 1;
@@ -107,6 +107,58 @@ describeWithFlags('depthwiseConv2D', ALL_ENVS, () => {
       0.0490466, 0.410569, 0.10902, 0.0514242
     ];
     expectArraysClose(result, expected);
+  });
+
+  it('input=1x3x3x2,f=2,s=1,d=2,p=same,chMul=1', () => {
+    const fSize = 2;
+    const pad = 'same';
+    const stride = 1;
+    const dilation = 2;
+    const inDepth = 2;
+
+    const x = dl.tensor4d(
+        [
+          0.111057, 0.661818, 0.701979, 0.424362, 0.992854, 0.417599, 0.423036,
+          0.500499, 0.368484, 0.714135, 0.456693, 0.531058, 0.636636, 0.345024,
+          0.0506303, 0.789682, 0.177473, 0.793569
+        ],
+        [1, 3, 3, inDepth]);
+
+    const w =
+        dl.stack(
+              [
+                dl.tensor2d(
+                    [0.614293, 0.0648011, 0.101113, 0.452887], [fSize, fSize]),
+                dl.tensor2d(
+                    [0.0582746, 0.426481, 0.872743, 0.765767], [fSize, fSize])
+              ],
+              2)
+            .expandDims(3) as dl.Tensor4D;
+
+    // adding a dilation rate is equivalent to using a filter
+    // with 0s for the dilation rate
+    const fSizeDilated = fSize + (fSize - 1) * (dilation - 1);
+    const wDilated =
+        dl.stack(
+              [
+                dl.tensor2d(
+                    [0.614293, 0, 0.0648011, 0, 0, 0, 0.101113, 0, 0.452887],
+                    [fSizeDilated, fSizeDilated]),
+                dl.tensor2d(
+                    [0.0582746, 0, 0.426481, 0, 0, 0, 0.872743, 0, 0.765767],
+                    [fSizeDilated, fSizeDilated])
+              ],
+              2)
+            .expandDims(3) as dl.Tensor4D;
+
+    expect(wDilated.shape).toEqual([fSizeDilated, fSizeDilated, inDepth, 1]);
+
+    const result = dl.depthwiseConv2d(x, w, stride, pad, 'NHWC', dilation);
+
+    const expectedResult = dl.depthwiseConv2d(x, wDilated, stride, pad);
+
+    expect(result.shape).toEqual(expectedResult.shape);
+    expectArraysClose(result, expectedResult);
   });
 
   it('input=1x3x3x2,f=2,s=1,p=same,chMul=2', () => {
@@ -185,6 +237,76 @@ describeWithFlags('depthwiseConv2D', ALL_ENVS, () => {
       0.346842, 0.598472
     ];
     expectArraysClose(result, expected);
+  });
+
+  it('input=2x3x3x2,f=2,s=1,d=2,p=same,chMul=2', () => {
+    const fSize = 2;
+    const pad = 'same';
+    const stride = 1;
+    // const chMul = 2;
+    const inDepth = 2;
+    const dilation = 2;
+    const noDilation = 1;
+
+    const x = dl.tensor4d(
+        [
+          0.261945, 0.0528113, 0.656698,  0.127345,  0.610039, 0.169131,
+          0.458647, 0.0988288, 0.966109,  0.0421747, 0.82035,  0.274711,
+          0.359377, 0.512113,  0.689682,  0.941571,  0.31961,  0.743826,
+          0.858147, 0.984766,  0.926973,  0.579597,  0.444104, 0.505969,
+          0.241437, 0.937999,  0.0957074, 0.773611,  0.46023,  0.469379,
+          0.363789, 0.269745,  0.486136,  0.894215,  0.794299, 0.724615
+        ],
+        [2, 3, 3, inDepth]);
+
+    const w = dl.stack([
+      dl.stack(
+          [
+            dl.tensor2d(
+                [0.240347, 0.906352, 0.478657, 0.825918], [fSize, fSize]),
+            dl.tensor2d(
+                [0.380769, 0.184705, 0.238241, 0.201907], [fSize, fSize])
+          ],
+          2),
+      dl.stack(
+          [
+            dl.tensor2d([0.294087, 0.181165, 0.191303, 0.7225], [fSize, fSize]),
+            dl.tensor2d(
+                [0.430064, 0.900622, 0.670338, 0.33478], [fSize, fSize])
+          ],
+          2)
+    ], 3) as dl.Tensor4D;
+
+    const fSizeDilated = fSize + (fSize - 1) * (dilation - 1);
+    const wDilated = dl.stack([
+      dl.stack(
+          [
+            dl.tensor2d(
+              [0.240347, 0, 0.906352, 0, 0, 0, 0.478657, 0, 0.825918],
+              [fSizeDilated, fSizeDilated]),
+            dl.tensor2d(
+              [0.380769, 0, 0.184705, 0, 0, 0, 0.238241, 0, 0.201907],
+              [fSizeDilated, fSizeDilated])
+          ],
+          2),
+      dl.stack(
+          [
+            dl.tensor2d([0.294087, 0, 0.181165, 0, 0, 0, 0.191303, 0, 0.7225],
+              [fSizeDilated, fSizeDilated]),
+            dl.tensor2d(
+              [0.430064, 0, 0.900622, 0, 0, 0, 0.670338, 0, 0.33478],
+              [fSizeDilated, fSizeDilated])
+          ],
+          2)
+    ], 3) as dl.Tensor4D;
+
+    const result = dl.depthwiseConv2d(x, w, stride, pad, 'NHWC', dilation);
+
+    const expectedResult =
+        dl.depthwiseConv2d(x, wDilated, stride, pad, 'NHWC', noDilation);
+
+    expect(result.shape).toEqual(expectedResult.shape);
+    expectArraysClose(result, expectedResult);
   });
 
   it('Tensor3D is allowed', () => {

--- a/src/ops/conv_util.ts
+++ b/src/ops/conv_util.ts
@@ -40,6 +40,8 @@ export type Conv2DInfo = {
   dataFormat: 'channelsFirst'|'channelsLast',
   strideHeight: number,
   strideWidth: number,
+  dilationHeight: number,
+  dilationWidth: number,
   filterHeight: number,
   filterWidth: number,
   padInfo: PadInfo,
@@ -126,6 +128,8 @@ export function computeConv2DInfo(
     strideWidth,
     filterHeight,
     filterWidth,
+    dilationHeight,
+    dilationWidth,
     inShape,
     outShape,
     filterShape
@@ -161,8 +165,10 @@ function computeOutputShape3D(
 
 export function computeDefaultPad(
     inputShape: [number, number, number], fieldSize: number,
-    stride: number): number {
-  return Math.floor((inputShape[0] * (stride - 1) - stride + fieldSize) / 2);
+    stride: number, dilation = 1): number {
+  const effectiveFieldSize = getEffectiveFilterSize(fieldSize, dilation);
+  return Math.floor(
+    (inputShape[0] * (stride - 1) - stride + effectiveFieldSize) / 2);
 }
 
 function parseTupleParam(param: number|[number, number]): [number, number] {

--- a/src/tensor.ts
+++ b/src/tensor.ts
@@ -776,15 +776,20 @@ export class Tensor<R extends Rank = Rank> {
   // Convolutions.
   conv1d<T extends Tensor2D|Tensor3D>(
       this: T, filter: Tensor3D, stride: number, pad: 'valid'|'same'|number,
+      dataFormat: 'NWC'|'NCW' = 'NWC', dilation = 1,
       dimRoundingMode?: 'floor'|'round'|'ceil'): T {
     (this as Tensor).throwIfDisposed();
-    return ops.conv1d(this, filter, stride, pad, dimRoundingMode);
+    return ops.conv1d(
+        this, filter, stride, pad, dataFormat, dilation, dimRoundingMode);
   }
   conv2d<T extends Tensor3D|Tensor4D>(
       this: T, filter: Tensor4D, strides: [number, number]|number,
-      pad: 'valid'|'same'|number, dimRoundingMode?: 'floor'|'round'|'ceil'): T {
+      pad: 'valid'|'same'|number, dataFormat: 'NHWC'|'NCHW' = 'NHWC',
+      dilations: [number, number]|number = [1, 1],
+      dimRoundingMode?: 'floor'|'round'|'ceil'): T {
     (this as Tensor).throwIfDisposed();
-    return ops.conv2d(this, filter, strides, pad, dimRoundingMode);
+    return ops.conv2d(
+        this, filter, strides, pad, dataFormat, dilations, dimRoundingMode);
   }
   conv2dTranspose<T extends Tensor3D|Tensor4D>(
       this: T, filter: Tensor4D,
@@ -798,10 +803,11 @@ export class Tensor<R extends Rank = Rank> {
   depthwiseConv2D<T extends Tensor3D|Tensor4D>(
       this: T, filter: Tensor4D, strides: [number, number]|number,
       pad: 'valid'|'same'|number, dilations: [number, number]|number = [1, 1],
+      dataFormat: 'NHWC'|'NCHW' = 'NHWC',
       dimRoundingMode?: 'floor'|'round'|'ceil'): T {
     (this as Tensor).throwIfDisposed();
     return ops.depthwiseConv2d(
-        this, filter, strides, pad, dilations, dimRoundingMode);
+        this, filter, strides, pad, dilations, dataFormat, dimRoundingMode);
   }
 
   // Pooling.

--- a/src/tensor.ts
+++ b/src/tensor.ts
@@ -802,12 +802,12 @@ export class Tensor<R extends Rank = Rank> {
   }
   depthwiseConv2D<T extends Tensor3D|Tensor4D>(
       this: T, filter: Tensor4D, strides: [number, number]|number,
-      pad: 'valid'|'same'|number, dilations: [number, number]|number = [1, 1],
-      dataFormat: 'NHWC'|'NCHW' = 'NHWC',
+      pad: 'valid'|'same'|number, dataFormat: 'NHWC'|'NCHW' = 'NHWC',
+      dilations: [number, number]|number = [1, 1],
       dimRoundingMode?: 'floor'|'round'|'ceil'): T {
     (this as Tensor).throwIfDisposed();
     return ops.depthwiseConv2d(
-        this, filter, strides, pad, dilations, dataFormat, dimRoundingMode);
+        this, filter, strides, pad, dataFormat, dilations, dimRoundingMode);
   }
 
   // Pooling.


### PR DESCRIPTION
This implements 2d atrous convolution and 2d atrous depthwise convolution, as described in [Rethinking Atrous Convolution for Semantic Image Segmentation](https://arxiv.org/abs/1706.05587). Refer to the [documentation for tf.nn.atrous_conv_2d](https://www.tensorflow.org/api_docs/python/tf/nn/atrous_conv2d) for an explanation of of how atrous convolution works.

Atrous convolution is currently implemented in TensorFlow in the following methods (the parameter name is listed next to each method):

* [tf.nn.conv2d](https://www.tensorflow.org/api_docs/python/tf/nn/conv2d) - `dilations`
* [tf.nn.conv2d_backprop_filter](https://www.tensorflow.org/api_docs/python/tf/nn/conv2d_backprop_filter) - `dilations`
* [tf.nn.conv2d_backprop_input](https://www.tensorflow.org/api_docs/python/tf/nn/conv2d_backprop_input) - `dilations`
* [tf.nn.conv3d](https://www.tensorflow.org/api_docs/python/tf/nn/conv3d) - `dilations`
* [tf.nn.conv3d_backprop_filter_v2](https://www.tensorflow.org/api_docs/python/tf/nn/conv3d_backprop_filter_v2) - `dilations`
* [tf.nn.convolution](https://www.tensorflow.org/api_docs/python/tf/nn/convolution) - `dilation_rate`
* [tf.nn.atrous_conv2d](https://www.tensorflow.org/api_docs/python/tf/nn/atrous_conv2d) -`rate`
* [tf.nn.atrous_conv2d_transpose](https://www.tensorflow.org/api_docs/python/tf/nn/atrous_conv2d_transpose) - `rate`
* [tf.nn.depthwise_conv2d](https://www.tensorflow.org/api_docs/python/tf/nn/depthwise_conv2d) - `rate`
* [tf.nn.depthwise_conv2d_native](https://www.tensorflow.org/api_docs/python/tf/nn/depthwise_conv2d_native) - `dilations`
* [tf.nn.depthwise_conv2d_native_backprop_filter](https://www.tensorflow.org/api_docs/python/tf/nn/depthwise_conv2d_native_backprop_filter) - `dilations`
* [tf.nn.depthwise_conv2d_native_backprop_input](https://www.tensorflow.org/api_docs/python/tf/nn/depthwise_conv2d_native_backprop_input) - `dilations`
* [tf.nn.dilation2d](https://www.tensorflow.org/api_docs/python/tf/nn/dilation2d) - `rates`
* [tf.nn.quantized_conv2d](https://www.tensorflow.org/api_docs/python/tf/nn/quantized_conv2d) - `dilations`

This PR modifies the webgl and cpu ops `depthwiseConv2d` and `conv2d` to take the parameter `dilationRate` and perform atrous convolution if the rate width or height is greater than 1.  In its current state, it is potentially a breaking change in the api for `conv1d` and `conv2d` as it adds the positional argument `dilations`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/794)
<!-- Reviewable:end -->
