### PR TITLE
Turn off WEBGL_get_buffer_sub_data_async. 

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -174,6 +174,12 @@ function isFloatTextureReadPixelsEnabled(webGLVersion: number): boolean {
 }
 
 function isWebGLGetBufferSubDataAsyncExtensionEnabled(webGLVersion: number) {
+  // TODO(nsthorat): Remove this once we fix
+  // https://github.com/PAIR-code/deeplearnjs/issues/848
+  if (webGLVersion > 0) {
+    return false;
+  }
+
   if (webGLVersion !== 2) {
     return false;
   }

--- a/src/environment_test.ts
+++ b/src/environment_test.ts
@@ -145,7 +145,6 @@ describe('WEBGL_GET_BUFFER_SUB_DATA_ASYNC_EXTENSION_ENABLED', () => {
     });
   });
 
-
   it('WebGL 2 enabled', () => {
     const features: Features = {'WEBGL_VERSION': 2};
 

--- a/src/environment_test.ts
+++ b/src/environment_test.ts
@@ -145,6 +145,9 @@ describe('WEBGL_GET_BUFFER_SUB_DATA_ASYNC_EXTENSION_ENABLED', () => {
     });
   });
 
+  /* TODO(nsthorat): Uncomment this block when we fix
+     https://github.com/PAIR-code/deeplearnjs/issues/848
+
   it('WebGL 2 enabled', () => {
     const features: Features = {'WEBGL_VERSION': 2};
 
@@ -153,6 +156,7 @@ describe('WEBGL_GET_BUFFER_SUB_DATA_ASYNC_EXTENSION_ENABLED', () => {
     expect(env.get('WEBGL_GET_BUFFER_SUB_DATA_ASYNC_EXTENSION_ENABLED'))
         .toBe(true);
   });
+  */
 
   it('WebGL 1 disabled', () => {
     const features: Features = {'WEBGL_VERSION': 1};

--- a/src/environment_test.ts
+++ b/src/environment_test.ts
@@ -145,18 +145,17 @@ describe('WEBGL_GET_BUFFER_SUB_DATA_ASYNC_EXTENSION_ENABLED', () => {
     });
   });
 
-  /* TODO(nsthorat): Uncomment this block when we fix
-     https://github.com/PAIR-code/deeplearnjs/issues/848
 
   it('WebGL 2 enabled', () => {
     const features: Features = {'WEBGL_VERSION': 2};
 
     const env = new Environment(features);
 
+    // TODO(nsthorat): Expect true when we fix
+    // https://github.com/PAIR-code/deeplearnjs/issues/848
     expect(env.get('WEBGL_GET_BUFFER_SUB_DATA_ASYNC_EXTENSION_ENABLED'))
-        .toBe(true);
+        .toBe(false);
   });
-  */
 
   it('WebGL 1 disabled', () => {
     const features: Features = {'WEBGL_VERSION': 1};


### PR DESCRIPTION
It's broken in large demos right now. I will spend some time debugging this later.

![image](https://user-images.githubusercontent.com/1100749/37315514-83449af8-2630-11e8-891c-ed7437a96485.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/849)
<!-- Reviewable:end -->
