### PR TITLE
Inform backends when tensors reshape.

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -141,6 +141,8 @@ export class Engine implements TensorManager {
       this.numBytes +=
           util.sizeFromShape(a.shape) * util.bytesPerElement(a.dtype);
       this.backend.register(a.dataId, a.shape, a.dtype);
+    } else {
+      this.backend.updateShape(a.dataId, a.shape, a.dtype);
     }
     this.refCounter.set(a.dataId, refCount + 1);
     if (!(a instanceof Variable)) {

--- a/src/kernels/backend.ts
+++ b/src/kernels/backend.ts
@@ -33,6 +33,7 @@ export interface TensorStorage {
       pixels: ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement,
       numChannels: number): Tensor3D;
   register(dataId: DataId, shape: number[], dtype: DataType): void;
+  updateShape(dataId: DataId, shape: number[], dtype: DataType): void;
   memory(): {unreliable: boolean;};  // Backend-specific information.
 }
 

--- a/src/kernels/backend_cpu.ts
+++ b/src/kernels/backend_cpu.ts
@@ -49,6 +49,11 @@ export class MathBackendCPU implements KernelBackend {
     }
     this.data.set(dataId, null);
   }
+  updateShape(dataId: object, shape: number[], dtype: DataType): void {
+    if (!this.data.has(dataId)) {
+      throw new Error(`Data buffer was not registered`);
+    }
+  }
   write(dataId: DataId, values: TypedArray): void {
     if (values == null) {
       throw new Error('MathBackendCPU.write(): values can not be null');

--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -98,6 +98,11 @@ export class MathBackendWebGL implements KernelBackend {
       texType: TextureType.FLOAT
     });
   }
+  updateShape(dataId: object, shape: number[], dtype: DataType): void {
+    if (!this.texData.has(dataId)) {
+      throw new Error(`Data buffer was not registered`);
+    }
+  }
   fromPixels(
       pixels: ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement,
       numChannels: number): Tensor3D {

--- a/src/kernels/backend_webgl_test.ts
+++ b/src/kernels/backend_webgl_test.ts
@@ -101,4 +101,13 @@ describeWithFlags('backendWebGL', WEBGL_ENVS, () => {
     backend.dispose();
     expect(texManager.getNumUsedTextures()).toBe(0);
   });
+
+  it('should handle invalid shapeUpdates', () => {
+    const delayedStorage = false;
+    const backend = new MathBackendWebGL(null, delayedStorage);
+    const dataId = {};
+    expect(() => {
+      backend.updateShape(dataId, [3], 'float32');
+    }).toThrowError();
+  });
 });


### PR DESCRIPTION
Some backends might need to know when a Tensor reshapes to update any backing. This change introduces a new API on the backend to inform backends that a Tensor is reshaped.

I'm not 100% how to test this since most of this functionality is protected through the Tensor API. Open to suggestions if you have any.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/deeplearnjs/881)
<!-- Reviewable:end -->
